### PR TITLE
fix: reduce arrow key input latency

### DIFF
--- a/src-tauri/src/daemon_client/client.rs
+++ b/src-tauri/src/daemon_client/client.rs
@@ -558,7 +558,7 @@ impl DaemonClient {
 
         tx.send(BridgeRequest {
             request: request.clone(),
-            response_tx,
+            response_tx: Some(response_tx),
         })
         .map_err(|e| format!("Failed to send request to bridge: {}", e))?;
 
@@ -580,6 +580,9 @@ impl DaemonClient {
     /// Send a request without waiting for the response.
     /// Used for latency-sensitive writes where blocking on the round-trip
     /// would saturate the Tauri thread pool and cause input lag.
+    ///
+    /// Sets response_tx = None so the bridge skips tracking a dead channel
+    /// and instead counts orphan responses to discard when they arrive.
     pub fn send_fire_and_forget(&self, request: &Request) -> Result<(), String> {
         let tx = self
             .request_tx
@@ -588,11 +591,9 @@ impl DaemonClient {
             .ok_or("Bridge not started yet")?
             .clone();
 
-        let (response_tx, _response_rx) = mpsc::channel();
-
         tx.send(BridgeRequest {
             request: request.clone(),
-            response_tx,
+            response_tx: None,
         })
         .map_err(|e| format!("Failed to send request to bridge: {}", e))?;
 


### PR DESCRIPTION
## Summary

- **Adaptive polling** in both bridge and daemon I/O threads replaces `thread::sleep(1ms)` with a spin-then-sleep strategy. On Windows, `Sleep(1)` can sleep ~15ms due to the default timer resolution (15.625ms), adding up to ~30ms of accumulated polling delay across both threads during active typing. Now uses `yield_now()` during active I/O and only falls back to sleep after 100 idle iterations.
- **Direct I/O handling** for Write and Resize requests in the daemon's I/O thread, bypassing the async handler entirely. This eliminates 2 tokio channel hops and scheduler latency per keystroke.
- **Fire-and-forget optimization**: writes no longer allocate dead response channels. The bridge tracks orphan response counts instead of pushing dead senders into the pending queue.

## Test plan

- [ ] Build daemon (`npm run build:daemon`) and restart the app
- [ ] Open a terminal, type a few commands to build history
- [ ] Hold arrow-up — should scroll through history with noticeably less lag than before
- [ ] Hold arrow-down — same improvement expected
- [ ] Rapid typing should feel responsive
- [ ] Verify `cargo test -p godly-daemon -p godly-protocol` still passes
- [ ] Verify `npm test` still passes