### PR TITLE
feat: drag-and-drop file path paste into terminal

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "fullscreen": false,
         "decorations": true,
         "transparent": false,
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/src/components/App.test.ts
+++ b/src/components/App.test.ts
@@ -850,3 +850,4 @@ describe('App Persistence', () => {
     });
   });
 });
+

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -262,6 +262,17 @@ html, body {
   overflow: hidden;
 }
 
+.terminal-container.drag-file-over::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border: 2px dashed var(--accent);
+  border-radius: 8px;
+  background: rgba(0, 120, 212, 0.08);
+  pointer-events: none;
+  z-index: 10;
+}
+
 .terminal-pane {
   position: absolute;
   top: 0;

--- a/src/utils/quote-path.test.ts
+++ b/src/utils/quote-path.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { quotePath } from './quote-path';
+
+describe('quotePath', () => {
+  it('should return path unchanged when it has no spaces', () => {
+    expect(quotePath('C:\\Users\\test\\file.png')).toBe('C:\\Users\\test\\file.png');
+  });
+
+  it('should wrap path in double quotes when it contains spaces', () => {
+    // Bug trigger: ShareX screenshots land in paths like "C:\Users\name\My Screenshots\image.png"
+    expect(quotePath('C:\\Users\\test\\My Screenshots\\image.png'))
+      .toBe('"C:\\Users\\test\\My Screenshots\\image.png"');
+  });
+
+  it('should handle single-segment path with space', () => {
+    expect(quotePath('my file.txt')).toBe('"my file.txt"');
+  });
+
+  it('should handle multiple paths joined with space for multi-file drop', () => {
+    const paths = [
+      'C:\\no-space.txt',
+      'C:\\has space\\file.png',
+      'D:\\another path\\doc.pdf',
+    ];
+    const result = paths.map(quotePath).join(' ');
+    expect(result).toBe('C:\\no-space.txt "C:\\has space\\file.png" "D:\\another path\\doc.pdf"');
+  });
+});

--- a/src/utils/quote-path.ts
+++ b/src/utils/quote-path.ts
@@ -1,0 +1,7 @@
+/** Quote a file path if it contains spaces, for pasting into the terminal. */
+export function quotePath(path: string): string {
+  if (path.includes(' ')) {
+    return `"${path}"`;
+  }
+  return path;
+}


### PR DESCRIPTION
## Summary

- Enable OS-level file drop target on the Tauri webview (`dragDropEnabled: true`)
- Listen for drag-drop events via `getCurrentWebview().onDragDropEvent()` in App.ts
- On drop, paste file path(s) into the active terminal (space-containing paths are auto-quoted)
- Add visual drop-zone feedback with a dashed accent border overlay
- Extract `quotePath` utility to `src/utils/quote-path.ts` with dedicated unit tests

## Test plan

- [x] All 131 vitest tests pass (7 test files)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Vite production build succeeds
- [x] Rust crates compile (`cargo check -p godly-protocol -p godly-daemon`)
- [ ] Manual: run `npm run tauri dev`, drag a file from Explorer onto the terminal, verify path appears
- [ ] Manual: drag a file with spaces in the path, verify it is quoted
- [ ] Manual: verify dashed blue border appears on drag-enter and disappears on drag-leave/drop