### PR TITLE
fix: use blocking_send instead of ring buffer fallback for attached clients (A1)

### DIFF
--- a/docs/terminal-freeze-investigation.md
+++ b/docs/terminal-freeze-investigation.md
@@ -320,3 +320,284 @@ bridge I/O thread → EventEmitter → Tauri emit (was synchronous, now async)
 ```
 
 Each layer had its own bottleneck. Fixing one revealed the next. Attempt 12 attacks the source — preventing unbounded event accumulation via backpressure, reducing event frequency via larger reads, and adding crash diagnostics for silent daemon deaths. All known layers have now been addressed through 12 fix attempts.
+
+---
+
+# Potential Remaining Causes
+
+Deep-dive analysis from 5 independent perspectives (PTY/reader thread, IPC pipeline, frontend rendering, daemon lifecycle, concurrency). Findings below are NEW issues not addressed by Attempts 1–12, organized by category and severity.
+
+---
+
+## Category A: Data Flow & Output Loss
+
+### A1. Ring buffer fallback data never replayed to attached client
+**Severity**: HIGH
+**File**: `daemon/src/session.rs:175-179`
+
+When the per-session output channel is full (`TrySendError::Full`), data is written to the ring buffer as a fallback. However, this data is **never replayed to the still-attached client**. The ring buffer is only drained during `attach()` (line 269-278). If the channel fills transiently during heavy output and then drains, the data stored during the backpressure window is stranded — the client never receives it.
+
+**Freeze mechanism**: Missing output in the terminal. In the worst case, a VT sequence like `\x1b[?25l` (hide cursor) gets sent via the channel but the matching `\x1b[?25h` (show cursor) goes to the ring buffer instead. The terminal appears frozen with no visible cursor. This was *introduced* by Attempt 12's backpressure mechanism — the ring buffer fallback was designed for detached sessions but is now also used during transient channel fullness while the client is attached.
+
+### A2. No SessionClosed event when PTY process exits
+**Severity**: HIGH
+**Files**: `daemon/src/session.rs:146-148`, `daemon/src/server.rs:924-940`
+
+When the reader thread detects EOF (`Ok(0)`) or a read error, it logs the event and exits. It does **not** set `running` to false, does not emit a `SessionClosed` event, and does not notify the attached client. The session stays in the `sessions` HashMap forever. The `SessionClosed` event is only sent on explicit `CloseSession` request — there is no mechanism for the daemon to proactively notify the client that a session's PTY has exited.
+
+**Freeze mechanism**: If a shell process exits (user types `exit`, process crashes), the terminal tab remains open with no indication the process is dead. The user can type but nothing happens. This looks exactly like a freeze. Dead sessions also accumulate forwarding tasks (tokio) that never complete, since the `rx` channel stays open.
+
+### A3. Race between attach() and reader thread — data gap
+**Severity**: MEDIUM
+**File**: `daemon/src/session.rs:265-293` vs `session.rs:155-202`
+
+`attach()` drains the ring buffer (line 269), then sets `output_tx` (line 281-288), then sets `is_attached_flag` (line 291). Between draining the ring buffer and setting the channel, the reader thread can push data into the ring buffer (seeing `output_tx` is `None`). That data is never delivered. Under heavy output the window is large enough for multiple chunks to be lost.
+
+**Freeze mechanism**: Data ordering gap after reattach — client gets old ring buffer, misses some data, then gets the live stream. Garbled terminal state.
+
+### A4. Reader thread TOCTOU — attach() sender overwritten by stale cleanup
+**Severity**: MEDIUM
+**File**: `daemon/src/session.rs:189-191`
+
+In the `TrySendError::Closed` branch, the reader thread: (1) drops `tx_guard` (releases lock), (2) sets `reader_attached = false`, (3) re-locks `output_tx` to set it to `None`. Between steps 1 and 3, `attach()` can run and install a new sender. The reader thread then overwrites it with `None`, losing the new attachment.
+
+**Freeze mechanism**: Client thinks it's attached, but output stops flowing. Terminal appears frozen.
+
+---
+
+## Category B: IPC Pipeline & Serialization
+
+### B1. JSON 4x serialization amplification on Vec<u8>
+**Severity**: MEDIUM-HIGH
+**File**: `protocol/src/messages.rs:59`, `protocol/src/frame.rs:8`
+
+Output events carry `data: Vec<u8>`. The frame protocol uses `serde_json::to_vec()`. JSON encoding of `Vec<u8>` serializes as a **JSON array of numbers**: `[27, 91, 51, 50, 109, ...]`. A 64KB read yields ~262KB of JSON — a **4x amplification** on the hot path.
+
+**Freeze mechanism**: The 256KB pipe buffer effectively holds only ~64KB of actual terminal data. Under heavy output, the pipe fills 4x faster than expected, causing daemon `write_message` to block, stalling the I/O thread and all request processing. This is likely a significant contributor to the "SLOW WRITE" stalls observed in daemon logs (Attempt 12 saw 2.4s stalls).
+
+**Fix**: Add `#[serde(with = "serde_bytes")]` on `Vec<u8>` fields (serializes as base64 or byte string) or switch to bincode/MessagePack.
+
+### B2. Bidirectional pipe buffer deadlock potential
+**Severity**: MEDIUM
+**File**: `daemon_client/bridge.rs:279-284`
+
+Reader and writer are DuplicateHandle'd from the same file object. On Windows, synchronous named pipes serialize I/O per file object. If `write_message` blocks (pipe buffer full), `PeekNamedPipe` on the reader handle is serialized behind it. The bridge cannot read responses while a write is blocked, and the daemon may be trying to send a response but its own buffer is full too.
+
+**Freeze mechanism**: Full bidirectional deadlock — neither side can make progress. The 256KB buffers make this rare, but the 4x JSON amplification (B1) reduces effective buffer to ~64KB, making it more likely under sustained heavy output.
+
+### B3. DuplicateHandle File drop race
+**Severity**: MEDIUM
+**File**: `daemon_client/client.rs:142-172`
+
+Both `File` objects (reader/writer) own independent handles to the same pipe via `DuplicateHandle`. During reconnection teardown, if one `File` is dropped while the other is still being read in the I/O thread, the read could hang on an invalid handle rather than returning an error.
+
+**Freeze mechanism**: Bridge I/O thread hangs on invalid handle during reconnection.
+
+### B4. Partial frame read blocks on broken pipe
+**Severity**: MEDIUM
+**File**: `protocol/src/frame.rs:22-28`
+
+If the pipe breaks mid-frame (after 1-3 bytes of the 4-byte length prefix), `read_exact` blocks waiting for the remaining bytes until the OS detects the broken pipe — which on Windows can take seconds. Also, no maximum message size validation before allocation — a corrupted length prefix of 15MB causes a 15MB allocation + blocking read.
+
+**Freeze mechanism**: Bridge I/O thread blocked for seconds on partial frame during daemon crash.
+
+### B5. Unsafe raw pointer cast for handle extraction
+**Severity**: MEDIUM (correctness)
+**File**: `daemon_client/bridge.rs:505-513`
+
+```rust
+let reader_ptr = &**reader as *const dyn Read as *const std::fs::File;
+unsafe { (*reader_ptr).as_raw_handle() as isize }
+```
+
+Casts a trait object pointer to `*const std::fs::File`. Only valid if the concrete type is `File`. If the reader type ever changes (e.g., wrapped in BufReader), this is undefined behavior — `PeekNamedPipe` gets a garbage handle.
+
+---
+
+## Category C: Frontend & xterm.js
+
+### C1. xterm.js write() called per-event without batching
+**Severity**: HIGH
+**File**: `src/services/terminal-service.ts:56-63`, `src/components/TerminalPane.ts:146-151`
+
+Each `terminal-output` Tauri event triggers a separate `this.terminal.write(data)` call. Under heavy output (hundreds of events/sec), every `write()` triggers xterm.js's internal parser. While xterm.js batches renders via RAF, the parser work for each individual `write()` accumulates as microtasks.
+
+**Freeze mechanism**: Main thread saturated with queued microtasks from hundreds of individual `write()` calls per frame. Combined with C4 (hidden terminals), this multiplies by total terminal count.
+
+**Fix**: Collect output data in a buffer and flush once per animation frame.
+
+### C2. Hidden terminals still parse all output
+**Severity**: HIGH
+**File**: `src/components/TerminalPane.ts:146-151`, `src/components/App.ts:104-110`
+
+When a TerminalPane is not visible (`setActive(false)` toggles a CSS class), output subscription is **never paused**. The xterm.js instance continues to parse all output. The renderer skips off-screen terminals, but the **parser** still runs for every `write()` call.
+
+**Freeze mechanism**: With N terminals and M events/sec, the main thread does N×M parse operations. Only 1 terminal is visible, but all N are processing. For 10 terminals under heavy output, this is a 10x overhead.
+
+**Fix**: Pause output subscription for inactive terminals and replay from ring buffer on reactivation.
+
+### C3. Synchronous multi-MB scrollback serialization
+**Severity**: MEDIUM
+**File**: `src/components/TerminalPane.ts:167-181`
+
+Every 5 minutes, `saveScrollback()` serializes the entire terminal buffer (up to 10,000 lines) via `serializeAddon.serialize()`. Then `new TextEncoder().encode()` creates a copy. Then `Array.from(data)` creates a THIRD copy (JS array of numbers for Tauri IPC).
+
+**Freeze mechanism**: Synchronous multi-hundred-ms main thread block every 5 minutes. Multiple terminals can align their intervals, multiplying the impact.
+
+### C4. WorkspaceSidebar still does full DOM rebuild
+**Severity**: MEDIUM
+**File**: `src/components/WorkspaceSidebar.ts:224-233`
+
+Unlike TabBar (fixed in Attempt 7), `WorkspaceSidebar.render()` still uses `innerHTML = ''` and recreates ALL elements. Worse, `notificationStore.notify()` is **synchronous** (bypasses RAF batching), triggering a full sidebar rebuild outside the coalescing mechanism.
+
+**Freeze mechanism**: Every notification event causes a synchronous full DOM rebuild, bypassing the batching added in Attempt 7.
+
+### C5. process-changed triggers N render cycles every 2 seconds
+**Severity**: MEDIUM
+**File**: `src/services/terminal-service.ts:66-71`
+
+ProcessMonitor fires `process-changed` every 2 seconds for every terminal. With N terminals, that's N state changes per cycle. If they arrive across different RAF frames, each triggers a separate render pass.
+
+**Freeze mechanism**: Linear degradation with terminal count — 10+ terminals = 10+ render cycles every 2 seconds.
+
+---
+
+## Category D: Daemon Lifecycle & Resource Leaks
+
+### D1. Child process handle leak via immortal thread
+**Severity**: HIGH
+**File**: `daemon/src/session.rs:237-240`
+
+```rust
+thread::spawn(move || {
+    let _ = child;
+});
+```
+
+Every session spawns a thread to hold the child handle alive. This thread never exits — `let _ = child` drops the handle immediately, but the thread itself persists. After many create/close cycles, threads accumulate (~1MB stack each on Windows). Additionally, the child process exit code is never reaped, leaking kernel process objects.
+
+**Freeze mechanism**: After ~2000 sessions, 2GB of committed stack memory. Under memory pressure, the OS pages aggressively, stalling all daemon threads.
+
+### D2. Reader thread not joined on session close
+**Severity**: HIGH
+**File**: `daemon/src/session.rs:124-235, 379-385`
+
+`session.close()` sets `running = false`, but the reader thread blocks on `reader.read()` which is NOT interrupted by an AtomicBool. The thread only exits on PTY EOF or read error. If the shell process hangs (frozen WSL, network-waiting process), the reader thread and its resources (65KB buffer, Arc references) persist indefinitely.
+
+**Freeze mechanism**: Zombie threads + resource accumulation from hung sessions.
+
+### D3. Forwarding task leak on attach/detach cycles
+**Severity**: HIGH
+**File**: `daemon/src/server.rs:836-849`
+
+Every `Attach` spawns a `tokio::spawn` forwarding task. On detach, the old channel sender is dropped, but if buffered items remain, the task drains them before exiting. If re-attach happens before the old task exits, TWO forwarding tasks exist for the same session. The old task holds a `msg_tx` clone, preventing event channel cleanup.
+
+**Freeze mechanism**: Rapid reconnection scenarios accumulate dozens of tokio tasks holding channel senders.
+
+### D4. accept_connection blocks indefinitely on shutdown
+**Severity**: MEDIUM
+**File**: `daemon/src/server.rs:186-232`
+
+`ConnectNamedPipe` with `PIPE_WAIT` blocks indefinitely. When idle timeout fires and sets `running = false`, the daemon can't exit because `accept_connection().await` is stuck in `ConnectNamedPipe`. No cancellation mechanism exists.
+
+**Freeze mechanism**: Daemon can't shut down. New daemon refuses to start (old holds mutex). App connects to zombie daemon that immediately exits. User sees a hang during connection attempts.
+
+### D5. DaemonLock doesn't handle abandoned mutex
+**Severity**: MEDIUM
+**File**: `daemon/src/pid.rs:109-141`
+
+If the previous daemon was killed without releasing the mutex, `CreateMutexW` returns `ERROR_ALREADY_EXISTS`. The new daemon assumes another instance is running and exits. In reality, the old daemon is dead.
+
+**Freeze mechanism**: After a daemon crash (Task Manager kill, etc.), the new daemon refuses to start for a brief window until the kernel garbage-collects the abandoned mutex. User sees no daemon and frozen terminals.
+
+### D6. Exception handler may crash on stack overflow
+**Severity**: MEDIUM
+**File**: `daemon/src/debug_log.rs:135-176`
+
+The exception handler attempts string formatting and mutex acquisition during stack overflow, when only 4KB of stack remains. This may cause a double-fault that terminates the process without logging. Also, returning `EXCEPTION_EXECUTE_HANDLER` calls `ExitProcess()` which may not clean up named pipe handles properly.
+
+**Freeze mechanism**: Daemon vanishes without evidence. Stale pipe handles confuse reconnection.
+
+---
+
+## Category E: Concurrency & Locking
+
+### E1. All Tauri commands blocked during reconnect()
+**Severity**: HIGH
+**File**: `daemon_client/client.rs:377-432`
+
+`reconnect()` holds `reconnect_lock` while performing multiple operations including `send_request` calls (re-attach) that can themselves block for up to 15s. ALL other Tauri command threads (write, resize, create, close) pile up behind `reconnect_lock` via the `send_request -> reconnect` path. The keepalive thread also blocks.
+
+**Freeze mechanism**: Every terminal operation hangs during reconnection. If re-attach is slow (daemon under load), the entire app freezes for up to 15s × N sessions.
+
+### E2. Blocking PTY write under sessions read lock
+**Severity**: MEDIUM
+**File**: `daemon/src/session.rs:321-357`
+
+`write()` acquires `self.writer.lock()` and calls `write_all()` which can block under ConPTY backpressure. The `handle_request` function holds `sessions.read()` while calling `session.write()`. If the PTY write blocks, the read lock prevents `CloseSession` (needs write lock) from proceeding.
+
+**Freeze mechanism**: ConPTY backpressure cascades to session management stall, blocking all session operations for this client.
+
+### E3. Sync Tauri commands with 15s timeout exhaust thread pool
+**Severity**: MEDIUM
+**File**: `commands/terminal.rs` (all command handlers)
+
+All terminal commands are synchronous `#[tauri::command]` handlers that call `send_request()` with a 15s timeout. `create_terminal` calls it twice (up to 30s). Under reconnection, all command threads block on `reconnect_lock`, potentially exhausting Tauri's thread pool.
+
+**Freeze mechanism**: Thread pool saturation — no new commands can be dispatched while existing ones are blocked.
+
+### E4. is_attached_flag desync from output_tx
+**Severity**: MEDIUM (correctness)
+**File**: `daemon/src/session.rs:190,291,298`
+
+The `is_attached_flag` AtomicBool can desynchronize from the actual `output_tx` state due to non-atomic multi-step updates in `attach()`, `detach()`, and the reader thread's `TrySendError::Closed` handler. On x86 this is masked by TSO, but formally incorrect.
+
+**Impact**: Stale attachment state reported in `info()`. Not a direct freeze cause but contributes to confusing diagnostics.
+
+---
+
+## Priority Matrix
+
+### Critical (fix first — likely remaining freeze causes)
+
+| ID | Issue | Category | Impact |
+|----|-------|----------|--------|
+| A1 | Ring buffer fallback data never replayed | Data Flow | Missing output / garbled VT state under load |
+| A2 | No SessionClosed on PTY exit | Data Flow | Dead terminals appear permanently frozen |
+| C1 | xterm.js write() per-event, no batching | Frontend | Main thread saturation under heavy output |
+| C2 | Hidden terminals parse all output | Frontend | N× CPU overhead (N = total terminal count) |
+| E1 | All commands blocked during reconnect | Concurrency | Full app freeze during reconnection |
+
+### High (significant contributors)
+
+| ID | Issue | Category | Impact |
+|----|-------|----------|--------|
+| B1 | JSON 4x serialization amplification | IPC | Pipe fills 4x faster, causes stalls |
+| D1 | Child handle thread leak | Daemon | Memory exhaustion over time |
+| D2 | Reader thread not joined | Daemon | Zombie threads from hung sessions |
+| D3 | Forwarding task leak | Daemon | Task accumulation on reconnects |
+| A4 | Reader TOCTOU overwrites new sender | Data Flow | Output stops after race |
+
+### Medium (contributing factors)
+
+| ID | Issue | Category | Impact |
+|----|-------|----------|--------|
+| B2 | Bidirectional pipe buffer deadlock | IPC | Full deadlock under extreme load |
+| B3 | DuplicateHandle File drop race | IPC | Hang during reconnection |
+| B4 | Partial frame read blocks | IPC | Seconds-long hang on daemon crash |
+| C3 | Sync scrollback serialization | Frontend | Periodic multi-100ms freezes |
+| C4 | WorkspaceSidebar sync DOM rebuild | Frontend | Bypasses RAF batching |
+| C5 | process-changed N renders/2s | Frontend | Linear degradation with terminals |
+| D4 | accept_connection blocks shutdown | Daemon | Daemon can't exit on idle |
+| D5 | Abandoned mutex not handled | Daemon | New daemon won't start after crash |
+| E2 | PTY write under sessions lock | Concurrency | ConPTY backpressure cascade |
+| E3 | Thread pool exhaustion | Concurrency | All commands blocked on timeout |
+
+### Low (correctness/robustness)
+
+| ID | Issue | Category | Impact |
+|----|-------|----------|--------|
+| A3 | Attach data gap | Data Flow | Brief data loss on reattach |
+| B5 | Unsafe raw pointer cast | IPC | UB if reader type changes |
+| D6 | Exception handler stack overflow | Daemon | No crash evidence |
+| E4 | is_attached_flag desync | Concurrency | Stale diagnostics |


### PR DESCRIPTION
## Summary

- **Bug A1**: When the per-session output channel filled during heavy output, data fell back to the ring buffer but was never replayed to the still-attached client, causing missing terminal output and potentially garbled VT state (e.g. cursor hidden permanently)
- **Fix**: Replace `try_send` + ring buffer fallback with `blocking_send` when a client is attached, providing true end-to-end backpressure — the PTY read pauses naturally because the reader thread blocks until channel capacity is available
- **Regression test**: Verifies ring buffer stays empty while a client is attached under heavy output (confirmed failing before fix, passing after)
- **Docs**: Added deep-dive analysis of remaining potential freeze causes to `terminal-freeze-investigation.md`

## Test plan

- [x] Regression test `test_no_data_stranded_in_ring_buffer_while_attached` fails before fix (2005 bytes stranded), passes after
- [x] All daemon tests pass (`cargo test -p godly-daemon`)
- [x] All frontend tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)