### PR TITLE
fix: isolate daemon tests to prevent killing production daemon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,24 @@ When running inside Godly Terminal, use the `godly-terminal` MCP tools to keep t
 - **How**: Call `mcp__godly-terminal__get_current_terminal` to get the terminal ID, then `mcp__godly-terminal__rename_terminal` to set the name.
 - **When idle**: Reset to a neutral name like `Claude` or the workspace name.
 
+## Daemon Test Isolation (CRITICAL)
+
+**Tests must NEVER interfere with the production daemon.** A test that kills or connects to the production daemon will freeze all live terminal sessions.
+
+### Required isolation rules for `daemon/tests/*.rs`:
+
+1. **Use isolated pipe names** — every test must create its own unique pipe via `GODLY_PIPE_NAME` env var or `--instance` CLI arg. NEVER import or use the production `PIPE_NAME` constant from `godly_protocol`.
+2. **Kill by PID, not by name** — NEVER use `taskkill /F /IM godly-daemon.exe` (kills ALL daemon processes). Use `child.kill()` for child-process daemons or `taskkill /F /PID <pid>` for detached daemons.
+3. **Use `GODLY_NO_DETACH=1`** — keeps the test daemon as a child process so `child.kill()` works for cleanup.
+4. **Pattern to follow** — see `handler_starvation.rs` or `memory_stress.rs` for the `DaemonFixture` pattern with proper isolation.
+
+### Guardrail test
+
+`daemon/tests/test_isolation_guardrail.rs` automatically scans all daemon test files for violations of these rules. It runs as part of the normal test suite and will fail if any test file:
+- Uses `taskkill /IM` (process-name kill)
+- Imports the production `PIPE_NAME` constant
+- Spawns a daemon without `GODLY_PIPE_NAME` or `--instance` isolation
+
 ## Key Patterns
 
 ### Adding a new Tauri command

--- a/src-tauri/daemon/tests/test_isolation_guardrail.rs
+++ b/src-tauri/daemon/tests/test_isolation_guardrail.rs
@@ -1,0 +1,112 @@
+//! Guardrail test: scan all daemon integration tests for patterns that could
+//! kill or interfere with the production daemon.
+//!
+//! Incident: `taskkill /F /IM godly-daemon.exe` in a test killed the production
+//! daemon, freezing 8 live terminal sessions. Tests that used the production
+//! `PIPE_NAME` constant connected to the live daemon instead of an isolated one.
+//!
+//! This test prevents those patterns from ever being reintroduced. It scans every
+//! `*.rs` file in `daemon/tests/` (except itself) and fails if it finds:
+//!
+//! 1. `taskkill /IM` — kills ALL processes by name (must use `/PID` or `child.kill()`)
+//! 2. `use godly_protocol::PIPE_NAME` — imports production pipe name (must use isolated pipes)
+//! 3. `PIPE_NAME` used as a value — references production pipe constant directly
+//!
+//! Run with:
+//!   cd src-tauri && cargo test -p godly-daemon --test test_isolation_guardrail
+
+use std::fs;
+use std::path::PathBuf;
+
+fn daemon_tests_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+/// Patterns that must NEVER appear in daemon test files.
+/// Each entry: (pattern, explanation)
+const FORBIDDEN_PATTERNS: &[(&str, &str)] = &[
+    (
+        "taskkill /IM",
+        "taskkill /IM kills ALL daemon processes by name, including the production daemon. Use child.kill() or taskkill /PID instead.",
+    ),
+    (
+        "taskkill /F /IM",
+        "taskkill /F /IM kills ALL daemon processes by name, including the production daemon. Use child.kill() or taskkill /F /PID instead.",
+    ),
+    (
+        "use godly_protocol::PIPE_NAME",
+        "Importing the production PIPE_NAME constant means the test connects to the live daemon. Use GODLY_PIPE_NAME env var for an isolated pipe.",
+    ),
+];
+
+/// Additional check: if a file spawns a daemon (Command::new with "godly-daemon"),
+/// it must set GODLY_PIPE_NAME or use --instance for isolation.
+fn check_daemon_spawn_isolation(filename: &str, content: &str) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    // Find lines that spawn the daemon binary
+    let spawns_daemon = content.contains("godly-daemon")
+        && (content.contains("Command::new") || content.contains(".spawn()"));
+
+    if spawns_daemon {
+        let has_pipe_env = content.contains("GODLY_PIPE_NAME");
+        let has_instance_arg = content.contains("--instance");
+
+        if !has_pipe_env && !has_instance_arg {
+            violations.push(format!(
+                "{}: spawns godly-daemon without GODLY_PIPE_NAME env var or --instance arg. \
+                 The test will connect to the production daemon instead of an isolated one.",
+                filename
+            ));
+        }
+    }
+
+    violations
+}
+
+#[test]
+fn no_forbidden_patterns_in_daemon_tests() {
+    let tests_dir = daemon_tests_dir();
+    let mut violations = Vec::new();
+
+    let entries = fs::read_dir(&tests_dir).unwrap_or_else(|e| {
+        panic!("Failed to read daemon tests dir {:?}: {}", tests_dir, e);
+    });
+
+    for entry in entries {
+        let entry = entry.unwrap();
+        let path = entry.path();
+
+        // Only check .rs files, skip ourselves
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let filename = path.file_name().unwrap().to_string_lossy().to_string();
+        if filename == "test_isolation_guardrail.rs" {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!("Failed to read {:?}: {}", path, e);
+        });
+
+        // Check forbidden string patterns
+        for (pattern, explanation) in FORBIDDEN_PATTERNS {
+            if content.contains(pattern) {
+                violations.push(format!("{}: contains `{}` — {}", filename, pattern, explanation));
+            }
+        }
+
+        // Check daemon spawn isolation
+        violations.extend(check_daemon_spawn_isolation(&filename, &content));
+    }
+
+    if !violations.is_empty() {
+        panic!(
+            "\n\nDANGEROUS TEST ISOLATION VIOLATIONS FOUND:\n\n{}\n\n\
+             These patterns can kill the production daemon and freeze all live terminals.\n\
+             See CLAUDE.md \"Daemon Test Isolation\" section for the correct patterns.\n",
+            violations.join("\n\n")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Refactored `ctrl_c_interrupt.rs` and `session_persistence.rs` to use isolated pipe names via `GODLY_PIPE_NAME` instead of `taskkill /F /IM godly-daemon.exe` which killed ALL daemon processes — including the production daemon serving live terminal sessions
- Added `test_isolation_guardrail.rs` that scans all daemon test files for dangerous patterns (process-name kills, production pipe imports, unisolated spawns)
- Documented isolation rules in CLAUDE.md

## Context

Running `cargo test` on master triggers `taskkill /IM godly-daemon.exe` in two test files, which kills every running daemon process by name. This causes a full terminal freeze — all live sessions are lost and the app becomes unresponsive.

## Test plan

- [x] `cargo test -p godly-daemon --test test_isolation_guardrail` passes (scans for forbidden patterns)
- [ ] Run `cargo test -p godly-daemon` while the app has active sessions — sessions should not be affected