### PR TITLE
fix: restore custom tab names across app restarts

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -42,6 +42,7 @@ pub fn create_terminal(
     shell_type_override: Option<ShellType>,
     id_override: Option<String>,
     worktree_name: Option<String>,
+    name_override: Option<String>,
     state: State<Arc<AppState>>,
     daemon: State<Arc<DaemonClient>>,
     auto_save: State<Arc<AutoSaveManager>>,
@@ -167,7 +168,7 @@ pub fn create_terminal(
     let terminal = Terminal {
         id: terminal_id.clone(),
         workspace_id,
-        name: String::from("Terminal"),
+        name: name_override.unwrap_or_else(|| String::from("Terminal")),
         process_name,
     };
     state.add_terminal(terminal);

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -325,6 +325,7 @@ export class App {
             cwdOverride: t.cwd ?? undefined,
             shellTypeOverride: shellType,
             idOverride: t.id,
+            nameOverride: tabName,
           });
 
           console.log('[App] Terminal created with ID:', result.id, '(requested:', t.id, ')');

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -90,6 +90,7 @@ class TerminalService {
       shellTypeOverride?: ShellType;
       idOverride?: string;
       worktreeName?: string;
+      nameOverride?: string;
     }
   ): Promise<CreateTerminalResult> {
     const result = await invoke<CreateTerminalResult>('create_terminal', {
@@ -100,6 +101,7 @@ class TerminalService {
         : null,
       idOverride: options?.idOverride ?? null,
       worktreeName: options?.worktreeName ?? null,
+      nameOverride: options?.nameOverride ?? null,
     });
     return result;
   }


### PR DESCRIPTION
## Summary

- `create_terminal` hardcoded `name: "Terminal"` in the backend Terminal record, so when autosave ran it overwrote the persisted custom tab name with "Terminal"
- Added `name_override` parameter to the `create_terminal` Tauri command so the saved name can be passed during restoration
- Frontend now passes the saved tab name (`worktree_branch || name`) when recreating dead sessions on restart

## Test plan

- [x] Added two unit tests verifying `nameOverride` is passed to the backend during restore (custom name and worktree branch)
- [x] All 39 TypeScript tests pass
- [x] Rust unit tests pass (protocol + daemon)
- [x] TypeScript type check passes
- [x] Production build succeeds
- [ ] Manual: rename a tab, close and reopen app, verify name persists