### PR TITLE
fix: send SessionClosed event when PTY process exits

### DIFF
--- a/src-tauri/protocol/src/types.rs
+++ b/src-tauri/protocol/src/types.rs
@@ -25,4 +25,5 @@ pub struct SessionInfo {
     pub cwd: Option<String>,
     pub created_at: u64,
     pub attached: bool,
+    pub running: bool,
 }

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -338,7 +338,10 @@ export class App {
 
         // Check daemon for live sessions that can be reattached
         const liveSessions = await terminalService.reconnectSessions();
-        const liveSessionIds = new Set(liveSessions.map((s) => s.id));
+        // Filter out dead sessions (PTY exited but session still in daemon HashMap)
+        const liveSessionIds = new Set(
+          liveSessions.filter((s) => s.running).map((s) => s.id)
+        );
         console.log('[App] Live daemon sessions:', liveSessionIds.size);
 
         // Restore terminals: reattach if alive, or create fresh with scrollback

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -45,6 +45,7 @@ export interface SessionInfo {
   cwd: string | null;
   created_at: number;
   attached: boolean;
+  running: boolean;
 }
 
 class TerminalService {


### PR DESCRIPTION
## Summary

- When a shell process exits (user types `exit`, process crashes, etc.), the daemon now sends a `SessionClosed` event to the attached client, closing the terminal tab automatically instead of leaving it frozen
- Reader thread marks session as dead (`running=false`) and closes the output channel on EOF, which triggers the forwarding task to send `SessionClosed`
- Added `running` field to `SessionInfo` so `ListSessions` reveals dead sessions to clients that weren't attached when the PTY died
- Reconnection logic filters out dead sessions (`running=false`) to avoid reattaching to zombie entries

## Test plan

- [x] 5 new Rust unit tests: `test_close_sets_running_false`, `test_info_reflects_running_state`, `test_running_flag_is_shared`, `test_forwarding_sends_session_closed_on_pty_exit`, `test_forwarding_no_session_closed_on_detach`
- [x] All 18 daemon unit tests pass (`cargo test -p godly-daemon --bin godly-daemon`)
- [x] All 12 protocol tests pass (`cargo test -p godly-protocol`)
- [x] All 163 TypeScript tests pass (`npx vitest run`)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] Frontend build succeeds (`npm run build`)
- [ ] Manual: open terminal, type `exit`, verify tab closes automatically
- [ ] Manual: close and reopen app, verify dead sessions are not reattached