### PR TITLE
fix: re-attach sessions after daemon reconnection to prevent terminal freeze

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,11 @@ pub fn run() {
                 .setup_bridge(app_handle.clone())
                 .expect("Failed to setup daemon bridge");
 
+            // Start keepalive thread — periodically pings the daemon to detect
+            // broken connections early (e.g. after system sleep/wake) and trigger
+            // reconnection + session re-attachment before the user notices.
+            DaemonClient::start_keepalive(daemon_client.clone());
+
             // Start process monitor (queries daemon for PIDs, resolves process names locally)
             process_monitor.start(app_handle.clone(), state_clone.clone(), daemon_client.clone());
 


### PR DESCRIPTION
## Summary

- When the named pipe connection between the Tauri app and daemon breaks (e.g. after system sleep/wake), the daemon auto-detaches all sessions but the existing reconnection logic never re-attached them, causing the terminal to appear frozen (input works but no output flows back)
- Added session tracking in `DaemonClient` so it knows which sessions to re-attach after reconnection, with ring buffer replay for any missed output
- Added a 30-second keepalive ping thread that proactively detects broken connections and triggers reconnection before the user notices

## Test plan

- [ ] Open terminal, let system sleep and wake — verify terminal resumes output without manual intervention
- [ ] Open multiple terminals, break the daemon connection (kill daemon process) — verify all terminals recover
- [ ] Verify keepalive log messages appear every 30s in daemon stderr
- [ ] Run `cargo test -p godly-protocol` and `cargo test -p godly-daemon -- session::tests` — all pass
- [ ] Run `npm test` — all 117 tests pass
- [ ] Run `npm run build` — production build succeeds