### PR TITLE
fix: scroll to bottom after tab switch to prevent viewport reset

### DIFF
--- a/src/components/TerminalPane.activation.test.ts
+++ b/src/components/TerminalPane.activation.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { activatePane } from './pane-activation';
+
+// Bug: When switching tabs, the terminal viewport resets to the top of the
+// buffer instead of staying at the bottom (where the cursor is). Even scrolling
+// to what xterm.js thinks is the "bottom" shows truncated content because the
+// viewport's scroll area wasn't updated for data written while the pane was
+// display:none. Typing input forces a viewport refresh that reveals the real
+// bottom — proving the buffer is correct but the viewport is stale.
+//
+// Fix: After making a pane visible, call scrollToBottom() after fit() to
+// reposition the viewport at the actual end of the buffer.
+
+describe('Terminal pane activation (scroll-to-bottom on tab switch)', () => {
+  it('calls scrollToBottom after fit when pane becomes active', () => {
+    const callOrder: string[] = [];
+    const terminal = {
+      scrollToBottom: vi.fn(() => callOrder.push('scrollToBottom')),
+      focus: vi.fn(() => callOrder.push('focus')),
+    };
+    const fit = vi.fn(() => callOrder.push('fit'));
+
+    activatePane(terminal, fit, true);
+
+    // Bug: scrollToBottom was never called, so viewport stayed at top after
+    // switching tabs. Data written while hidden made the buffer longer than the
+    // viewport knew, so even scrolling to "bottom" showed truncated content.
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+    // Correct order: fit dimensions first, then scroll, then focus
+    expect(callOrder).toEqual(['fit', 'scrollToBottom', 'focus']);
+  });
+
+  it('calls scrollToBottom even when not focusing (split-visible but not focused)', () => {
+    const terminal = {
+      scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+    };
+    const fit = vi.fn();
+
+    activatePane(terminal, fit, false);
+
+    expect(fit).toHaveBeenCalledTimes(1);
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(terminal.focus).not.toHaveBeenCalled();
+  });
+
+  it('scrollToBottom runs after fit so dimensions are correct first', () => {
+    // Bug: without scrollToBottom, viewport has stale scroll area from when
+    // the element was display:none. Data written while hidden makes the buffer
+    // longer than the viewport knows, so "bottom" is truncated.
+    let fitCalled = false;
+    let scrollCalledAfterFit = false;
+
+    const terminal = {
+      scrollToBottom: vi.fn(() => { scrollCalledAfterFit = fitCalled; }),
+      focus: vi.fn(),
+    };
+    const fit = vi.fn(() => { fitCalled = true; });
+
+    activatePane(terminal, fit, true);
+
+    expect(scrollCalledAfterFit).toBe(true);
+  });
+});

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -7,6 +7,7 @@ import { terminalService } from '../services/terminal-service';
 import { store } from '../state/store';
 import { isAppShortcut, isTerminalControlKey } from './keyboard';
 import { keybindingStore } from '../state/keybinding-store';
+import { activatePane } from './pane-activation';
 
 export class TerminalPane {
   private terminal: Terminal;
@@ -271,8 +272,7 @@ export class TerminalPane {
     this.container.classList.toggle('active', active);
     if (active) {
       requestAnimationFrame(() => {
-        this.fit();
-        this.terminal.focus();
+        activatePane(this.terminal, () => this.fit(), true);
       });
     }
   }
@@ -283,10 +283,7 @@ export class TerminalPane {
     this.container.classList.toggle('split-focused', focused);
     if (visible) {
       requestAnimationFrame(() => {
-        this.fit();
-        if (focused) {
-          this.terminal.focus();
-        }
+        activatePane(this.terminal, () => this.fit(), focused);
       });
     }
   }

--- a/src/components/pane-activation.ts
+++ b/src/components/pane-activation.ts
@@ -1,0 +1,19 @@
+/**
+ * Activation sequence for terminal panes.
+ *
+ * Extracted from TerminalPane so the sequence (fit → scrollToBottom → focus)
+ * can be unit-tested without a DOM or real xterm.js instance.
+ *
+ * Called inside requestAnimationFrame after the pane's CSS visibility is toggled.
+ */
+export function activatePane(
+  terminal: { scrollToBottom: () => void; focus: () => void },
+  fit: () => void,
+  shouldFocus: boolean,
+): void {
+  fit();
+  terminal.scrollToBottom();
+  if (shouldFocus) {
+    terminal.focus();
+  }
+}


### PR DESCRIPTION
## Summary

- Fix terminal viewport resetting to the top of the buffer when switching tabs
- Extract pane activation sequence into `pane-activation.ts` with `scrollToBottom()` call after `fit()` so the viewport repositions at the actual end of the buffer
- Add unit tests verifying the activation sequence (fit → scrollToBottom → focus)

## Root Cause

Terminal panes use `display: none` when inactive. When xterm.js receives `write()` calls while its container is hidden, the viewport's scroll state becomes stale (zero-dimension element can't calculate scroll areas). On re-activation, `fit()` recalculates dimensions but doesn't restore the viewport scroll position, causing:
1. Viewport resets to the top of the buffer
2. Scrolling to "bottom" shows truncated content (viewport doesn't know about data written while hidden)
3. Typing input forces a viewport refresh that reveals the real bottom

## Test plan

- [x] New unit tests pass (`TerminalPane.activation.test.ts` — 3 tests)
- [x] Full test suite passes (185 tests)
- [x] TypeScript compiles cleanly
- [x] Production build succeeds
- [ ] Manual: open two terminals, generate output in both, switch tabs — viewport should be at the bottom
- [ ] Manual: switch to a tab that received output while hidden — should show latest content without needing to type