### PR TITLE
fix: MCP handshake timeout due to notification response

### DIFF
--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -37,6 +37,11 @@ fn main() {
             }
         };
 
+        // JSON-RPC notifications have no id — servers MUST NOT respond to them.
+        if request.id.is_none() {
+            continue;
+        }
+
         let response = handle_request(&request, &mut client, &session_id);
 
         if let Err(e) = write_message(&mut stdout, &response) {
@@ -66,13 +71,6 @@ fn handle_request(
                     }
                 }),
             )
-        }
-
-        "notifications/initialized" => {
-            // No response needed for notifications, but since our loop always
-            // writes a response, return an empty success. MCP clients should
-            // ignore responses to notifications.
-            JsonRpcResponse::success(request.id.clone(), json!({}))
         }
 
         "tools/list" => {


### PR DESCRIPTION
## Summary

- **Root cause**: `godly-mcp.exe` was sending a response for `notifications/initialized`, a JSON-RPC notification (no `id`). The MCP spec requires servers to NOT respond to notifications. The spurious id-less response confused Claude Code's MCP client, causing it to timeout during handshake.
- **Fix**: Skip writing a response when the incoming message has no `id` (i.e., it's a notification).
- Removed the dead `notifications/initialized` match arm since notifications are now filtered before reaching `handle_request`.

## Test plan

- [x] Manual end-to-end test: send `initialize` + `notifications/initialized` + `tools/list` — only 2 responses returned (previously 3)
- [x] `cargo test -p godly-protocol` — 3 passed
- [x] `cargo test -p godly-mcp` — 0 tests (no unit tests in crate)
- [x] `npm test` — 64 passed
- [x] Copied fixed binary to `C:\Program Files\Godly Terminal\` for immediate testing