### PR TITLE
feat: add in-app toast notifications

### DIFF
--- a/src/components/ToastContainer.ts
+++ b/src/components/ToastContainer.ts
@@ -1,0 +1,76 @@
+import { store } from '../state/store';
+
+interface Toast {
+  id: number;
+  terminalId: string;
+  title: string;
+  body: string;
+  element: HTMLElement;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+const TOAST_DURATION_MS = 4000;
+const FADE_OUT_MS = 300;
+
+export class ToastContainer {
+  private container: HTMLElement;
+  private toasts: Toast[] = [];
+  private nextId = 0;
+
+  constructor() {
+    this.container = document.createElement('div');
+    this.container.className = 'toast-container';
+  }
+
+  mount(parent: HTMLElement) {
+    parent.appendChild(this.container);
+  }
+
+  show(title: string, body: string, terminalId: string) {
+    const id = this.nextId++;
+
+    const el = document.createElement('div');
+    el.className = 'toast';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'toast-title';
+    titleEl.textContent = title;
+
+    const bodyEl = document.createElement('div');
+    bodyEl.className = 'toast-body';
+    bodyEl.textContent = body;
+
+    el.appendChild(titleEl);
+    el.appendChild(bodyEl);
+
+    el.addEventListener('click', () => {
+      this.dismiss(id);
+      // Switch to the terminal's workspace and activate the terminal
+      const terminal = store.getState().terminals.find(t => t.id === terminalId);
+      if (terminal) {
+        store.setActiveWorkspace(terminal.workspaceId);
+        store.setActiveTerminal(terminalId);
+      }
+    });
+
+    const timeout = setTimeout(() => this.dismiss(id), TOAST_DURATION_MS);
+
+    const toast: Toast = { id, terminalId, title, body, element: el, timeout };
+    this.toasts.push(toast);
+    this.container.appendChild(el);
+  }
+
+  private dismiss(id: number) {
+    const index = this.toasts.findIndex(t => t.id === id);
+    if (index === -1) return;
+
+    const toast = this.toasts[index];
+    clearTimeout(toast.timeout);
+    toast.element.classList.add('toast-exit');
+
+    setTimeout(() => {
+      toast.element.remove();
+      this.toasts = this.toasts.filter(t => t.id !== id);
+    }, FADE_OUT_MS);
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -963,3 +963,54 @@ html, body {
   outline: none;
   border-color: var(--accent);
 }
+
+/* Toast notifications */
+.toast-container {
+  position: fixed;
+  bottom: 12px;
+  right: 12px;
+  z-index: 999;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  padding: 10px 14px;
+  min-width: 240px;
+  max-width: 340px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  animation: toast-slide-in 0.25s ease-out;
+}
+
+.toast-title {
+  font-weight: 600;
+  color: var(--text-active);
+  font-size: 13px;
+  margin-bottom: 2px;
+}
+
+.toast-body {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.toast.toast-exit {
+  animation: toast-fade-out 0.3s ease-in forwards;
+}
+
+@keyframes toast-slide-in {
+  from { transform: translateX(100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes toast-fade-out {
+  to { opacity: 0; transform: translateX(30%); }
+}


### PR DESCRIPTION
## Summary

- Add `ToastContainer` component that renders slide-in toast notifications in the bottom-right corner
- Wire into existing `mcp-notify` handler so toasts appear **always** (regardless of window focus), showing terminal tab name + message
- Clicking a toast switches to that terminal and its workspace; toasts auto-dismiss after 4 seconds with fade-out animation

## Test plan

- [x] `npm run build` passes (TypeScript + Vite)
- [x] `npm test` passes (169 tests)
- [ ] Manual: trigger notification via `godly-notify.exe "test message"` while window is focused — verify in-app toast appears with terminal name + message
- [ ] Manual: verify clicking toast switches to the correct terminal
- [ ] Manual: verify multiple toasts stack upward and auto-dismiss