### PR TITLE
feat: add taskbar flash and Windows native notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
+    "@tauri-apps/plugin-notification": "^2.0.0",
     "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-store": "^2.0.0",
     "@xterm/addon-fit": "^0.10.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri = { version = "2.0", features = [] }
 tauri-plugin-store = "2.0"
 tauri-plugin-dialog = "2.0"
 tauri-plugin-opener = "2"
+tauri-plugin-notification = "2"
 godly-protocol = { path = "protocol" }
 uuid = { version = "1.0", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,8 +6,10 @@
   "permissions": [
     "core:default",
     "core:path:default",
+    "core:window:allow-request-user-attention",
     "store:default",
     "dialog:default",
-    "opener:default"
+    "opener:default",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(app_state.clone())
         .manage(auto_save.clone())
         .manage(daemon_client.clone())


### PR DESCRIPTION
## Summary
- Taskbar icon now flashes orange when an MCP notification is triggered (via `requestUserAttention`)
- Windows toast notifications are shown when the app window is not focused (via `tauri-plugin-notification`)
- Both features respect the existing global notification enabled toggle

## Changes
- Added `tauri-plugin-notification` Rust dependency and registered it in the Tauri app
- Added `@tauri-apps/plugin-notification` JS dependency
- Added `notification:default` and `core:window:allow-request-user-attention` permissions
- Extended the `mcp-notify` handler in `App.ts` to flash the taskbar and send native notifications

## Test plan
- [ ] Trigger a notification via MCP `notify` tool while the window is not focused
- [ ] Verify the taskbar icon flashes orange
- [ ] Verify a Windows toast notification appears with the terminal name and message
- [ ] Verify no flash/toast when the window is focused and active on the notifying terminal
- [ ] Verify the global notification toggle disables all behaviors (sound, flash, toast)