### PR TITLE
feat: add test instance isolation via GODLY_INSTANCE env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run build:daemon && npm run build:mcp && vite",
+    "dev:test": "cross-env GODLY_INSTANCE=test npx tauri dev --config src-tauri/tauri.conf.test.json",
     "build": "tsc && vite build",
     "build:daemon": "cd src-tauri && cargo build -p godly-daemon",
     "build:daemon:release": "cd src-tauri && cargo build -p godly-daemon --release",

--- a/src-tauri/daemon/src/main.rs
+++ b/src-tauri/daemon/src/main.rs
@@ -14,6 +14,16 @@ async fn main() {
     #[cfg(feature = "leak-check")]
     let _profiler = dhat::Profiler::new_heap();
 
+    // Parse --instance arg (must happen before any protocol calls).
+    // WMI-launched processes don't inherit env vars, so CLI args are the
+    // only reliable way to pass the instance name through that path.
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(pos) = args.iter().position(|a| a == "--instance") {
+        if let Some(name) = args.get(pos + 1) {
+            unsafe { std::env::set_var("GODLY_INSTANCE", name) };
+        }
+    }
+
     eprintln!("[daemon] Godly Terminal daemon starting (pid: {})", std::process::id());
 
     // Check if another instance is already running

--- a/src-tauri/daemon/src/pid.rs
+++ b/src-tauri/daemon/src/pid.rs
@@ -2,10 +2,13 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-/// Get the PID file path at %APPDATA%/com.godly.terminal/godly-daemon.pid
+/// Get the PID file path at %APPDATA%/com.godly.terminal[suffix]/godly-daemon.pid
+/// When GODLY_INSTANCE is set (e.g. "test"), the directory becomes
+/// "com.godly.terminal-test" so test and production daemons don't collide.
 pub fn pid_file_path() -> PathBuf {
     let app_data = std::env::var("APPDATA").unwrap_or_else(|_| ".".to_string());
-    let dir = PathBuf::from(app_data).join("com.godly.terminal");
+    let dir_name = format!("com.godly.terminal{}", godly_protocol::instance_suffix());
+    let dir = PathBuf::from(app_data).join(dir_name);
     fs::create_dir_all(&dir).ok();
     dir.join("godly-daemon.pid")
 }

--- a/src-tauri/protocol/src/lib.rs
+++ b/src-tauri/protocol/src/lib.rs
@@ -14,13 +14,152 @@ pub const PIPE_NAME: &str = r"\\.\pipe\godly-terminal-daemon";
 /// Named pipe path for MCP communication (Tauri app <-> godly-mcp binary)
 pub const MCP_PIPE_NAME: &str = r"\\.\pipe\godly-terminal-mcp";
 
+/// Get a suffix derived from the GODLY_INSTANCE env var (e.g. "-test").
+/// Returns empty string when unset, so production paths are unchanged.
+pub fn instance_suffix() -> String {
+    std::env::var("GODLY_INSTANCE")
+        .ok()
+        .filter(|name| !name.is_empty())
+        .map(|name| format!("-{}", name))
+        .unwrap_or_default()
+}
+
 /// Get the daemon pipe name, allowing override via GODLY_PIPE_NAME env var.
-/// Used by tests to run isolated daemon instances on different pipes.
+/// Falls back to the default pipe name with an optional instance suffix.
 pub fn pipe_name() -> String {
-    std::env::var("GODLY_PIPE_NAME").unwrap_or_else(|_| PIPE_NAME.to_string())
+    std::env::var("GODLY_PIPE_NAME")
+        .unwrap_or_else(|_| format!(r"\\.\pipe\godly-terminal-daemon{}", instance_suffix()))
 }
 
 /// Get the MCP pipe name, allowing override via GODLY_MCP_PIPE_NAME env var.
+/// Falls back to the default MCP pipe name with an optional instance suffix.
 pub fn mcp_pipe_name() -> String {
-    std::env::var("GODLY_MCP_PIPE_NAME").unwrap_or_else(|_| MCP_PIPE_NAME.to_string())
+    std::env::var("GODLY_MCP_PIPE_NAME")
+        .unwrap_or_else(|_| format!(r"\\.\pipe\godly-terminal-mcp{}", instance_suffix()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run a check in a child process with isolated env vars.
+    /// Uses a temp file to pass the result back (stdout is polluted by the
+    /// test harness in the subprocess).
+    fn run_in_subprocess(env_vars: &[(&str, &str)], check: &str) -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let result_file = std::env::temp_dir().join(format!(
+            "godly-protocol-test-{}-{}-{}.txt",
+            check,
+            std::process::id(),
+            id
+        ));
+        let mut cmd = std::process::Command::new(std::env::current_exe().unwrap());
+        cmd.arg("--ignored")
+            .arg("--exact")
+            .arg("tests::subprocess_harness");
+        cmd.env("__SUBPROCESS_CHECK", check);
+        cmd.env("__SUBPROCESS_RESULT_FILE", &result_file);
+        // Clear instance-related vars so the subprocess starts clean
+        cmd.env_remove("GODLY_INSTANCE");
+        cmd.env_remove("GODLY_PIPE_NAME");
+        cmd.env_remove("GODLY_MCP_PIPE_NAME");
+        for (k, v) in env_vars {
+            cmd.env(k, v);
+        }
+        let output = cmd.output().expect("failed to run subprocess");
+        assert!(
+            output.status.success(),
+            "subprocess failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let result = std::fs::read_to_string(&result_file)
+            .unwrap_or_else(|e| panic!("failed to read result file {:?}: {}", result_file, e));
+        let _ = std::fs::remove_file(&result_file);
+        result
+    }
+
+    /// Internal harness — run via subprocess only, ignored by normal test runner.
+    #[test]
+    #[ignore]
+    fn subprocess_harness() {
+        let check = std::env::var("__SUBPROCESS_CHECK").unwrap_or_default();
+        let result_file = std::env::var("__SUBPROCESS_RESULT_FILE").unwrap();
+        let result = match check.as_str() {
+            "instance_suffix" => instance_suffix(),
+            "pipe_name" => pipe_name(),
+            "mcp_pipe_name" => mcp_pipe_name(),
+            _ => panic!("unknown check: {}", check),
+        };
+        std::fs::write(result_file, &result).expect("failed to write result file");
+    }
+
+    #[test]
+    fn instance_suffix_empty_when_unset() {
+        let result = run_in_subprocess(&[], "instance_suffix");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn instance_suffix_empty_string_treated_as_unset() {
+        // Empty GODLY_INSTANCE should behave like unset, not produce a lone "-"
+        let result = run_in_subprocess(&[("GODLY_INSTANCE", "")], "instance_suffix");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn instance_suffix_returns_dash_prefixed_name() {
+        let result = run_in_subprocess(&[("GODLY_INSTANCE", "test")], "instance_suffix");
+        assert_eq!(result, "-test");
+    }
+
+    #[test]
+    fn pipe_name_default_without_instance() {
+        let result = run_in_subprocess(&[], "pipe_name");
+        assert_eq!(result, r"\\.\pipe\godly-terminal-daemon");
+    }
+
+    #[test]
+    fn pipe_name_with_instance_suffix() {
+        let result = run_in_subprocess(&[("GODLY_INSTANCE", "test")], "pipe_name");
+        assert_eq!(result, r"\\.\pipe\godly-terminal-daemon-test");
+    }
+
+    #[test]
+    fn pipe_name_explicit_override_takes_precedence() {
+        // GODLY_PIPE_NAME should override even when GODLY_INSTANCE is set
+        let result = run_in_subprocess(
+            &[
+                ("GODLY_INSTANCE", "test"),
+                ("GODLY_PIPE_NAME", r"\\.\pipe\custom"),
+            ],
+            "pipe_name",
+        );
+        assert_eq!(result, r"\\.\pipe\custom");
+    }
+
+    #[test]
+    fn mcp_pipe_name_default_without_instance() {
+        let result = run_in_subprocess(&[], "mcp_pipe_name");
+        assert_eq!(result, r"\\.\pipe\godly-terminal-mcp");
+    }
+
+    #[test]
+    fn mcp_pipe_name_with_instance_suffix() {
+        let result = run_in_subprocess(&[("GODLY_INSTANCE", "test")], "mcp_pipe_name");
+        assert_eq!(result, r"\\.\pipe\godly-terminal-mcp-test");
+    }
+
+    #[test]
+    fn mcp_pipe_name_explicit_override_takes_precedence() {
+        let result = run_in_subprocess(
+            &[
+                ("GODLY_INSTANCE", "test"),
+                ("GODLY_MCP_PIPE_NAME", r"\\.\pipe\custom-mcp"),
+            ],
+            "mcp_pipe_name",
+        );
+        assert_eq!(result, r"\\.\pipe\custom-mcp");
+    }
 }

--- a/src-tauri/tauri.conf.test.json
+++ b/src-tauri/tauri.conf.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schema.tauri.app/config/2.0.0",
+  "productName": "Godly Terminal (TEST)",
+  "identifier": "com.godly.terminal.test",
+  "build": {
+    "beforeDevCommand": "vite --port 1421",
+    "devUrl": "http://localhost:1421"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Godly Terminal (TEST)"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce `GODLY_INSTANCE` env var that suffixes all shared resources (named pipes, PID files, app data directories) so a test build can run alongside production without collisions
- Daemon accepts `--instance <name>` CLI arg to propagate the instance name through WMI process creation (which does not inherit env vars)
- Add `tauri.conf.test.json` overlay with separate app identifier (`com.godly.terminal.test`), dev port 1421, and "(TEST)" window title
- Add `dev:test` npm script for launching the test instance

## Changed files

| File | Change |
|------|--------|
| `src-tauri/protocol/src/lib.rs` | `instance_suffix()` function; `pipe_name()`/`mcp_pipe_name()` use it as fallback; 9 subprocess-isolated tests |
| `src-tauri/daemon/src/main.rs` | Parse `--instance` CLI arg, set `GODLY_INSTANCE` env var before any protocol calls |
| `src-tauri/daemon/src/pid.rs` | Instance-aware PID file directory via `instance_suffix()` |
| `src-tauri/src/daemon_client/client.rs` | Forward `--instance` in both direct spawn and WMI launch paths |
| `src-tauri/tauri.conf.test.json` | New Tauri config overlay for test builds |
| `package.json` | `dev:test` script |

## Test plan

- [ ] Run `cargo test -p godly-protocol` — all 9 new tests should pass
- [ ] Run `npm run dev` — production instance starts normally (no suffix)
- [ ] Run `npm run dev:test` — test instance starts with "(TEST)" title, uses separate pipe and PID file
- [ ] Run both simultaneously — they should not interfere with each other