### PR TITLE
feat: bundle godly-daemon.exe in Windows installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,7 @@ npm run build:daemon
 # Development mode (starts Vite + Tauri)
 npm run tauri dev
 
-# Production build (daemon must be built first)
-npm run build:daemon:release
+# Production build (daemon is built automatically via beforeBundleCommand)
 npm run tauri build
 
 # TypeScript check only

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,6 +7,7 @@
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
+    "beforeBundleCommand": "cargo build -p godly-daemon --release",
     "frontendDist": "../dist"
   },
   "app": {
@@ -30,7 +31,10 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": ["icons/icon.ico"]
+    "icon": ["icons/icon.ico"],
+    "resources": {
+      "target/release/godly-daemon.exe": "godly-daemon.exe"
+    }
   },
   "plugins": {}
 }


### PR DESCRIPTION
## Summary
- Adds `beforeBundleCommand` to `tauri.conf.json` to automatically build the daemon in release mode before installer generation
- Adds `bundle.resources` to include `godly-daemon.exe` alongside the main app binary in NSIS/MSI installers
- Updates `CLAUDE.md` to reflect that production build is now a single `npm run tauri build` command

## Details

The existing `find_daemon_binary()` in `client.rs` already looks for `godly-daemon.exe` in the same directory as the app binary, so no Rust code changes are needed — only the installer config needed updating.

## Test plan
- [ ] Run `npm run tauri dev` — confirm it still works (daemon found in `target/debug/`)
- [ ] Run `npm run tauri build` — confirm it produces installers with the daemon bundled
- [ ] Check installer contents: NSIS exe / MSI should contain both `Godly Terminal.exe` and `godly-daemon.exe`
- [ ] Install and run — confirm the app launches, finds the daemon, and terminals work