### PR TITLE
feat: reopen worktree in terminal

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -559,6 +559,14 @@ html, body {
   gap: 6px;
   overflow: hidden;
   min-width: 0;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+  transition: color 0.1s;
+}
+
+.worktree-item-info:hover {
+  color: var(--text-active);
 }
 
 .worktree-item-branch {


### PR DESCRIPTION
## Summary
- Make worktree items in the WorktreePanel clickable to open a new terminal tab at that worktree's directory
- Uses existing `cwdOverride` parameter on `create_terminal` — no backend changes needed
- If `claudeCodeMode` is enabled, auto-types the claude command in the new terminal
- Adds hover highlight and cursor pointer styles to indicate worktree items are clickable

## Test plan
- [ ] Enable worktree mode on a git repo workspace
- [ ] Create some worktrees (or have existing ones)
- [ ] Click a worktree item and verify a new terminal tab opens in that directory
- [ ] Verify the tab is named after the branch
- [ ] Enable Claude Code mode, click a worktree, and verify the claude command is auto-typed
- [ ] Verify the delete button still works independently (not triggered by clicking the item)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (117 tests)
- [ ] `npm run build` succeeds