### PR TITLE
fix: enable worktree toggle for WSL workspaces

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -59,28 +59,34 @@ pub fn create_terminal(
         // Explicit CWD override (e.g., restore) - skip worktree creation
         Some(cwd)
     } else if let Some(ref ws) = workspace {
-        if ws.worktree_mode && crate::worktree::is_git_repo(&ws.folder_path) {
-            // Worktree mode enabled and it's a git repo - create a worktree
-            match crate::worktree::get_repo_root(&ws.folder_path) {
-                Ok(repo_root) => {
-                    let custom_name = worktree_name.as_deref();
-                    match crate::worktree::create_worktree(&repo_root, &terminal_id, custom_name) {
-                        Ok(wt_result) => {
-                            eprintln!("[terminal] Created worktree at: {} (branch: {})", wt_result.path, wt_result.branch);
-                            worktree_path_result = Some(wt_result.path.clone());
-                            worktree_branch = Some(wt_result.branch);
-                            Some(wt_result.path)
-                        }
-                        Err(e) => {
-                            eprintln!("[terminal] Warning: worktree creation failed, falling back to workspace dir: {}", e);
-                            Some(ws.folder_path.clone())
+        if ws.worktree_mode {
+            // Auto-detect WSL from the workspace folder path
+            let wsl = crate::worktree::WslConfig::from_path(&ws.folder_path);
+            if crate::worktree::is_git_repo(&ws.folder_path, wsl.as_ref()) {
+                // Worktree mode enabled and it's a git repo - create a worktree
+                match crate::worktree::get_repo_root(&ws.folder_path, wsl.as_ref()) {
+                    Ok(repo_root) => {
+                        let custom_name = worktree_name.as_deref();
+                        match crate::worktree::create_worktree(&repo_root, &terminal_id, custom_name, wsl.as_ref()) {
+                            Ok(wt_result) => {
+                                eprintln!("[terminal] Created worktree at: {} (branch: {})", wt_result.path, wt_result.branch);
+                                worktree_path_result = Some(wt_result.path.clone());
+                                worktree_branch = Some(wt_result.branch);
+                                Some(wt_result.path)
+                            }
+                            Err(e) => {
+                                eprintln!("[terminal] Warning: worktree creation failed, falling back to workspace dir: {}", e);
+                                Some(ws.folder_path.clone())
+                            }
                         }
                     }
+                    Err(e) => {
+                        eprintln!("[terminal] Warning: could not get repo root, falling back to workspace dir: {}", e);
+                        Some(ws.folder_path.clone())
+                    }
                 }
-                Err(e) => {
-                    eprintln!("[terminal] Warning: could not get repo root, falling back to workspace dir: {}", e);
-                    Some(ws.folder_path.clone())
-                }
+            } else {
+                Some(ws.folder_path.clone())
             }
         } else {
             Some(ws.folder_path.clone())

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,8 +1,10 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Output};
 use std::time::Instant;
+
+use crate::utils::path::windows_to_wsl_path;
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -40,6 +42,34 @@ pub struct WorktreeInfo {
     pub is_main: bool,
 }
 
+/// WSL configuration for running git commands inside a WSL distribution.
+#[derive(Debug, Clone)]
+pub struct WslConfig {
+    pub distribution: Option<String>,
+}
+
+impl WslConfig {
+    /// Auto-detect WSL configuration from a Windows UNC path.
+    /// Returns `Some` if the path is a WSL UNC path (e.g. `\\wsl.localhost\Ubuntu\...`).
+    pub fn from_path(path: &str) -> Option<Self> {
+        let normalized = path.replace('\\', "/");
+        let after_prefix = if normalized.starts_with("//wsl.localhost/") {
+            Some(&normalized["//wsl.localhost/".len()..])
+        } else if normalized.starts_with("//wsl$/") {
+            Some(&normalized["//wsl$/".len()..])
+        } else {
+            None
+        };
+
+        after_prefix.map(|s| {
+            let distribution = s.split('/').next()
+                .filter(|d| !d.is_empty())
+                .map(|d| d.to_string());
+            WslConfig { distribution }
+        })
+    }
+}
+
 fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
     #[cfg(windows)]
@@ -47,25 +77,57 @@ fn git_cmd() -> Command {
     cmd
 }
 
-/// Check if `path` is inside a git repository.
-pub fn is_git_repo(path: &str) -> bool {
-    let output = git_cmd()
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(path)
-        .output();
+/// Run a git command, optionally through WSL.
+///
+/// For WSL, the `cwd` is converted to a Linux path and passed via `wsl.exe --cd`.
+/// The `cwd` can be either a Windows UNC path or an already-converted Linux path.
+fn run_git(args: &[&str], cwd: &str, wsl: Option<&WslConfig>) -> std::io::Result<Output> {
+    match wsl {
+        Some(config) => {
+            let linux_cwd = windows_to_wsl_path(cwd);
+            let mut cmd = Command::new("wsl.exe");
+            #[cfg(windows)]
+            cmd.creation_flags(CREATE_NO_WINDOW);
+            if let Some(distro) = &config.distribution {
+                cmd.args(["-d", distro]);
+            }
+            cmd.args(["--cd", &linux_cwd, "--", "git"]);
+            cmd.args(args);
+            cmd.output()
+        }
+        None => {
+            let mut cmd = git_cmd();
+            cmd.args(args);
+            cmd.current_dir(cwd);
+            cmd.output()
+        }
+    }
+}
 
-    match output {
+/// Run a shell command inside WSL (e.g. `mkdir -p`).
+fn run_wsl_cmd(config: &WslConfig, program: &str, args: &[&str]) -> std::io::Result<Output> {
+    let mut cmd = Command::new("wsl.exe");
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+    if let Some(distro) = &config.distribution {
+        cmd.args(["-d", distro]);
+    }
+    cmd.args(["--", program]);
+    cmd.args(args);
+    cmd.output()
+}
+
+/// Check if `path` is inside a git repository.
+pub fn is_git_repo(path: &str, wsl: Option<&WslConfig>) -> bool {
+    match run_git(&["rev-parse", "--is-inside-work-tree"], path, wsl) {
         Ok(o) => o.status.success(),
         Err(_) => false,
     }
 }
 
 /// Return the root of the git repository that contains `path`.
-pub fn get_repo_root(path: &str) -> Result<String, String> {
-    let output = git_cmd()
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(path)
-        .output()
+pub fn get_repo_root(path: &str, wsl: Option<&WslConfig>) -> Result<String, String> {
+    let output = run_git(&["rev-parse", "--show-toplevel"], path, wsl)
         .map_err(|e| format!("Failed to run git: {}", e))?;
 
     if !output.status.success() {
@@ -98,41 +160,70 @@ pub fn worktree_path(repo_root: &str, terminal_id: &str, custom_name: Option<&st
     temp.join(WORKTREES_DIR).join(&repo_hash).join(&wt_name)
 }
 
+/// Build the worktree path for WSL: `/tmp/godly-worktrees/<repo-hash>/wt-<name>`
+fn worktree_path_wsl(repo_root: &str, terminal_id: &str, custom_name: Option<&str>) -> String {
+    let repo_hash = short_hash(repo_root);
+    let wt_name = wt_name_from(custom_name, terminal_id);
+    format!("/tmp/{}/{}/{}", WORKTREES_DIR, repo_hash, wt_name)
+}
+
 /// Create a new worktree for the given terminal.
 /// If `custom_name` is provided, it is used as the branch/folder suffix instead of the terminal id prefix.
 /// Returns a `WorktreeResult` with the path and branch name.
-pub fn create_worktree(repo_root: &str, terminal_id: &str, custom_name: Option<&str>) -> Result<WorktreeResult, String> {
-    let wt_path = worktree_path(repo_root, terminal_id, custom_name);
+pub fn create_worktree(repo_root: &str, terminal_id: &str, custom_name: Option<&str>, wsl: Option<&WslConfig>) -> Result<WorktreeResult, String> {
     let branch_name = wt_name_from(custom_name, terminal_id);
 
-    // Ensure parent directory exists
-    if let Some(parent) = wt_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create worktree parent dir: {}", e))?;
-    }
+    if let Some(wsl_config) = wsl {
+        // WSL: create worktree inside WSL's /tmp
+        let wt_linux_path = worktree_path_wsl(repo_root, terminal_id, custom_name);
 
-    let wt_path_str = wt_path.to_string_lossy().to_string();
+        // Ensure parent directory exists inside WSL
+        if let Some(parent) = wt_linux_path.rsplit_once('/').map(|(p, _)| p) {
+            let _ = run_wsl_cmd(wsl_config, "mkdir", &["-p", parent]);
+        }
 
-    let output = git_cmd()
-        .args(["worktree", "add", &wt_path_str, "-b", &branch_name])
-        .current_dir(repo_root)
-        .output()
+        let output = run_git(
+            &["worktree", "add", &wt_linux_path, "-b", &branch_name],
+            repo_root, Some(wsl_config),
+        )
         .map_err(|e| format!("Failed to run git worktree add: {}", e))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git worktree add failed: {}", stderr.trim()));
-    }
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("git worktree add failed: {}", stderr.trim()));
+        }
 
-    Ok(WorktreeResult { path: wt_path_str, branch: branch_name })
+        // Return the Linux path — the daemon's windows_to_wsl_path passes it through unchanged
+        Ok(WorktreeResult { path: wt_linux_path, branch: branch_name })
+    } else {
+        // Windows: create worktree in %TEMP%
+        let wt_path = worktree_path(repo_root, terminal_id, custom_name);
+
+        if let Some(parent) = wt_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create worktree parent dir: {}", e))?;
+        }
+
+        let wt_path_str = wt_path.to_string_lossy().to_string();
+
+        let output = run_git(
+            &["worktree", "add", &wt_path_str, "-b", &branch_name],
+            repo_root, None,
+        )
+        .map_err(|e| format!("Failed to run git worktree add: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("git worktree add failed: {}", stderr.trim()));
+        }
+
+        Ok(WorktreeResult { path: wt_path_str, branch: branch_name })
+    }
 }
 
 /// List all worktrees for the repo at `repo_root`.
-pub fn list_worktrees(repo_root: &str) -> Result<Vec<WorktreeInfo>, String> {
-    let output = git_cmd()
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(repo_root)
-        .output()
+pub fn list_worktrees(repo_root: &str, wsl: Option<&WslConfig>) -> Result<Vec<WorktreeInfo>, String> {
+    let output = run_git(&["worktree", "list", "--porcelain"], repo_root, wsl)
         .map_err(|e| format!("Failed to run git worktree list: {}", e))?;
 
     if !output.status.success() {
@@ -200,16 +291,13 @@ pub fn list_worktrees(repo_root: &str) -> Result<Vec<WorktreeInfo>, String> {
 }
 
 /// Remove a single worktree by its path.
-pub fn remove_worktree(repo_root: &str, wt_path: &str, force: bool) -> Result<(), String> {
+pub fn remove_worktree(repo_root: &str, wt_path: &str, force: bool, wsl: Option<&WslConfig>) -> Result<(), String> {
     let mut args = vec!["worktree", "remove", wt_path];
     if force {
         args.push("--force");
     }
 
-    let output = git_cmd()
-        .args(&args)
-        .current_dir(repo_root)
-        .output()
+    let output = run_git(&args, repo_root, wsl)
         .map_err(|e| format!("Failed to run git worktree remove: {}", e))?;
 
     if !output.status.success() {
@@ -223,7 +311,7 @@ pub fn remove_worktree(repo_root: &str, wt_path: &str, force: bool) -> Result<()
 /// Remove all godly-managed worktrees with progress reporting.
 /// Calls `on_progress` at each stage: "listing", "removing", and "done".
 /// Returns the number of worktrees removed.
-pub fn cleanup_all_worktrees_with_progress<F>(repo_root: &str, on_progress: F) -> Result<u32, String>
+pub fn cleanup_all_worktrees_with_progress<F>(repo_root: &str, on_progress: F, wsl: Option<&WslConfig>) -> Result<u32, String>
 where
     F: Fn(&CleanupProgress),
 {
@@ -237,23 +325,33 @@ where
         worktree_name: String::new(),
     });
 
-    let worktrees = list_worktrees(repo_root)?;
-    let temp = std::env::temp_dir();
-    let godly_prefix = temp.join(WORKTREES_DIR);
-    let godly_prefix_str = godly_prefix.to_string_lossy().to_string();
+    let worktrees = list_worktrees(repo_root, wsl)?;
 
     // Filter to godly-managed worktrees
-    let managed: Vec<&WorktreeInfo> = worktrees
-        .iter()
-        .filter(|wt| {
-            if wt.is_main {
-                return false;
-            }
-            let normalized = wt.path.replace('/', "\\");
-            let normalized_prefix = godly_prefix_str.replace('/', "\\");
-            normalized.starts_with(&normalized_prefix) || wt.path.starts_with(&godly_prefix_str)
-        })
-        .collect();
+    let managed: Vec<&WorktreeInfo> = if wsl.is_some() {
+        // WSL: worktrees are in /tmp/godly-worktrees/
+        let godly_prefix = format!("/tmp/{}", WORKTREES_DIR);
+        worktrees
+            .iter()
+            .filter(|wt| !wt.is_main && wt.path.starts_with(&godly_prefix))
+            .collect()
+    } else {
+        // Windows: worktrees are in %TEMP%/godly-worktrees/
+        let temp = std::env::temp_dir();
+        let godly_prefix = temp.join(WORKTREES_DIR);
+        let godly_prefix_str = godly_prefix.to_string_lossy().to_string();
+        worktrees
+            .iter()
+            .filter(|wt| {
+                if wt.is_main {
+                    return false;
+                }
+                let normalized = wt.path.replace('/', "\\");
+                let normalized_prefix = godly_prefix_str.replace('/', "\\");
+                normalized.starts_with(&normalized_prefix) || wt.path.starts_with(&godly_prefix_str)
+            })
+            .collect()
+    };
 
     let total = managed.len() as u32;
     eprintln!("[worktree] cleanup_all: found {} godly-managed worktrees", total);
@@ -270,7 +368,7 @@ where
             worktree_name: name.clone(),
         });
 
-        match remove_worktree(repo_root, &wt.path, true) {
+        match remove_worktree(repo_root, &wt.path, true, wsl) {
             Ok(()) => removed += 1,
             Err(e) => eprintln!("[worktree] Warning: failed to remove {}: {}", wt.path, e),
         }
@@ -291,8 +389,8 @@ where
 
 /// Remove all godly-managed worktrees (those in the temp directory) for a repo.
 /// Returns the number of worktrees removed.
-pub fn cleanup_all_worktrees(repo_root: &str) -> Result<u32, String> {
-    cleanup_all_worktrees_with_progress(repo_root, |_| {})
+pub fn cleanup_all_worktrees(repo_root: &str, wsl: Option<&WslConfig>) -> Result<u32, String> {
+    cleanup_all_worktrees_with_progress(repo_root, |_| {}, wsl)
 }
 
 #[cfg(test)]
@@ -341,19 +439,19 @@ mod tests {
     #[test]
     fn test_is_git_repo_positive() {
         let repo = create_test_repo();
-        assert!(is_git_repo(repo.path().to_str().unwrap()));
+        assert!(is_git_repo(repo.path().to_str().unwrap(), None));
     }
 
     #[test]
     fn test_is_git_repo_negative() {
         let dir = tempfile::tempdir().expect("create temp dir");
-        assert!(!is_git_repo(dir.path().to_str().unwrap()));
+        assert!(!is_git_repo(dir.path().to_str().unwrap(), None));
     }
 
     #[test]
     fn test_get_repo_root() {
         let repo = create_test_repo();
-        let root = get_repo_root(repo.path().to_str().unwrap()).expect("get repo root");
+        let root = get_repo_root(repo.path().to_str().unwrap(), None).expect("get repo root");
         // Normalize for comparison (Windows paths may differ in case/slashes)
         let expected = repo.path().canonicalize().unwrap();
         let got = Path::new(&root).canonicalize().unwrap();
@@ -366,7 +464,7 @@ mod tests {
         let repo_root = repo.path().to_str().unwrap();
         let terminal_id = "abcdef-1234-5678";
 
-        let result = create_worktree(repo_root, terminal_id, None).expect("create worktree");
+        let result = create_worktree(repo_root, terminal_id, None, None).expect("create worktree");
         assert!(Path::new(&result.path).is_dir(), "worktree directory should exist");
         assert_eq!(result.branch, "wt-abcdef");
 
@@ -389,7 +487,7 @@ mod tests {
         let repo_root = repo.path().to_str().unwrap();
         let terminal_id = "abcdef-1234-5678";
 
-        let result = create_worktree(repo_root, terminal_id, Some("my-feature")).expect("create worktree with custom name");
+        let result = create_worktree(repo_root, terminal_id, Some("my-feature"), None).expect("create worktree with custom name");
         assert!(Path::new(&result.path).is_dir(), "worktree directory should exist");
         assert_eq!(result.branch, "wt-my-feature");
 
@@ -412,15 +510,15 @@ mod tests {
         let repo_root = repo.path().to_str().unwrap();
 
         // Initially just the main worktree
-        let worktrees = list_worktrees(repo_root).expect("list worktrees");
+        let worktrees = list_worktrees(repo_root, None).expect("list worktrees");
         assert_eq!(worktrees.len(), 1, "should have 1 worktree (main)");
         assert!(worktrees[0].is_main);
 
         // Create a worktree
         let terminal_id = "112233-aabb-ccdd";
-        let result = create_worktree(repo_root, terminal_id, None).expect("create worktree");
+        let result = create_worktree(repo_root, terminal_id, None, None).expect("create worktree");
 
-        let worktrees = list_worktrees(repo_root).expect("list worktrees after create");
+        let worktrees = list_worktrees(repo_root, None).expect("list worktrees after create");
         assert_eq!(worktrees.len(), 2, "should have 2 worktrees");
 
         // Cleanup
@@ -433,17 +531,17 @@ mod tests {
         let repo_root = repo.path().to_str().unwrap();
         let terminal_id = "aabbcc-1111-2222";
 
-        let result = create_worktree(repo_root, terminal_id, None).expect("create worktree");
+        let result = create_worktree(repo_root, terminal_id, None, None).expect("create worktree");
         assert!(Path::new(&result.path).is_dir());
 
-        remove_worktree(repo_root, &result.path, false).expect("remove worktree");
+        remove_worktree(repo_root, &result.path, false, None).expect("remove worktree");
         assert!(!Path::new(&result.path).is_dir(), "worktree should be removed");
     }
 
     #[test]
     fn test_create_worktree_non_git_fails() {
         let dir = tempfile::tempdir().expect("create temp dir");
-        let result = create_worktree(dir.path().to_str().unwrap(), "test-id", None);
+        let result = create_worktree(dir.path().to_str().unwrap(), "test-id", None, None);
         assert!(result.is_err(), "should fail on non-git dir");
     }
 
@@ -458,17 +556,21 @@ mod tests {
     #[test]
     fn test_worktree_path_formula() {
         let path = worktree_path("C:\\repo", "abcdef-1234", None);
-        let path_str = path.to_string_lossy().to_string();
-        assert!(path_str.contains(WORKTREES_DIR));
-        assert!(path_str.contains("wt-abcdef"));
+        let expected = std::env::temp_dir()
+            .join(WORKTREES_DIR)
+            .join(short_hash("C:\\repo"))
+            .join("wt-abcdef");
+        assert_eq!(path, expected);
     }
 
     #[test]
     fn test_worktree_path_custom_name() {
         let path = worktree_path("C:\\repo", "abcdef-1234", Some("my-feature"));
-        let path_str = path.to_string_lossy().to_string();
-        assert!(path_str.contains(WORKTREES_DIR));
-        assert!(path_str.contains("wt-my-feature"));
+        let expected = std::env::temp_dir()
+            .join(WORKTREES_DIR)
+            .join(short_hash("C:\\repo"))
+            .join("wt-my-feature");
+        assert_eq!(path, expected);
     }
 
     #[test]
@@ -478,10 +580,10 @@ mod tests {
         let repo = create_test_repo();
         let repo_root = repo.path().to_str().unwrap();
 
-        // Create 2 worktrees
-        let wt1 = create_worktree(repo_root, "progress-test-1111", None)
+        // Create 2 worktrees (IDs must have different first-6-char prefixes)
+        let wt1 = create_worktree(repo_root, "aaaaaa-prog-test-1", None, None)
             .expect("create worktree 1");
-        let wt2 = create_worktree(repo_root, "progress-test-2222", None)
+        let wt2 = create_worktree(repo_root, "bbbbbb-prog-test-2", None, None)
             .expect("create worktree 2");
 
         assert!(Path::new(&wt1.path).is_dir());
@@ -493,7 +595,7 @@ mod tests {
 
         let removed = cleanup_all_worktrees_with_progress(repo_root, move |progress| {
             events_clone.lock().unwrap().push(progress.clone());
-        })
+        }, None)
         .expect("cleanup should succeed");
 
         assert_eq!(removed, 2, "should have removed 2 worktrees");
@@ -526,5 +628,81 @@ mod tests {
         assert_eq!(collected[3].step, "done");
         assert_eq!(collected[3].current, 2); // current = removed count
         assert_eq!(collected[3].total, 2);
+    }
+
+    // --- WslConfig auto-detection tests ---
+
+    #[test]
+    fn test_wsl_config_from_wsl_localhost_path() {
+        let config = WslConfig::from_path("\\\\wsl.localhost\\Ubuntu\\home\\user\\project");
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().distribution.as_deref(), Some("Ubuntu"));
+    }
+
+    #[test]
+    fn test_wsl_config_from_wsl_dollar_path() {
+        let config = WslConfig::from_path("\\\\wsl$\\Debian\\home\\user\\project");
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().distribution.as_deref(), Some("Debian"));
+    }
+
+    #[test]
+    fn test_wsl_config_from_windows_path() {
+        let config = WslConfig::from_path("C:\\Users\\user\\project");
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_wsl_config_from_linux_path() {
+        let config = WslConfig::from_path("/home/user/project");
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_worktree_path_wsl() {
+        let path = worktree_path_wsl("/home/user/project", "abcdef-1234", None);
+        let expected = format!("/tmp/{}/{}/wt-abcdef", WORKTREES_DIR, short_hash("/home/user/project"));
+        assert_eq!(path, expected);
+    }
+
+    #[test]
+    fn test_worktree_path_wsl_custom_name() {
+        let path = worktree_path_wsl("/home/user/project", "abcdef-1234", Some("my-feature"));
+        let expected = format!("/tmp/{}/{}/wt-my-feature", WORKTREES_DIR, short_hash("/home/user/project"));
+        assert_eq!(path, expected);
+    }
+
+    #[test]
+    fn test_worktree_path_wsl_different_repos_different_paths() {
+        let path_a = worktree_path_wsl("/home/user/repo-a", "abcdef-1234", None);
+        let path_b = worktree_path_wsl("/home/user/repo-b", "abcdef-1234", None);
+        assert_ne!(path_a, path_b, "different repos must produce different worktree paths");
+    }
+
+    #[test]
+    fn test_wsl_config_from_forward_slash_unc() {
+        // Pre-normalized UNC paths with forward slashes
+        let config = WslConfig::from_path("//wsl.localhost/Ubuntu/home/user/project");
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().distribution.as_deref(), Some("Ubuntu"));
+
+        let config = WslConfig::from_path("//wsl$/Debian/home/user/project");
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().distribution.as_deref(), Some("Debian"));
+    }
+
+    #[test]
+    fn test_wsl_config_from_distro_only_path() {
+        // UNC path pointing to just the distro root (no trailing path)
+        let config = WslConfig::from_path("\\\\wsl.localhost\\Ubuntu");
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().distribution.as_deref(), Some("Ubuntu"));
+    }
+
+    #[test]
+    fn test_wt_name_from_empty_custom_name_falls_through() {
+        // Empty custom name should fall back to terminal ID prefix
+        let name = wt_name_from(Some(""), "abcdef-1234");
+        assert_eq!(name, "wt-abcdef");
     }
 }


### PR DESCRIPTION
## Summary

- Worktree toggle button ("WT") silently failed on WSL workspaces because `is_git_repo()` ran Windows `git` against WSL UNC paths, which always returned false
- Added `WslConfig` auto-detection from UNC paths (`\wsl.localhost\...` / `\wsl$\...`) and a `run_git()` helper that routes all git commands through `wsl.exe --cd` when WSL is detected
- All worktree operations (is_git_repo, get_repo_root, create/list/remove/cleanup) now work for both Windows and WSL workspaces
- WSL worktrees are placed in `/tmp/godly-worktrees/` inside the WSL distribution instead of Windows `%TEMP%`
- Fixed pre-existing test bug where `cleanup_all` test used two terminal IDs with identical 6-char prefixes causing branch name collision

## Test plan

- [x] All 79 Rust lib tests pass (including 26 worktree tests with new WSL unit tests)
- [x] All 131 TypeScript tests pass
- [x] Production build succeeds
- [ ] Manual: create WSL workspace pointing to a git repo, click WT toggle → should activate
- [ ] Manual: create new terminal in WSL worktree mode → should spawn in `/tmp/godly-worktrees/...`
- [ ] Manual: verify worktree panel lists WSL worktrees and "Clean All" removes them