### PR TITLE
fix: paste full file paths on drag-drop instead of filenames

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "fullscreen": false,
         "decorations": true,
         "transparent": false,
-        "dragDropEnabled": false,
+        "dragDropEnabled": true,
         "additionalBrowserArgs": "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --remote-debugging-port=9222"
       }
     ],


### PR DESCRIPTION
## Summary

- Enable Tauri's native drag-drop (`dragDropEnabled: true`) so the OS IDropTarget provides full file system paths
- Replace HTML5 File API drop handler with Tauri's `onDragDropEvent` from `@tauri-apps/api/webviewWindow`
- Dropping a file from Explorer/ShareX now pastes the full path (e.g., `C:\Users\...\screenshot.png`) instead of just the filename

## Context

WebView2's HTML5 File API doesn't expose `File.path` for security reasons. With `dragDropEnabled: false`, we were forced to use `File.name`, which pastes only the filename into the terminal — useless for commands.

Internal HTML5 DnD (tab reordering, workspace drag, split zones) should be unaffected since Chromium handles intra-webview drags internally without going through the OS drop target.

## Test plan

- [ ] Drag a file from Explorer/ShareX into the terminal — verify full path is pasted
- [ ] Drag a file with spaces in the path — verify it's quoted
- [ ] Drag multiple files — verify all paths are pasted space-separated
- [ ] Drag a tab to reorder — verify tab reordering still works
- [ ] Drag a tab to sidebar workspace — verify cross-workspace move still works
- [ ] Drag a tab to terminal edges — verify split view still works
- [ ] Drag a workspace in sidebar to reorder — verify reordering still works