### PR TITLE
feat: add worktree and command flags to MCP create_terminal

### DIFF
--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -12,7 +12,7 @@ use log::mcp_log;
 use pipe_client::McpPipeClient;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 7;
+const BUILD: u32 = 8;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -43,6 +43,14 @@ pub fn list_tools() -> Value {
                         "worktree_name": {
                             "type": "string",
                             "description": "Create a git worktree with this name and use it as the terminal's working directory. The workspace must be a git repo. Mutually exclusive with cwd."
+                        },
+                        "worktree": {
+                            "type": "boolean",
+                            "description": "Create a git worktree with an auto-generated name. The workspace must be a git repo. Mutually exclusive with cwd. Can be combined with worktree_name for a custom name."
+                        },
+                        "command": {
+                            "type": "string",
+                            "description": "A command to run in the terminal immediately after creation. A newline (Enter) is appended automatically."
                         }
                     },
                     "required": ["workspace_id"]
@@ -259,11 +267,15 @@ pub fn call_tool(
                 .get("worktree_name")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let worktree = args.get("worktree").and_then(|v| v.as_bool());
+            let command = args.get("command").and_then(|v| v.as_str()).map(String::from);
             McpRequest::CreateTerminal {
                 workspace_id,
                 shell_type: None,
                 cwd,
                 worktree_name,
+                worktree,
+                command,
             }
         }
 

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -22,6 +22,10 @@ pub enum McpRequest {
         cwd: Option<String>,
         #[serde(default)]
         worktree_name: Option<String>,
+        #[serde(default)]
+        worktree: Option<bool>,
+        #[serde(default)]
+        command: Option<String>,
     },
     CloseTerminal { terminal_id: String },
     RenameTerminal { terminal_id: String, name: String },


### PR DESCRIPTION
## Summary

- Add `worktree` (boolean) parameter to `create_terminal` MCP tool for auto-generating worktree names without requiring a custom name
- Add `command` (string) parameter to run a command in the terminal immediately after creation (e.g., `dclaude`)
- Bump MCP build constant to 8

## Test plan

- [x] `cargo check --workspace` passes (protocol, mcp, daemon crates)
- [x] `cargo test -p godly-protocol -p godly-daemon -p godly-mcp` passes (9 tests)
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (163 tests)
- [x] `npm run build` passes
- [ ] Manual: call `create_terminal` with `worktree: true` to verify auto-generated worktree
- [ ] Manual: call `create_terminal` with `command: "dclaude"` to verify command execution
- [ ] Manual: call with both `worktree: true` and `command: "dclaude"` combined