### PR TITLE
feat: update terminal tab name from OSC title escape sequences

### DIFF
--- a/src-tauri/src/pty/process_monitor.rs
+++ b/src-tauri/src/pty/process_monitor.rs
@@ -15,7 +15,7 @@ use winapi::um::tlhelp32::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
 #[cfg(windows)]
-use winapi::um::winnt::PROCESS_QUERY_INFORMATION;
+use winapi::um::winnt::{PROCESS_QUERY_INFORMATION, PROCESS_VM_READ};
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -157,7 +157,7 @@ fn find_deepest_child(parent_pid: u32) -> Option<u32> {
 #[cfg(windows)]
 fn get_process_name(pid: u32) -> Option<String> {
     unsafe {
-        let handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
+        let handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
         if handle.is_null() {
             return None;
         }

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -86,8 +86,8 @@ export class TabBar {
     tab.dataset.terminalId = terminal.id;
     tab.draggable = true;
 
-    // Display name: custom name or process name
-    const displayName = terminal.name || terminal.processName || 'Terminal';
+    // Display name priority: user rename > OSC title sequence > process name
+    const displayName = terminal.name || terminal.oscTitle || terminal.processName || 'Terminal';
 
     const title = document.createElement('span');
     title.className = 'tab-title';

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -4,6 +4,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { terminalService } from '../services/terminal-service';
+import { store } from '../state/store';
 import { isAppShortcut, isTerminalControlKey } from './keyboard';
 import { keybindingStore } from '../state/keybinding-store';
 
@@ -138,6 +139,13 @@ export class TerminalPane {
         this.terminal.write(data);
       }
     );
+
+    // Update tab name when programs set the title via OSC escape sequences
+    // (e.g. \x1b]0;title\x07). This is how Claude Code, vim, etc. set the
+    // terminal title in Windows Terminal and other native terminals.
+    this.terminal.onTitleChange((title) => {
+      store.updateTerminal(this.terminalId, { oscTitle: title });
+    });
 
     // Start periodic scrollback saving (every 5 minutes)
     this.startScrollbackSaveInterval();

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -67,7 +67,9 @@ class TerminalService {
       'process-changed',
       (event) => {
         const { terminal_id, process_name } = event.payload;
-        store.updateTerminal(terminal_id, { processName: process_name });
+        // Clear oscTitle when the underlying process changes so stale titles
+        // don't persist (e.g. after exiting Claude Code back to PowerShell)
+        store.updateTerminal(terminal_id, { processName: process_name, oscTitle: '' });
       }
     );
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -3,6 +3,7 @@ export interface Terminal {
   workspaceId: string;
   name: string;
   processName: string;
+  oscTitle?: string;
   order: number;
 }
 


### PR DESCRIPTION
## Summary

- Listen to xterm.js `onTitleChange` in `TerminalPane` so programs that set the terminal title via OSC escape sequences (e.g. `\x1b]0;title\x07`) update the tab name — matching Windows Terminal behavior
- Add `oscTitle` field to `Terminal` store with display priority: user rename > OSC title > process name
- Clear `oscTitle` when the process monitor detects a process change, preventing stale titles after exiting a program
- Fix `OpenProcess` flags in process monitor to include `PROCESS_VM_READ` for more reliable process name detection

## Test plan

- [x] 5 new store tests covering oscTitle storage, clearing, preservation, and multi-terminal isolation
- [x] All 136 TypeScript tests pass
- [x] Rust crates compile cleanly (`cargo check -p godly-protocol -p godly-daemon`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: run Claude Code in a terminal tab and verify the tab name updates to reflect Claude's title
- [ ] Manual: exit Claude Code and verify the tab name reverts to the shell process name