### PR TITLE
fix: resolve worktree panel lag on delete and add refresh button

### DIFF
--- a/src-tauri/src/commands/worktree.rs
+++ b/src-tauri/src/commands/worktree.rs
@@ -23,23 +23,35 @@ pub fn is_git_repo(folder_path: String) -> bool {
 }
 
 #[tauri::command]
-pub fn list_worktrees(folder_path: String) -> Result<Vec<worktree::WorktreeInfo>, String> {
-    let repo_root = worktree::get_repo_root(&folder_path)?;
-    worktree::list_worktrees(&repo_root)
+pub async fn list_worktrees(folder_path: String) -> Result<Vec<worktree::WorktreeInfo>, String> {
+    tokio::task::spawn_blocking(move || {
+        let repo_root = worktree::get_repo_root(&folder_path)?;
+        worktree::list_worktrees(&repo_root)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 #[tauri::command]
-pub fn remove_worktree(
+pub async fn remove_worktree(
     folder_path: String,
     worktree_path: String,
     force: Option<bool>,
 ) -> Result<(), String> {
-    let repo_root = worktree::get_repo_root(&folder_path)?;
-    worktree::remove_worktree(&repo_root, &worktree_path, force.unwrap_or(false))
+    tokio::task::spawn_blocking(move || {
+        let repo_root = worktree::get_repo_root(&folder_path)?;
+        worktree::remove_worktree(&repo_root, &worktree_path, force.unwrap_or(false))
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 #[tauri::command]
-pub fn cleanup_all_worktrees(folder_path: String) -> Result<u32, String> {
-    let repo_root = worktree::get_repo_root(&folder_path)?;
-    worktree::cleanup_all_worktrees(&repo_root)
+pub async fn cleanup_all_worktrees(folder_path: String) -> Result<u32, String> {
+    tokio::task::spawn_blocking(move || {
+        let repo_root = worktree::get_repo_root(&folder_path)?;
+        worktree::cleanup_all_worktrees(&repo_root)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -556,6 +556,45 @@ html, body {
   color: var(--danger);
 }
 
+.worktree-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.worktree-refresh-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background 0.1s, color 0.1s, transform 0.1s;
+  line-height: 1;
+}
+
+.worktree-refresh-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+.worktree-refresh-btn.spinning {
+  animation: spin 0.8s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 .worktree-clean-all {
   background: none;
   border: 1px solid var(--border-color);
@@ -571,6 +610,12 @@ html, body {
   background: var(--danger);
   color: white;
   border-color: var(--danger);
+}
+
+.worktree-item-delete.deleting {
+  opacity: 1;
+  cursor: wait;
+  color: var(--text-secondary);
 }
 
 /* Empty state */


### PR DESCRIPTION
## Summary

- **Debounced refresh**: `onStoreChange` was calling `git worktree list` on every store mutation (terminal output, tab switches, etc.) with no debouncing, flooding the system with git subprocesses. Now debounced to 500ms with a guard against concurrent refreshes.
- **Delete loading state**: Clicking the delete button now shows an hourglass icon and disables the button during the operation, preventing double-clicks and providing visual feedback.
- **Async Rust commands**: `list_worktrees`, `remove_worktree`, and `cleanup_all_worktrees` now use `tokio::task::spawn_blocking` to avoid blocking Tauri's async runtime.
- **Refresh button**: Added a circular refresh button (↻) in the worktree panel header with a spin animation during refresh.

## Test plan

- [ ] Enable worktree mode on a workspace, verify the panel loads without lag
- [ ] Click the X on a worktree — verify hourglass shows, worktree is removed, list updates
- [ ] Click the refresh button — verify it spins and re-fetches the list
- [ ] Rapidly switch tabs / type in terminal — verify no lag from worktree panel