### PR TITLE
fix: include daemon binary in production bundle

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run build:daemon:release && npm run build",
     "frontendDist": "../dist"
   },
   "app": {
@@ -30,7 +30,10 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": ["icons/icon.ico"]
+    "icon": ["icons/icon.ico"],
+    "resources": {
+      "target/release/godly-daemon.exe": "./"
+    }
   },
   "plugins": {}
 }


### PR DESCRIPTION
## Summary

- Configures `tauri.conf.json` to bundle the `godly-daemon.exe` binary as a sidecar resource in production builds
- Adds WMI-based daemon launch to escape Tauri's Job Object process tree kills, ensuring the daemon survives app restarts
- Adds BUSL 1.1 license with Apache 2.0 change license (2031)
- Expands daemon session persistence test coverage

## Changes

- `src-tauri/tauri.conf.json` — add `externalBin` config for daemon sidecar bundling
- `src-tauri/src/daemon_client/client.rs` — WMI-based daemon spawning to escape Job Object
- `src-tauri/daemon/tests/session_persistence.rs` — expanded test suite
- `LICENSE` — BUSL 1.1 license file
- `Cargo.toml` files — license metadata

## Test plan

- [ ] `cd src-tauri && cargo test -p godly-protocol && cargo test -p godly-daemon && cargo test -p godly-terminal` passes
- [ ] `npm test` passes
- [ ] `npm run build` succeeds with daemon binary bundled
- [ ] Verify daemon survives app close/reopen cycle