### PR TITLE
fix: prevent terminal freeze from pipe deadlock and priority inversion

### DIFF
--- a/src-tauri/daemon/src/debug_log.rs
+++ b/src-tauri/daemon/src/debug_log.rs
@@ -1,0 +1,82 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+static LOG_FILE: OnceLock<Mutex<File>> = OnceLock::new();
+static START_TIME: OnceLock<Instant> = OnceLock::new();
+
+/// Initialize the daemon debug logger.
+/// Logs to `godly-daemon-debug.log` in %APPDATA%/com.godly.terminal[suffix]/,
+/// falling back to the system temp directory.
+pub fn init() {
+    START_TIME.get_or_init(Instant::now);
+
+    let app_data = std::env::var("APPDATA").unwrap_or_else(|_| ".".to_string());
+    let dir_name = format!(
+        "com.godly.terminal{}",
+        godly_protocol::instance_suffix()
+    );
+    let dir = std::path::PathBuf::from(app_data).join(dir_name);
+    std::fs::create_dir_all(&dir).ok();
+
+    let path = dir.join("godly-daemon-debug.log");
+
+    // Truncate to avoid unbounded growth (keep last run only)
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path);
+
+    match file {
+        Ok(f) => {
+            LOG_FILE.get_or_init(|| Mutex::new(f));
+        }
+        Err(e) => {
+            let fallback = std::env::temp_dir().join("godly-daemon-debug.log");
+            if let Ok(f) = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&fallback)
+            {
+                LOG_FILE.get_or_init(|| Mutex::new(f));
+            } else {
+                eprintln!("[daemon] Failed to open debug log: {}", e);
+            }
+        }
+    }
+}
+
+/// Write a log line with timestamp (wall clock + monotonic elapsed).
+pub fn log(msg: &str) {
+    if let Some(mutex) = LOG_FILE.get() {
+        if let Ok(mut file) = mutex.lock() {
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default();
+            let elapsed = START_TIME
+                .get()
+                .map(|s| s.elapsed())
+                .unwrap_or_default();
+            let _ = writeln!(
+                file,
+                "[{}.{:03}] [{:>8.3}s] {}",
+                ts.as_secs(),
+                ts.subsec_millis(),
+                elapsed.as_secs_f64(),
+                msg
+            );
+            let _ = file.flush();
+        }
+    }
+}
+
+macro_rules! daemon_log {
+    ($($arg:tt)*) => {
+        crate::debug_log::log(&format!($($arg)*))
+    };
+}
+
+pub(crate) use daemon_log;

--- a/src-tauri/daemon/src/main.rs
+++ b/src-tauri/daemon/src/main.rs
@@ -1,3 +1,4 @@
+mod debug_log;
 mod pid;
 mod server;
 mod session;
@@ -24,6 +25,8 @@ async fn main() {
         }
     }
 
+    debug_log::init();
+    debug_log::daemon_log!("=== Daemon starting === pid={}", std::process::id());
     eprintln!("[daemon] Godly Terminal daemon starting (pid: {})", std::process::id());
 
     // Check if another instance is already running


### PR DESCRIPTION
## Summary

- **Increased pipe buffer from 4KB to 256KB** — a single JSON-serialized output event easily exceeds 4KB, causing `write_all()` to block on Windows named pipes. While blocked, the daemon I/O thread cannot read incoming requests, freezing ALL terminals sharing the connection.
- **Fixed daemon I/O write starvation** — limited outgoing writes to 8 per iteration before checking for incoming client requests. Previously the daemon wrote all queued messages before reading, starving user input under heavy output.
- **Fixed bridge priority inversion** — limited event reads to 8 per iteration before checking for pending outgoing requests. Previously the bridge always prioritized reading events over writing requests, starving input writes during high-throughput output.
- **Added file-based debug logging** — daemon and bridge now write timestamped debug logs to `%APPDATA%/com.godly.terminal/` (`godly-daemon-debug.log`, `godly-bridge-debug.log`) with slow operation detection and periodic stats for diagnosing future freezes.

## Test plan

- [ ] Open multiple terminals, run a high-output command (`find / -name "*.rs"` or a large build) in one terminal while typing in another — the other terminal should remain responsive
- [ ] Verify debug logs are created in `%APPDATA%/com.godly.terminal/` after running
- [ ] Check that SLOW WRITE / SLOW EMIT entries appear in logs during heavy output (confirming the logging works)
- [ ] Run `cargo test -p godly-daemon -p godly-protocol` — all unit tests pass
- [ ] Run `npm test` — all 163 TypeScript tests pass
- [ ] Run `npm run build` — production build succeeds