### PR TITLE
fix: show Split and Workspace hotkeys in settings dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,10 @@ App.ts           - Root: manages layout, keyboard shortcuts, reconnection logic
 - Imports the production `PIPE_NAME` constant
 - Spawns a daemon without `GODLY_PIPE_NAME` or `--instance` isolation
 
+## Keyboard Shortcuts
+
+All keyboard shortcuts defined in `DEFAULT_SHORTCUTS` (`src/state/keybinding-store.ts`) must be displayed in the Settings dialog (`src/components/SettingsDialog.ts`). When adding a new shortcut category, add it to the `categories` array in `renderShortcuts()` so it appears in the UI.
+
 ## Key Patterns
 
 ### Adding a new Tauri command

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -285,7 +285,7 @@ export function showSettingsDialog(): Promise<void> {
     function renderShortcuts() {
       shortcutsContainer.textContent = '';
 
-      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs'];
+      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace'];
 
       for (const category of categories) {
         const defs = DEFAULT_SHORTCUTS.filter((d) => d.category === category);


### PR DESCRIPTION
## Summary
- Added `Split` and `Workspace` categories to the settings dialog hotkey list, so the worktree mode (Ctrl+Shift+W) and claude code mode (Ctrl+Shift+E) shortcuts are now visible and customizable in the UI
- Added a CLAUDE.md rule requiring all shortcut categories to be displayed in the settings dialog

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 197 tests pass
- [ ] Open settings (Ctrl+,) and verify Split and Workspace sections appear with their shortcuts