### PR TITLE
fix: disable Tauri native drag-drop to fix internal DnD forbidden cursor

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "fullscreen": false,
         "decorations": true,
         "transparent": false,
-        "dragDropEnabled": true
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/components/WorkspaceSidebar.ts
+++ b/src/components/WorkspaceSidebar.ts
@@ -332,6 +332,7 @@ export class WorkspaceSidebar {
     // Drop zone for tabs and workspace reordering
     item.ondragover = (e) => {
       e.preventDefault();
+      e.dataTransfer!.dropEffect = 'move';
       const isWorkspaceDrag = e.dataTransfer?.types.includes('application/x-workspace-id');
       if (isWorkspaceDrag && this.draggedItem && this.draggedItem !== item) {
         item.classList.add('drag-over-workspace');


### PR DESCRIPTION
## Summary

- Disabled `dragDropEnabled` in `tauri.conf.json` to prevent Tauri's native `IDropTarget` from intercepting internal HTML5 drag-and-drop operations (tab/workspace reordering), which caused a forbidden cursor and prevented drops from working on Windows
- Converted file drop handler from Tauri native events (`onDragDropEvent`) to HTML5 drag events (`dragenter`/`dragleave`/`drop`), with a `dragCounter` pattern for correct enter/leave tracking
- Added missing `dropEffect = 'move'` to workspace sidebar's `dragover` handler for proper cursor feedback

## Test plan

- [ ] Verify tab reordering works: drag a tab and drop it on another tab to reorder
- [ ] Verify workspace reordering works: drag a workspace item to reorder in the sidebar
- [ ] Verify tab-to-workspace drop works: drag a tab onto a different workspace in the sidebar
- [ ] Verify split-by-drop works: drag a tab to the edges of the terminal container to create a split
- [ ] Verify cursor shows move icon (not forbidden) during all drag operations above
- [ ] Verify file drop from Explorer shows dashed border overlay on the terminal container
- [ ] Verify file drop from Explorer pastes the filename into the active terminal