### PR TITLE
Fix notification showing 'Terminal' instead of OSC title

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -6,7 +6,7 @@ import { notificationStore } from '../state/notification-store';
 import { playNotificationSound } from '../services/notification-sound';
 import { quotePath } from '../utils/quote-path';
 import { WorkspaceSidebar } from './WorkspaceSidebar';
-import { TabBar } from './TabBar';
+import { TabBar, getDisplayName } from './TabBar';
 import { TerminalPane } from './TerminalPane';
 import { ToastContainer } from './ToastContainer';
 
@@ -999,7 +999,7 @@ export class App {
 
         // Show in-app toast (always, regardless of focus)
         const terminal = state.terminals.find(t => t.id === terminal_id);
-        const toastTitle = terminal?.name || 'Terminal';
+        const toastTitle = terminal ? getDisplayName(terminal) : 'Terminal';
         this.toastContainer.show(toastTitle, message || 'New notification', terminal_id);
 
         // Flash taskbar icon orange
@@ -1018,7 +1018,7 @@ export class App {
             }
             if (permitted) {
               const terminal = state.terminals.find(t => t.id === terminal_id);
-              const title = terminal?.name || 'Godly Terminal';
+              const title = terminal ? getDisplayName(terminal) : 'Godly Terminal';
               sendNotification({
                 title,
                 body: message || 'New notification',


### PR DESCRIPTION
## Summary
- Notifications (both in-app toast and native Windows notification) were using `terminal.name` directly, which is always the hardcoded default `"Terminal"`
- Changed both notification paths to use `getDisplayName(terminal)`, which respects `oscTitle` set by Claude Code via OSC escape sequences (`\x1b]0;title\x07`)
- This matches the same display logic already used by the tab bar

## Test plan
- [x] All 197 frontend tests pass
- [x] Production build succeeds
- [ ] Manual: trigger a notification from a terminal where Claude Code has set an OSC title — toast and native notification should show the OSC title, not "Terminal"