### PR TITLE
feat: add worktree_name parameter to create_terminal MCP tool

### DIFF
--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -12,7 +12,7 @@ use log::mcp_log;
 use pipe_client::McpPipeClient;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 6;
+const BUILD: u32 = 7;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -20,6 +20,8 @@ pub enum McpRequest {
         shell_type: Option<ShellType>,
         #[serde(default)]
         cwd: Option<String>,
+        #[serde(default)]
+        worktree_name: Option<String>,
     },
     CloseTerminal { terminal_id: String },
     RenameTerminal { terminal_id: String, name: String },
@@ -85,6 +87,12 @@ pub enum McpResponse {
     TerminalList { terminals: Vec<McpTerminalInfo> },
     TerminalInfo { terminal: McpTerminalInfo },
     WorkspaceList { workspaces: Vec<McpWorkspaceInfo> },
-    Created { id: String },
+    Created {
+        id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worktree_path: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worktree_branch: Option<String>,
+    },
     NotificationStatus { enabled: bool, source: String },
 }


### PR DESCRIPTION
## Summary

- Adds `worktree_name` parameter to the `create_terminal` MCP tool, enabling Claude to spin up terminals with their own git worktrees directly via MCP
- Validates mutual exclusivity with `cwd`, checks that the workspace is a git repo, and returns hard errors on failure
- Returns `worktree_path` and `worktree_branch` in the `Created` response so downstream consumers know where the worktree lives

## Changes

- **`protocol/src/mcp_messages.rs`** — Added `worktree_name` field to `McpRequest::CreateTerminal`; added `worktree_path`/`worktree_branch` to `McpResponse::Created`
- **`src/mcp_server/handler.rs`** — Worktree creation logic with validation (mutual exclusivity, git repo check, repo root resolution), stores worktree metadata in session state
- **`mcp/src/tools.rs`** — Updated tool schema with `worktree_name` property, dispatch, and response JSON serialization
- **`mcp/src/main.rs`** — Bumped BUILD 6 → 7

## Test plan

- [ ] Create a terminal via MCP with `worktree_name` set — verify worktree is created and response includes `worktree_path` and `worktree_branch`
- [ ] Create a terminal with both `cwd` and `worktree_name` — verify it returns an error
- [ ] Create a terminal with `worktree_name` on a non-git workspace — verify it returns an error
- [ ] Create a terminal with only `cwd` — verify existing behavior is unchanged
- [ ] Create a terminal with neither `cwd` nor `worktree_name` — verify it defaults to workspace folder