### PR TITLE
Add BUSL 1.1 license and metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,70 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             Alan Galvao Martini
+Licensed Work:        Godly Terminal 0.1.0
+Additional Use Grant: You may make non-production use of the Licensed Work, including
+                      for development, testing, and personal use.
+Change Date:          2031-02-07
+Change License:       Apache License, Version 2.0
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works,
+redistribute, and make non-production use of the Licensed Work. The Licensor may make
+an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this License,
+whichever comes first, the Licensor hereby grants you rights under the terms of the
+Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in
+effect as described in this License, you must purchase a commercial license from the
+Licensor, its affiliated entities, or authorized resellers, or you must refrain from
+using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the
+Licensed Work, are subject to this License. This License applies separately for each
+version of the Licensed Work and the Change Date may vary for each version of the
+Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the
+Licensed Work. If you receive the Licensed Work in original or modified form from a
+third party, the terms and conditions set forth in this License apply to your use of
+that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate
+your rights under this License for the current and all other versions of the Licensed
+Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its
+affiliates (provided that you may use a trademark or logo of Licensor as expressly
+required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS"
+BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED,
+INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license your works,
+and to refer to it using the trademark "Business Source License", as long as you
+comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business Source
+License" name and trademark, Licensor covenants to MariaDB, and to all other
+recipients of the licensed work, that Licensor will not modify this License's text in
+any way other than as permitted by this License.
+
+Licensor may specify an Additional Use Grant in the Parameters section above. Licensor
+may not modify the Terms section of this License in any way other than to replace the
+Change Date and Change License with the actual date and license to be applied.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open Source
+license. However, the Licensed Work will eventually be made available under an Open
+Source License, as stated in this License.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "godly-terminal",
   "version": "0.1.0",
   "private": true,
+  "license": "BUSL-1.1",
   "type": "module",
   "scripts": {
     "dev": "npm run build:daemon && vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "A Windows terminal application with workspaces"
 authors = ["you"]
 edition = "2021"
+license = "BUSL-1.1"
 
 [lib]
 name = "godly_terminal_lib"

--- a/src-tauri/daemon/Cargo.toml
+++ b/src-tauri/daemon/Cargo.toml
@@ -2,6 +2,7 @@
 name = "godly-daemon"
 version = "0.1.0"
 edition = "2021"
+license = "BUSL-1.1"
 
 [[bin]]
 name = "godly-daemon"

--- a/src-tauri/protocol/Cargo.toml
+++ b/src-tauri/protocol/Cargo.toml
@@ -2,6 +2,7 @@
 name = "godly-protocol"
 version = "0.1.0"
 edition = "2021"
+license = "BUSL-1.1"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### Motivation
- The repository had no license file, so add the Business Source License 1.1 to protect commercial use while allowing non-production use and future open-sourcing. 
- Embed project-specific parameters (Licensor, Licensed Work, Additional Use Grant, Change Date, Change License) into the license text.

### Description
- Add a `LICENSE` file containing the BUSL 1.1 template populated with project parameters for Alan Galvao Martini and `Godly Terminal 0.1.0`.
- Declare the license in the npm manifest by adding `"license": "BUSL-1.1"` to `package.json`.
- Add `license = "BUSL-1.1"` under `[package]` in `src-tauri/Cargo.toml` for the workspace crate.
- Add `license = "BUSL-1.1"` to the sub-crate manifests `src-tauri/daemon/Cargo.toml` and `src-tauri/protocol/Cargo.toml`.

### Testing
- Ran `npm run build`, which completed successfully (Vite build output produced without errors). 
- Ran `cd src-tauri && cargo check --workspace`, which attempted to build but failed due to missing system libraries (`glib-2.0`, `gobject-2.0`, `gio-2.0`) reported by `pkg-config`; this is an environment dependency issue rather than a manifest error.

------