### PR TITLE
feat: add 'Open in Explorer' to workspace context menu

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "store:default",
     "dialog:default",
     "opener:default",
+    "opener:allow-open-path",
     "notification:default"
   ]
 }

--- a/src/components/WorkspaceSidebar.ts
+++ b/src/components/WorkspaceSidebar.ts
@@ -2,6 +2,7 @@ import { store, Workspace, ShellType } from '../state/store';
 import { workspaceService } from '../services/workspace-service';
 import { notificationStore } from '../state/notification-store';
 import { open } from '@tauri-apps/plugin-dialog';
+import { openPath } from '@tauri-apps/plugin-opener';
 import { WorktreePanel } from './WorktreePanel';
 import { invoke } from '@tauri-apps/api/core';
 
@@ -394,6 +395,15 @@ export class WorkspaceSidebar {
       this.showRenameDialog(workspace);
     };
     menu.appendChild(renameItem);
+
+    const openFolderItem = document.createElement('div');
+    openFolderItem.className = 'context-menu-item';
+    openFolderItem.textContent = 'Open in Explorer';
+    openFolderItem.onclick = () => {
+      menu.remove();
+      openPath(workspace.folderPath);
+    };
+    menu.appendChild(openFolderItem);
 
     // Worktree mode toggle (only for git repos)
     const worktreeItem = document.createElement('div');


### PR DESCRIPTION
## Summary
- Adds an "Open in Explorer" option to the workspace right-click context menu
- Uses the Tauri opener plugin (`openPath`) to open the workspace folder in Windows Explorer
- Adds `opener:allow-open-path` permission to Tauri capabilities

## Test plan
- [ ] Right-click a workspace in the sidebar
- [ ] Click "Open in Explorer"
- [ ] Verify the workspace folder opens in Windows Explorer