### PR TITLE
fix: non-blocking emit channel prevents terminal freeze

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,8 +105,11 @@ pub fn run() {
             // reconnection + session re-attachment before the user notices.
             DaemonClient::start_keepalive(daemon_client.clone());
 
+            // Get the non-blocking event emitter for the process monitor
+            let emitter = daemon_client.event_emitter();
+
             // Start process monitor (queries daemon for PIDs, resolves process names locally)
-            process_monitor.start(app_handle.clone(), state_clone.clone(), daemon_client.clone());
+            process_monitor.start(app_handle.clone(), emitter, state_clone.clone(), daemon_client.clone());
 
             // Start auto-save manager
             auto_save.start(app_handle.clone(), state_clone.clone());


### PR DESCRIPTION
## Summary

- **Root cause**: Tauri's `app_handle.emit()` is synchronous. When the main thread stalls, any thread calling `emit()` blocks — including the bridge I/O thread AND the ProcessMonitor. The keepalive's `ping()` also blocks because it routes through the same bridge. All threads freeze simultaneously.
- **Fix**: Route all hot-path `emit()` calls through a bounded non-blocking channel (`EventEmitter`) with a dedicated "tauri-emitter" thread. The bridge I/O thread enqueues via `try_send()` (sub-microsecond) instead of blocking on `emit()`.
- **Keepalive diagnostics**: Watchdog check now runs BEFORE ping (fires even when ping blocks), with `eprintln!` at every step including iteration counter, bridge phase, stall duration, and ping timing.

## Changes

| File | What |
|------|------|
| `bridge.rs` | Add `EmitPayload` enum, `EventEmitter` struct (spawn + try_send + dropped_count). Bridge I/O loop uses `try_send()` instead of direct `emit()`. Stats track dropped events. |
| `client.rs` | Add `event_emitter` field + accessor. Create emitter in `setup_bridge()`, clear in `reconnect()`. Buffer replay routes through emitter. Rewrite `start_keepalive()` with watchdog-before-ping + diagnostics. |
| `process_monitor.rs` | Accept `Option<EventEmitter>`, route `process-changed` through it with direct-emit fallback. |
| `lib.rs` | Pass emitter from `daemon_client.event_emitter()` to `process_monitor.start()`. |

## Test plan

- [x] `cargo check -p godly-terminal` — compiles clean
- [x] `cargo test -p godly-protocol` — 12 passed
- [x] `cargo test -p godly-daemon` — 9 unit tests passed (integration tests are pre-existing flaky)
- [x] `cargo test -p godly-terminal` — 86 passed, 2 ignored
- [x] `npm test` — 156 passed
- [x] `npm run build` — production build succeeds