### PR TITLE
fix: decode UTF-16LE output from wsl.exe to resolve WSL_E_DISTRO_NOT_FOUND

### DIFF
--- a/src-tauri/src/commands/wsl.rs
+++ b/src-tauri/src/commands/wsl.rs
@@ -6,15 +6,41 @@ use std::os::windows::process::CommandExt;
 use winapi::um::winbase::CREATE_NO_WINDOW;
 
 /// Parse WSL distribution names from raw stdout bytes.
-/// Handles UTF-16LE encoding artifacts (null characters) and whitespace.
+/// `wsl --list --quiet` outputs UTF-16LE on Windows, so we detect and decode it.
 pub fn parse_wsl_distributions(stdout: &[u8]) -> Vec<String> {
-    let stdout_str = String::from_utf8_lossy(stdout);
+    let decoded = decode_utf16le_or_utf8(stdout);
 
-    stdout_str
+    decoded
         .lines()
         .map(|line| line.trim().trim_matches('\0').to_string())
         .filter(|line| !line.is_empty())
         .collect()
+}
+
+/// Decode bytes as UTF-16LE if they look like it, otherwise fall back to UTF-8.
+fn decode_utf16le_or_utf8(bytes: &[u8]) -> String {
+    let data = if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
+        &bytes[2..] // Strip UTF-16LE BOM
+    } else {
+        bytes
+    };
+
+    // Detect UTF-16LE: even length and every other byte (odd positions) is 0x00
+    // for ASCII-range characters, which WSL distribution names always are.
+    let looks_utf16le = data.len() >= 2
+        && data.len() % 2 == 0
+        && data.iter().skip(1).step_by(2).all(|&b| b == 0);
+
+    if looks_utf16le {
+        let u16_iter = data
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]));
+        char::decode_utf16(u16_iter)
+            .map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER))
+            .collect()
+    } else {
+        String::from_utf8_lossy(data).into_owned()
+    }
 }
 
 #[tauri::command]
@@ -68,11 +94,10 @@ mod tests {
     #[test]
     fn test_parse_wsl_distributions_with_null_characters() {
         // Simulates UTF-16LE artifacts with null bytes interspersed
+        // This is detected as UTF-16LE and decoded properly
         let stdout = b"U\0b\0u\0n\0t\0u\0\n\0D\0e\0b\0i\0a\0n\0";
         let result = parse_wsl_distributions(stdout);
-        // After from_utf8_lossy and trim_matches('\0'), we should get cleaned strings
-        assert!(!result.is_empty());
-        // The exact result depends on how the nulls are interpreted
+        assert_eq!(result, vec!["Ubuntu", "Debian"]);
     }
 
     #[test]
@@ -122,6 +147,90 @@ mod tests {
         let stdout = b"Ubuntu-22.04\nUbuntu-20.04\nDebian\n";
         let result = parse_wsl_distributions(stdout);
         assert_eq!(result, vec!["Ubuntu-22.04", "Ubuntu-20.04", "Debian"]);
+    }
+
+    // Bug reproduction: WSL_E_DISTRO_NOT_FOUND when creating WSL workspace
+    // `wsl --list --quiet` outputs UTF-16LE on Windows, but parse_wsl_distributions
+    // uses from_utf8_lossy which mangles the names with embedded null chars.
+    // When these mangled names are passed to `wsl.exe -d <name>`, WSL can't find them.
+
+    #[test]
+    fn test_parse_real_utf16le_wsl_output() {
+        // Real output from `wsl --list --quiet` on Windows is UTF-16LE encoded.
+        // "Ubuntu\r\n" in UTF-16LE:
+        let stdout: Vec<u8> = vec![
+            0x55, 0x00, // U
+            0x62, 0x00, // b
+            0x75, 0x00, // u
+            0x6E, 0x00, // n
+            0x74, 0x00, // t
+            0x75, 0x00, // u
+            0x0D, 0x00, // \r
+            0x0A, 0x00, // \n
+        ];
+
+        let result = parse_wsl_distributions(&stdout);
+        assert_eq!(
+            result,
+            vec!["Ubuntu"],
+            "Bug: UTF-16LE output from wsl.exe is not decoded correctly, \
+             producing mangled distribution names that cause WSL_E_DISTRO_NOT_FOUND"
+        );
+    }
+
+    #[test]
+    fn test_parse_real_utf16le_multiple_distros() {
+        // Real output: "Ubuntu\r\ndocker-desktop\r\n" in UTF-16LE
+        let stdout: Vec<u8> = "Ubuntu\r\ndocker-desktop\r\n"
+            .encode_utf16()
+            .flat_map(|c| c.to_le_bytes())
+            .collect();
+
+        let result = parse_wsl_distributions(&stdout);
+        assert_eq!(
+            result,
+            vec!["Ubuntu", "docker-desktop"],
+            "Bug: UTF-16LE output from wsl.exe is not decoded correctly, \
+             producing mangled distribution names that cause WSL_E_DISTRO_NOT_FOUND"
+        );
+    }
+
+    #[test]
+    fn test_parse_utf16le_with_bom() {
+        // Some Windows tools prepend a UTF-16LE BOM (0xFF 0xFE)
+        let mut stdout: Vec<u8> = vec![0xFF, 0xFE]; // BOM
+        stdout.extend(
+            "Ubuntu\r\n"
+                .encode_utf16()
+                .flat_map(|c| c.to_le_bytes()),
+        );
+
+        let result = parse_wsl_distributions(&stdout);
+        assert_eq!(
+            result,
+            vec!["Ubuntu"],
+            "Bug: UTF-16LE output with BOM from wsl.exe is not decoded correctly"
+        );
+    }
+
+    #[test]
+    fn test_parsed_distro_names_contain_no_null_bytes() {
+        // Real output: "Ubuntu\r\n" in UTF-16LE
+        let stdout: Vec<u8> = "Ubuntu\r\n"
+            .encode_utf16()
+            .flat_map(|c| c.to_le_bytes())
+            .collect();
+
+        let result = parse_wsl_distributions(&stdout);
+        for name in &result {
+            assert!(
+                !name.contains('\0'),
+                "Bug: distribution name '{}' contains null bytes — \
+                 wsl.exe will fail with WSL_E_DISTRO_NOT_FOUND",
+                name.escape_debug()
+            );
+        }
+        assert!(!result.is_empty(), "Should have parsed at least one distro");
     }
 
     // Integration tests that require WSL to be installed


### PR DESCRIPTION
## Summary

- `wsl --list --quiet` outputs UTF-16LE encoded text on Windows, but `parse_wsl_distributions` used `String::from_utf8_lossy` which mangled distribution names with embedded null bytes (e.g. `U\0b\0u\0n\0t\0u` instead of `Ubuntu`)
- When these mangled names were passed to `wsl.exe -d <name>`, WSL couldn't find them, producing `WSL_E_DISTRO_NOT_FOUND`
- Added `decode_utf16le_or_utf8` helper that detects UTF-16LE encoding (via BOM or null-byte pattern) and decodes properly before parsing lines
- Strengthened a pre-existing weak test assertion

## Test plan

- [x] 4 new regression tests covering real UTF-16LE output, multiple distros, BOM handling, and no-null-bytes invariant
- [x] All 14 WSL unit tests pass (including 10 pre-existing)
- [x] 127 TypeScript tests pass
- [x] Rust workspace compiles cleanly
- [x] Production build succeeds