### PR TITLE
feat: add open terminal button to worktree panel items

### DIFF
--- a/src/components/WorktreePanel.ts
+++ b/src/components/WorktreePanel.ts
@@ -170,6 +170,16 @@ export class WorktreePanel {
 
       item.appendChild(info);
 
+      const openBtn = document.createElement('button');
+      openBtn.className = 'worktree-item-open';
+      openBtn.textContent = '\u25B6';
+      openBtn.title = `Open terminal in ${wt.branch}`;
+      openBtn.onclick = (e) => {
+        e.stopPropagation();
+        this.handleOpen(wt);
+      };
+      item.appendChild(openBtn);
+
       const isDeleting = this.deleting.has(wt.path);
       const deleteBtn = document.createElement('button');
       deleteBtn.className = 'worktree-item-delete';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -594,6 +594,25 @@ html, body {
   flex-shrink: 0;
 }
 
+.worktree-item-open {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0 4px;
+  opacity: 0;
+  transition: opacity 0.1s, color 0.1s;
+}
+
+.worktree-item:hover .worktree-item-open {
+  opacity: 1;
+}
+
+.worktree-item-open:hover {
+  color: var(--accent);
+}
+
 .worktree-item-delete {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- Adds a visible play button (▶) to each worktree entry in the worktree sidebar panel
- Button appears on hover, positioned between the branch info and the delete button
- Clicking it opens a new terminal in that worktree (same behavior as clicking the branch name)
- Styled with accent color on hover, matching the existing delete button pattern

## Test plan
- [x] TypeScript build passes (`npm run build`)
- [x] All 169 tests pass (`npm test`)
- [ ] Manual: enable worktree mode on a workspace, verify ▶ button appears on hover for each worktree
- [ ] Manual: click ▶ button, verify a new terminal opens in the correct worktree directory