### PR TITLE
fix: drag-drop overlay stuck after dropping file onto terminal

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -865,6 +865,15 @@ export class App {
       this.terminalContainer.classList.add('drag-file-over');
     });
 
+    this.terminalContainer.addEventListener('dragover', (e) => {
+      // Must preventDefault on dragover to allow the drop event to fire.
+      // Without this, the browser refuses the drop and our cleanup in the
+      // drop handler never runs, leaving the overlay stuck.
+      if (!e.dataTransfer?.types.includes('Files')) return;
+      e.preventDefault();
+      e.dataTransfer!.dropEffect = 'copy';
+    });
+
     this.terminalContainer.addEventListener('dragleave', (e) => {
       if (!e.dataTransfer?.types.includes('Files')) return;
       dragCounter--;
@@ -886,6 +895,13 @@ export class App {
       const names = Array.from(e.dataTransfer.files).map(f => f.name);
       const text = names.map(quotePath).join(' ');
       terminalService.writeToTerminal(state.activeTerminalId, text);
+    });
+
+    // Safety net: if a file drag ends without a clean drop (e.g. dropped
+    // outside the window, or Escape pressed), clear the overlay.
+    document.addEventListener('dragend', () => {
+      dragCounter = 0;
+      this.terminalContainer.classList.remove('drag-file-over');
     });
   }
 


### PR DESCRIPTION
## Summary

- The file drag overlay (blue dashed border) got permanently stuck on the terminal container after dragging an image file, affecting all terminals
- **Root cause**: The split zone `dragover` handler returned early for file drags without calling `preventDefault()`, so the browser refused the drop and the `drop` event never fired — meaning the cleanup code that removes the `drag-file-over` class never ran
- Added a `dragover` handler for file drags that calls `preventDefault()` to allow the drop event to fire
- Added a `dragend` safety net on the document to clear the overlay if the drag ends abnormally (dropped outside window, Escape pressed)

## Test plan

- [ ] Drag an image file from Explorer onto a terminal — overlay should appear during drag, disappear on drop, filename gets pasted
- [ ] Drag a file and drop it outside the terminal window — overlay should disappear
- [ ] Drag a file and press Escape — overlay should disappear
- [ ] Tab drag-to-reorder and split drop zones still work correctly (no regression)