### PR TITLE
feat: add WaitForIdle and WaitForText MCP tools

### DIFF
--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -1161,6 +1161,36 @@ async fn handle_request(
             }
         }
 
+        Request::GetLastOutputTime { session_id } => {
+            let sessions_guard = sessions.read();
+            match sessions_guard.get(session_id) {
+                Some(session) => Response::LastOutputTime {
+                    epoch_ms: session.last_output_epoch_ms(),
+                    running: session.is_running(),
+                },
+                None => Response::Error {
+                    message: format!("Session {} not found", session_id),
+                },
+            }
+        }
+
+        Request::SearchBuffer {
+            session_id,
+            text,
+            strip_ansi,
+        } => {
+            let sessions_guard = sessions.read();
+            match sessions_guard.get(session_id) {
+                Some(session) => Response::SearchResult {
+                    found: session.search_output_history(text, *strip_ansi),
+                    running: session.is_running(),
+                },
+                None => Response::Error {
+                    message: format!("Session {} not found", session_id),
+                },
+            }
+        }
+
         Request::CloseSession { session_id } => {
             let mut sessions_guard = sessions.write();
             match sessions_guard.remove(session_id) {

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -12,7 +12,7 @@ use log::mcp_log;
 use pipe_client::McpPipeClient;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 10;
+const BUILD: u32 = 11;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/protocol/src/ansi.rs
+++ b/src-tauri/protocol/src/ansi.rs
@@ -1,0 +1,99 @@
+/// Strip ANSI escape sequences from terminal output.
+/// Handles CSI sequences (\x1b[...X), OSC sequences (\x1b]...BEL/ST),
+/// and simple 2-byte sequences (\x1b + single char).
+pub fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            match chars.peek() {
+                Some('[') => {
+                    // CSI sequence: consume until final byte (0x40..=0x7E)
+                    chars.next(); // consume '['
+                    while let Some(&c) = chars.peek() {
+                        chars.next();
+                        if (0x40..=0x7E).contains(&(c as u32)) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    // OSC sequence: consume until BEL (\x07) or ST (\x1b\\)
+                    chars.next(); // consume ']'
+                    while let Some(c) = chars.next() {
+                        if c == '\x07' {
+                            break;
+                        }
+                        if c == '\x1b' {
+                            if chars.peek() == Some(&'\\') {
+                                chars.next(); // consume '\\'
+                            }
+                            break;
+                        }
+                    }
+                }
+                Some(_) => {
+                    // Simple 2-byte sequence: skip one char
+                    chars.next();
+                }
+                None => {
+                    // Trailing ESC at end of string
+                }
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_ansi_csi_sequences() {
+        // SGR (color) sequences
+        assert_eq!(strip_ansi("\x1b[31mhello\x1b[0m"), "hello");
+        // Cursor movement
+        assert_eq!(strip_ansi("\x1b[2Jscreen"), "screen");
+        // Multiple params
+        assert_eq!(strip_ansi("\x1b[1;32mbold green\x1b[0m"), "bold green");
+    }
+
+    #[test]
+    fn test_strip_ansi_osc_with_bel() {
+        // OSC title set terminated by BEL
+        assert_eq!(strip_ansi("\x1b]0;My Title\x07prompt$"), "prompt$");
+    }
+
+    #[test]
+    fn test_strip_ansi_osc_with_st() {
+        // OSC sequence terminated by ST (\x1b\\)
+        assert_eq!(strip_ansi("\x1b]0;Title\x1b\\text"), "text");
+    }
+
+    #[test]
+    fn test_strip_ansi_no_escapes() {
+        assert_eq!(strip_ansi("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_strip_ansi_empty() {
+        assert_eq!(strip_ansi(""), "");
+    }
+
+    #[test]
+    fn test_strip_ansi_mixed() {
+        let input = "\x1b[32mPS C:\\>\x1b[0m echo \x1b]0;powershell\x07hello";
+        assert_eq!(strip_ansi(input), "PS C:\\> echo hello");
+    }
+
+    #[test]
+    fn test_strip_ansi_two_byte_sequence() {
+        // e.g. \x1b= (set alternate keypad mode)
+        assert_eq!(strip_ansi("\x1b=text"), "text");
+    }
+}

--- a/src-tauri/protocol/src/lib.rs
+++ b/src-tauri/protocol/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ansi;
 pub mod frame;
 pub mod mcp_messages;
 pub mod messages;

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -61,6 +61,18 @@ pub enum McpRequest {
         cols: u16,
     },
 
+    // Wait/polling tools
+    WaitForIdle {
+        terminal_id: String,
+        idle_ms: u64,
+        timeout_ms: u64,
+    },
+    WaitForText {
+        terminal_id: String,
+        text: String,
+        timeout_ms: u64,
+    },
+
     // Notifications
     Notify {
         terminal_id: String,
@@ -123,5 +135,9 @@ pub enum McpResponse {
     },
     ActiveTerminal {
         terminal: Option<McpTerminalInfo>,
+    },
+    WaitResult {
+        completed: bool,
+        last_output_ago_ms: u64,
     },
 }

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -39,6 +39,14 @@ pub enum Request {
     ReadBuffer {
         session_id: String,
     },
+    GetLastOutputTime {
+        session_id: String,
+    },
+    SearchBuffer {
+        session_id: String,
+        text: String,
+        strip_ansi: bool,
+    },
     Ping,
 }
 
@@ -53,6 +61,8 @@ pub enum Response {
     Pong,
     /// Initial buffer replay when attaching to a session
     Buffer { session_id: String, data: Vec<u8> },
+    LastOutputTime { epoch_ms: u64, running: bool },
+    SearchResult { found: bool, running: bool },
 }
 
 /// Asynchronous events pushed from the daemon to attached clients


### PR DESCRIPTION
## Summary

Add two new MCP tools for terminal output synchronization, plus supporting fixes:

- **`wait_for_idle`** — Polls the daemon for the last output timestamp. Returns when the terminal has been silent for a configurable `idle_ms` threshold, or when the timeout is reached. Useful for waiting until a command finishes producing output.
- **`wait_for_text`** — Polls the daemon's `SearchBuffer` to detect when specific text appears in terminal output (ANSI-stripped). Returns on match or timeout. Useful for waiting on prompts, success messages, or error strings.

### Supporting changes

- **Fix `write_to_terminal`**: Convert `\n` → `\r` before sending to PTY so Enter key works correctly from MCP clients (frontend xterm.js already sends CR).
- **Move `strip_ansi()` to `godly_protocol::ansi`**: Eliminates duplication between `handler.rs` and the new `session.rs` search logic.
- **Add `last_output_epoch_ms` tracking**: Daemon sessions now track the epoch-ms timestamp of the last PTY output via `AtomicU64`, enabling idle detection without buffering.
- **Add `GetLastOutputTime` / `SearchBuffer` protocol requests**: New daemon protocol variants used by the wait tools.
- **Bump MCP BUILD to 11**.

### Files changed

| File | Change |
|------|--------|
| `protocol/src/ansi.rs` | New shared `strip_ansi()` with tests |
| `protocol/src/lib.rs` | Export `ansi` module |
| `protocol/src/messages.rs` | Add `GetLastOutputTime`, `SearchBuffer`, `LastOutputTime`, `SearchResult` |
| `protocol/src/mcp_messages.rs` | Add `WaitForIdle`, `WaitForText`, `WaitResult` |
| `daemon/src/session.rs` | Add `last_output_epoch_ms` field, `search_output_history()` |
| `daemon/src/server.rs` | Handle `GetLastOutputTime` and `SearchBuffer` requests |
| `src/mcp_server/handler.rs` | Add wait tool handlers with polling loops, fix `\n`→`\r`, delegate `strip_ansi` |
| `mcp/src/tools.rs` | Add tool definitions, `call_tool` dispatch, response mapping |
| `mcp/src/main.rs` | Bump BUILD to 11 |