### PR TITLE
feat: add read_terminal MCP tool

### DIFF
--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -1052,6 +1052,22 @@ async fn handle_request(
             }
         }
 
+        Request::ReadBuffer { session_id } => {
+            let sessions_guard = sessions.read();
+            match sessions_guard.get(session_id) {
+                Some(session) => {
+                    let data = session.read_output_history();
+                    Response::Buffer {
+                        session_id: session_id.clone(),
+                        data,
+                    }
+                }
+                None => Response::Error {
+                    message: format!("Session {} not found", session_id),
+                },
+            }
+        }
+
         Request::CloseSession { session_id } => {
             let mut sessions_guard = sessions.write();
             match sessions_guard.remove(session_id) {

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -12,7 +12,7 @@ use log::mcp_log;
 use pipe_client::McpPipeClient;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 8;
+const BUILD: u32 = 9;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -42,6 +42,13 @@ pub enum McpRequest {
 
     // Terminal I/O
     WriteToTerminal { terminal_id: String, data: String },
+    ReadTerminal {
+        terminal_id: String,
+        #[serde(default)]
+        mode: Option<String>,
+        #[serde(default)]
+        lines: Option<usize>,
+    },
 
     // Notifications
     Notify {
@@ -99,4 +106,5 @@ pub enum McpResponse {
         worktree_branch: Option<String>,
     },
     NotificationStatus { enabled: bool, source: String },
+    TerminalOutput { content: String },
 }

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -36,6 +36,9 @@ pub enum Request {
     CloseSession {
         session_id: String,
     },
+    ReadBuffer {
+        session_id: String,
+    },
     Ping,
 }
 


### PR DESCRIPTION
## Summary

- Add `output_history` buffer to `DaemonSession` — always-on 1MB rolling buffer that captures all PTY output regardless of attachment state
- Add `ReadBuffer` daemon protocol command + handler in `server.rs`
- Add `ReadTerminal` / `TerminalOutput` MCP protocol messages with `mode` (full/head/tail) and `lines` parameters
- Add `truncate_output()` helper in Tauri MCP handler with unit tests
- Add `read_terminal` tool to godly-mcp with optional `filename` parameter to save output to file
- Bump MCP BUILD to 9

## Data flow

```
MCP client → read_terminal tool → McpRequest::ReadTerminal
  → Tauri handler → Request::ReadBuffer → daemon server
  → DaemonSession::read_output_history() (non-destructive read)
  → Response::Buffer → truncate_output() → McpResponse::TerminalOutput
```

## Test plan

- [x] `cargo check -p godly-protocol -p godly-daemon -p godly-mcp` — compiles clean
- [x] `cargo test -p godly-protocol` — 12 passed
- [x] `cargo test -p godly-daemon` — 19 unit tests + integration tests passed
- [x] `npx vitest run` — 169 TypeScript tests passed
- [ ] Manual E2E: rebuild MCP binary, use `read_terminal` tool from Claude Code in Godly Terminal