### PR TITLE
feat: add progress feedback to Clean All worktrees

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -650,6 +650,22 @@ html, body {
   border-color: var(--danger);
 }
 
+.worktree-clean-all.cleaning {
+  opacity: 0.6;
+  cursor: wait;
+  pointer-events: none;
+}
+
+.worktree-status {
+  padding: 4px 8px;
+  font-size: 11px;
+  font-family: 'Cascadia Code', Consolas, monospace;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  margin: 0 8px 4px;
+}
+
 .worktree-item-delete.deleting {
   opacity: 1;
   cursor: wait;


### PR DESCRIPTION
## Summary

- Add real-time progress feedback when clicking "Clean All" in the worktree panel — the button shows a loading state, disables to prevent double-clicks, and a status line shows per-worktree removal progress (e.g. "Removing wt-abc (2/5)...")
- Backend emits `worktree-cleanup-progress` Tauri events with listing/removing/done steps, frontend listens and renders status text
- Add `CleanupProgress` struct and `cleanup_all_worktrees_with_progress()` with callback API (existing function delegates to it for backward compatibility)

## Test plan

- [x] Rust unit test: `test_cleanup_all_worktrees_with_progress` — creates 2 worktrees, verifies removal, asserts exactly 4 progress events with correct field values
- [x] E2E tests: loading state (`.cleaning` class), status text with progress keywords, empty state after cleanup, button disable/re-enable
- [x] TypeScript builds cleanly (`tsc --noEmit`, `npm run build`)
- [x] All 117 JS unit tests pass
- [x] Rust crate checks pass (godly-protocol, godly-daemon)