### PR TITLE
fix: eliminate output flood bottleneck causing terminal slowdown

### DIFF
--- a/docs/output-flood-slowdown.md
+++ b/docs/output-flood-slowdown.md
@@ -1,0 +1,50 @@
+# Output Flood Slowdown
+
+## Issue
+
+Terminal becomes extremely slow when pasting rapid-output commands like:
+```powershell
+while($true) { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaas{}
+```
+
+## Root Cause
+
+Three compounding issues in the output pipeline:
+
+### 1. Useless data serialization in terminal-output events (PRIMARY)
+
+Every PTY output chunk (up to 65KB binary) was being serialized as a JSON number array in the `terminal-output` Tauri event. A 65KB binary payload becomes ~260KB of JSON (each byte → number + comma). Under sustained output (hundreds of chunks/second), this created **megabytes/second of JSON serialization overhead**.
+
+The frontend **never used this data** — it only used the event as a notification signal to fetch a grid snapshot via IPC.
+
+### 2. No event coalescing in the emitter thread
+
+The emitter thread called `app_handle.emit()` for every single output event with no deduplication. Under sustained output, this flooded the Tauri event system with thousands of events per second, all carrying the same message: "terminal X has new output".
+
+### 3. No minimum interval between snapshot fetches
+
+The frontend used `setTimeout(0)` to coalesce snapshot requests, but this only collapsed events within a single microtask. Under sustained output, the fetch→render→fetch cycle ran as fast as IPC allowed (~12fps at 85ms round-trip), with no frame budget enforcement.
+
+## Fix
+
+### Layer 1: Remove data from terminal-output events
+- `EmitPayload::TerminalOutput` no longer carries a `data: Vec<u8>` field
+- The JSON payload shrinks from ~260KB to ~50 bytes per event
+- Frontend type and listener updated to match
+
+### Layer 2: Event coalescing in the emitter thread
+- After receiving an event, the emitter drains all immediately-available events
+- Multiple `TerminalOutput` events for the same terminal are collapsed into one emit
+- Non-output events (closed, process-changed) are preserved in order
+
+### Layer 3: Frontend snapshot interval cap (60fps)
+- `scheduleSnapshotFetch()` uses `setTimeout(16)` instead of `setTimeout(0)`
+- Under sustained output, snapshot fetches are capped at ~60fps
+- Combined with `snapshotPending` guard, actual rate is `min(60fps, 1/IPC_round_trip)`
+
+## Files Changed
+
+- `src-tauri/src/daemon_client/bridge.rs` — EmitPayload, emitter coalescing
+- `src-tauri/src/daemon_client/client.rs` — Buffer replay emit
+- `src/services/terminal-service.ts` — Remove data from listener type
+- `src/components/TerminalPane.ts` — Snapshot interval cap

--- a/src-tauri/src/daemon_client/client.rs
+++ b/src-tauri/src/daemon_client/client.rs
@@ -488,12 +488,11 @@ impl DaemonClient {
                 session_id: session_id.clone(),
             };
             match self.try_send_request(&req) {
-                Ok(Response::Buffer { session_id, data }) => {
-                    // Emit buffered output through the non-blocking emitter
+                Ok(Response::Buffer { session_id, .. }) => {
+                    // Emit output notification (data is fetched via snapshot IPC)
                     if let Some(ref em) = emitter {
                         em.try_send(EmitPayload::TerminalOutput {
                             terminal_id: session_id.clone(),
-                            data,
                         });
                     } else {
                         // Fallback to direct emit if emitter not yet available
@@ -501,7 +500,6 @@ impl DaemonClient {
                             "terminal-output",
                             serde_json::json!({
                                 "terminal_id": session_id,
-                                "data": data,
                             }),
                         );
                     }

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -22,8 +22,10 @@ export class TerminalPane {
   private unsubscribeOutput: (() => void) | null = null;
 
   // Debounce grid snapshot requests: on terminal-output we schedule a snapshot
-  // fetch via setTimeout(0). Multiple output events within the same frame
-  // collapse into a single IPC call.
+  // fetch via setTimeout(SNAPSHOT_MIN_INTERVAL_MS). Multiple output events
+  // within the interval collapse into a single IPC call, capping snapshot
+  // fetches to ~60fps under sustained output.
+  private static readonly SNAPSHOT_MIN_INTERVAL_MS = 16;
   private snapshotPending = false;
   private snapshotTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -311,7 +313,7 @@ export class TerminalPane {
           // IPC requests that saturate the Tauri thread pool.
           this.snapshotPending = false;
         }
-      }, 0);
+      }, TerminalPane.SNAPSHOT_MIN_INTERVAL_MS);
     }
   }
 

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -17,7 +17,6 @@ function toBackendShellType(shellType: ShellType): BackendShellType {
 
 export interface TerminalOutputPayload {
   terminal_id: string;
-  data: number[];
 }
 
 export interface ProcessChangedPayload {
@@ -49,17 +48,17 @@ export interface SessionInfo {
 }
 
 class TerminalService {
-  private outputListeners: Map<string, (data: Uint8Array) => void> = new Map();
+  private outputListeners: Map<string, () => void> = new Map();
   private unlistenFns: UnlistenFn[] = [];
 
   async init() {
     const unlistenOutput = await listen<TerminalOutputPayload>(
       'terminal-output',
       (event) => {
-        const { terminal_id, data } = event.payload;
+        const { terminal_id } = event.payload;
         const listener = this.outputListeners.get(terminal_id);
         if (listener) {
-          listener(new Uint8Array(data));
+          listener();
         }
       }
     );
@@ -164,7 +163,7 @@ class TerminalService {
     await invoke('set_scrollback', { terminalId, offset });
   }
 
-  onTerminalOutput(terminalId: string, callback: (data: Uint8Array) => void) {
+  onTerminalOutput(terminalId: string, callback: () => void) {
     this.outputListeners.set(terminalId, callback);
     return () => this.outputListeners.delete(terminalId);
   }


### PR DESCRIPTION
## Summary

- **Remove data from terminal-output events**: The frontend never used the output data payload (it fetches grid snapshots via IPC). Each 65KB binary chunk was being serialized as ~260KB of JSON for nothing, creating MB/s of wasted serialization under sustained output.
- **Add event coalescing in the emitter thread**: Multiple `TerminalOutput` events for the same terminal are now collapsed into a single Tauri emit per drain cycle, preventing event system flooding.
- **Cap snapshot fetches at ~60fps**: Changed `setTimeout(0)` to `setTimeout(16)` in the frontend snapshot scheduler, enforcing a minimum interval between IPC round-trips.

## Test plan

- [x] All Rust tests pass (`cargo test -p godly-protocol`, `-p godly-daemon`, `-p godly-terminal`)
- [x] All frontend tests pass (`npm test` — 238 tests)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual test: paste `while($true) { "aaaa...s{}" }` — terminal should remain responsive
- [ ] Manual test: normal typing latency should not regress
- [ ] Manual test: terminal-closed and process-changed events still work correctly