### PR TITLE
fix: eliminate Windows timer resolution penalty causing arrow key latency

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1.0", features = ["full"] }
 parking_lot = "0.12"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["processthreadsapi", "handleapi", "psapi", "tlhelp32", "winbase", "namedpipeapi", "fileapi", "errhandlingapi", "winerror"] }
+winapi = { version = "0.3", features = ["processthreadsapi", "handleapi", "psapi", "tlhelp32", "winbase", "namedpipeapi", "fileapi", "errhandlingapi", "synchapi", "timeapi", "winerror"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/daemon/Cargo.toml
+++ b/src-tauri/daemon/Cargo.toml
@@ -33,6 +33,7 @@ winapi = { version = "0.3", features = [
     "fileapi",
     "errhandlingapi",
     "synchapi",
+    "timeapi",
     "winerror",
     "winnt",
 ] }

--- a/src-tauri/daemon/src/main.rs
+++ b/src-tauri/daemon/src/main.rs
@@ -25,6 +25,15 @@ async fn main() {
         }
     }
 
+    // Set Windows timer resolution to 1ms. Without this, thread::sleep(1ms)
+    // actually sleeps ~15ms due to the default 15.625ms timer resolution.
+    // The daemon I/O thread uses adaptive polling with sleep(1ms) fallback;
+    // this makes the fallback actually ~1ms instead of ~15ms.
+    #[cfg(windows)]
+    unsafe {
+        winapi::um::timeapi::timeBeginPeriod(1);
+    }
+
     debug_log::init();
     debug_log::install_panic_hook();
     debug_log::install_exception_handler();


### PR DESCRIPTION
## Summary

- Call `timeBeginPeriod(1)` at startup in both Tauri app and daemon to reduce Windows timer resolution from ~15ms to 1ms, making `thread::sleep(1ms)` actually sleep ~1ms
- Add a `WakeEvent` (Windows Event object) to the bridge I/O thread that is signaled immediately when `send_fire_and_forget` or `try_send_request` enqueues a request, giving zero-latency wakeup for user input
- Together these eliminate ~30ms of pure sleep overhead on the arrow key round-trip path (bridge sleep + daemon sleep + bridge sleep on return)

## Test plan

- [x] New `test_wake_event_signal_unblocks_wait` test verifies signal immediately unblocks wait
- [x] New `test_wake_event_timeout_without_signal` test verifies timeout behavior when not signaled
- [x] All 104 Rust lib tests pass
- [x] All 182 npm tests pass
- [x] All daemon tests pass (1 pre-existing memory stress flake unrelated)
- [ ] Manual testing: press arrow up after a pause in the terminal, verify reduced latency