### PR TITLE
fix: eliminate ~2s input lag on arrow-up and rapid keystrokes

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -229,12 +229,10 @@ pub fn write_to_terminal(
         session_id: terminal_id,
         data: data.into_bytes(),
     };
-    let response = daemon.send_request(&request)?;
-    match response {
-        Response::Ok => Ok(()),
-        Response::Error { message } => Err(message),
-        other => Err(format!("Unexpected response: {:?}", other)),
-    }
+    // Fire-and-forget: don't block the Tauri thread pool waiting for the
+    // daemon's Ok response. Blocking here caused ~2s input lag under rapid
+    // keystrokes (e.g. arrow-up) because threads saturated waiting on IPC.
+    daemon.send_fire_and_forget(&request)
 }
 
 #[tauri::command]

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -18,7 +18,7 @@ export class TerminalPane {
   private resizeRAF: number | null = null;
   private unsubscribeOutput: (() => void) | null = null;
   private outputBuffer: Uint8Array[] = [];
-  private outputFlushRAF: number | null = null;
+  private outputFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private scrollbackSaveInterval: number | null = null;
   private maxScrollbackLines = 10000;
 
@@ -144,15 +144,16 @@ export class TerminalPane {
       terminalService.writeToTerminal(this.terminalId, data);
     });
 
-    // Handle output: buffer chunks and flush once per animation frame.
+    // Handle output: buffer chunks and flush via microtask.
     // Bug C1: unbatched write() calls under heavy output saturate the main
     // thread because each call triggers xterm.js's parser synchronously.
+    // setTimeout(0) fires in ~1ms vs RAF's ~16ms, reducing echo latency.
     this.unsubscribeOutput = terminalService.onTerminalOutput(
       this.terminalId,
       (data) => {
         this.outputBuffer.push(data);
-        if (this.outputFlushRAF === null) {
-          this.outputFlushRAF = requestAnimationFrame(() => this.flushOutputBuffer());
+        if (this.outputFlushTimer === null) {
+          this.outputFlushTimer = setTimeout(() => this.flushOutputBuffer(), 0);
         }
       }
     );
@@ -172,7 +173,7 @@ export class TerminalPane {
   }
 
   private flushOutputBuffer() {
-    this.outputFlushRAF = null;
+    this.outputFlushTimer = null;
     const chunks = this.outputBuffer;
     if (chunks.length === 0) return;
     this.outputBuffer = [];
@@ -276,9 +277,9 @@ export class TerminalPane {
     // Save scrollback before destroying
     await this.saveScrollback();
 
-    if (this.outputFlushRAF !== null) {
-      cancelAnimationFrame(this.outputFlushRAF);
-      this.outputFlushRAF = null;
+    if (this.outputFlushTimer !== null) {
+      clearTimeout(this.outputFlushTimer);
+      this.outputFlushTimer = null;
     }
     this.outputBuffer = [];
     if (this.scrollbackSaveInterval) {


### PR DESCRIPTION
## Summary

- **Fire-and-forget terminal writes**: `write_to_terminal` no longer blocks the Tauri thread pool waiting for the daemon's `Ok` response. Under rapid input (e.g. arrow-up for history navigation), threads were saturating on IPC round-trips, causing compounding delays up to ~2s.
- **Faster output flushing**: Replaced `requestAnimationFrame` (~16ms) with `setTimeout(0)` (~1ms) for output buffer flushing, reducing echo latency.
- Added `send_fire_and_forget()` method to `DaemonClient` for latency-sensitive writes.

## Test plan

- [x] Rust compilation passes (`cargo check --workspace`)
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] All TypeScript tests pass (169/169)
- [x] All Rust tests pass (protocol, daemon, terminal crates)
- [ ] Manual test: press arrow-up rapidly in terminal — should feel instant, no 2s delay
- [ ] Manual test: heavy output (e.g. `cat` large file) still renders smoothly