### PR TITLE
feat: workspace drag-and-drop reordering

### DIFF
--- a/src/components/WorkspaceSidebar.ts
+++ b/src/components/WorkspaceSidebar.ts
@@ -8,6 +8,7 @@ export class WorkspaceSidebar {
   private listContainer: HTMLElement;
   private worktreePanel: WorktreePanel;
   private onDrop: ((workspaceId: string, terminalId: string) => void) | null = null;
+  private draggedItem: HTMLElement | null = null;
 
   constructor() {
     this.container = document.createElement('div');
@@ -222,22 +223,50 @@ export class WorkspaceSidebar {
       this.showContextMenu(e, workspace);
     };
 
-    // Drop zone for tabs
+    // Drag source for workspace reordering
+    item.draggable = true;
+
+    item.ondragstart = (e) => {
+      this.draggedItem = item;
+      item.classList.add('dragging');
+      e.dataTransfer!.effectAllowed = 'move';
+      e.dataTransfer!.setData('application/x-workspace-id', workspace.id);
+    };
+
+    item.ondragend = () => {
+      item.classList.remove('dragging');
+      this.draggedItem = null;
+      document.querySelectorAll('.drag-over-workspace').forEach(el => {
+        el.classList.remove('drag-over-workspace');
+      });
+    };
+
+    // Drop zone for tabs and workspace reordering
     item.ondragover = (e) => {
       e.preventDefault();
-      const terminalId = e.dataTransfer?.types.includes('text/plain');
-      if (terminalId && !isActive) {
+      const isWorkspaceDrag = e.dataTransfer?.types.includes('application/x-workspace-id');
+      if (isWorkspaceDrag && this.draggedItem && this.draggedItem !== item) {
+        item.classList.add('drag-over-workspace');
+      } else if (!isWorkspaceDrag && e.dataTransfer?.types.includes('text/plain') && !isActive) {
         item.classList.add('drag-over');
       }
     };
 
     item.ondragleave = () => {
       item.classList.remove('drag-over');
+      item.classList.remove('drag-over-workspace');
     };
 
     item.ondrop = (e) => {
       e.preventDefault();
       item.classList.remove('drag-over');
+      item.classList.remove('drag-over-workspace');
+
+      const droppedWorkspaceId = e.dataTransfer?.getData('application/x-workspace-id');
+      if (droppedWorkspaceId && droppedWorkspaceId !== workspace.id) {
+        this.handleWorkspaceReorder(droppedWorkspaceId, workspace.id);
+        return;
+      }
 
       const terminalId = e.dataTransfer?.getData('text/plain');
       if (terminalId && this.onDrop) {
@@ -246,6 +275,20 @@ export class WorkspaceSidebar {
     };
 
     return item;
+  }
+
+  private handleWorkspaceReorder(draggedId: string, targetId: string) {
+    const state = store.getState();
+    const ids = state.workspaces.map(w => w.id);
+
+    const draggedIndex = ids.indexOf(draggedId);
+    const targetIndex = ids.indexOf(targetId);
+    if (draggedIndex === -1 || targetIndex === -1) return;
+
+    ids.splice(draggedIndex, 1);
+    ids.splice(targetIndex, 0, draggedId);
+
+    store.reorderWorkspaces(ids);
   }
 
   private showContextMenu(e: MouseEvent, workspace: Workspace) {

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -110,6 +110,62 @@ describe('Store', () => {
       expect(updated?.shellType).toEqual({ type: 'windows' });
     });
 
+    it('should reorder workspaces by id list', () => {
+      store.addWorkspace({
+        id: 'ws-a', name: 'A', folderPath: 'C:\\a', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false,
+      });
+      store.addWorkspace({
+        id: 'ws-b', name: 'B', folderPath: 'C:\\b', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false,
+      });
+      store.addWorkspace({
+        id: 'ws-c', name: 'C', folderPath: 'C:\\c', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false,
+      });
+
+      store.reorderWorkspaces(['ws-c', 'ws-a', 'ws-b']);
+
+      const state = store.getState();
+      expect(state.workspaces.map(w => w.id)).toEqual(['ws-c', 'ws-a', 'ws-b']);
+    });
+
+    it('should ignore unknown ids in reorderWorkspaces', () => {
+      store.addWorkspace({
+        id: 'ws-a', name: 'A', folderPath: 'C:\\a', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false,
+      });
+      store.addWorkspace({
+        id: 'ws-b', name: 'B', folderPath: 'C:\\b', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false,
+      });
+
+      store.reorderWorkspaces(['ws-b', 'ws-nonexistent', 'ws-a']);
+
+      const state = store.getState();
+      expect(state.workspaces.map(w => w.id)).toEqual(['ws-b', 'ws-a']);
+    });
+
+    it('should preserve workspace data after reorder', () => {
+      store.addWorkspace({
+        id: 'ws-a', name: 'Alpha', folderPath: 'C:\\alpha', tabOrder: ['t1'],
+        shellType: { type: 'wsl', distribution: 'Ubuntu' }, worktreeMode: true,
+      });
+      store.addWorkspace({
+        id: 'ws-b', name: 'Beta', folderPath: 'C:\\beta', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false,
+      });
+
+      store.reorderWorkspaces(['ws-b', 'ws-a']);
+
+      const state = store.getState();
+      const alpha = state.workspaces.find(w => w.id === 'ws-a');
+      expect(alpha?.name).toBe('Alpha');
+      expect(alpha?.folderPath).toBe('C:\\alpha');
+      expect(alpha?.shellType).toEqual({ type: 'wsl', distribution: 'Ubuntu' });
+      expect(alpha?.worktreeMode).toBe(true);
+    });
+
     it('should remove workspace and its terminals', () => {
       const workspace: Workspace = {
         id: 'ws-6',

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -140,6 +140,14 @@ class Store {
     });
   }
 
+  reorderWorkspaces(workspaceIds: string[]) {
+    const workspaceMap = new Map(this.state.workspaces.map(w => [w.id, w]));
+    const reordered = workspaceIds
+      .map(id => workspaceMap.get(id))
+      .filter((w): w is Workspace => w !== undefined);
+    this.setState({ workspaces: reordered });
+  }
+
   reorderTerminals(workspaceId: string, tabOrder: string[]) {
     this.setState({
       terminals: this.state.terminals.map(t => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -79,9 +79,17 @@ html, body {
   background: var(--bg-active);
 }
 
+.workspace-item.dragging {
+  opacity: 0.5;
+}
+
 .workspace-item.drag-over {
   background: var(--accent);
   color: white;
+}
+
+.workspace-item.drag-over-workspace {
+  border-top: 2px solid var(--accent);
 }
 
 .workspace-name-container {


### PR DESCRIPTION
## Summary
- Workspaces in the sidebar can now be reordered via drag-and-drop, mirroring the existing tab reorder pattern
- Uses a custom MIME type (`application/x-workspace-id`) to distinguish workspace drags from tab-to-workspace drops
- Added `reorderWorkspaces()` to the store, drag handlers to `WorkspaceSidebar`, and CSS feedback styles

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` (tsc + vite) succeeds
- [x] `npm test` — 40 tests pass (3 new tests for `reorderWorkspaces`)
- [ ] Manual: launch with `npm run tauri dev`, create 3+ workspaces, drag to reorder, verify order persists after restart