### PR TITLE
style: Tokyo Night visual redesign

### DIFF
--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -97,27 +97,27 @@ export interface TerminalTheme {
 }
 
 export const DEFAULT_THEME: TerminalTheme = {
-  background: '#1e1e1e',
-  foreground: '#cccccc',
-  cursor: '#aeafad',
-  cursorAccent: '#1e1e1e',
-  selectionBackground: '#264f78',
-  black: '#000000',
-  red: '#cd3131',
-  green: '#0dbc79',
-  yellow: '#e5e510',
-  blue: '#2472c8',
-  magenta: '#bc3fbc',
-  cyan: '#11a8cd',
-  white: '#e5e5e5',
-  brightBlack: '#666666',
-  brightRed: '#f14c4c',
-  brightGreen: '#23d18b',
-  brightYellow: '#f5f543',
-  brightBlue: '#3b8eea',
-  brightMagenta: '#d670d6',
-  brightCyan: '#29b8db',
-  brightWhite: '#e5e5e5',
+  background: '#1a1b26',
+  foreground: '#c0caf5',
+  cursor: '#c0caf5',
+  cursorAccent: '#1a1b26',
+  selectionBackground: '#283457',
+  black: '#15161e',
+  red: '#f7768e',
+  green: '#9ece6a',
+  yellow: '#e0af68',
+  blue: '#7aa2f7',
+  magenta: '#bb9af7',
+  cyan: '#7dcfff',
+  white: '#a9b1d6',
+  brightBlack: '#414868',
+  brightRed: '#f7768e',
+  brightGreen: '#9ece6a',
+  brightYellow: '#e0af68',
+  brightBlue: '#7aa2f7',
+  brightMagenta: '#bb9af7',
+  brightCyan: '#7dcfff',
+  brightWhite: '#c0caf5',
 };
 
 // ---- Selection state ----
@@ -149,7 +149,7 @@ export class TerminalRenderer {
 
   // Font metrics
   private fontFamily = 'Cascadia Code, Consolas, monospace';
-  private fontSize = 14;
+  private fontSize = 13;
   private cellWidth = 0;
   private cellHeight = 0;
   private baselineOffset = 0;

--- a/src/components/renderer/CellDataEncoder.test.ts
+++ b/src/components/renderer/CellDataEncoder.test.ts
@@ -45,10 +45,10 @@ describe('CellDataEncoder', () => {
     const result = encoder.encode(snap, DEFAULT_THEME, stubAtlas, colorCache, null);
 
     expect(result.length).toBe(4); // 1 cell × 4 uint32s
-    // fg = default foreground #cccccc → 0xCCCCCCFF
-    expect(result[0]).toBe(0xCCCCCCFF);
-    // bg = default background #1e1e1e → 0x1E1E1EFF
-    expect(result[1]).toBe(0x1E1E1EFF);
+    // fg = default foreground #c0caf5 → 0xC0CAF5FF
+    expect(result[0]).toBe(0xC0CAF5FF);
+    // bg = default background #1a1b26 → 0x1A1B26FF
+    expect(result[1]).toBe(0x1A1B26FF);
     // Empty space → no atlas entry
     expect(result[2]).toBe(0);
     expect(result[3]).toBe(0);
@@ -152,8 +152,8 @@ describe('CellDataEncoder', () => {
 
     expect(result.length).toBe(8); // 2 cells × 4 uint32s
     // Second row should be default colors with no glyph
-    expect(result[4]).toBe(0xCCCCCCFF);
-    expect(result[5]).toBe(0x1E1E1EFF);
+    expect(result[4]).toBe(0xC0CAF5FF);
+    expect(result[5]).toBe(0x1A1B26FF);
     expect(result[6]).toBe(0);
     expect(result[7]).toBe(0);
   });
@@ -166,6 +166,6 @@ describe('CellDataEncoder', () => {
     const result2 = encoder.encode(snap, DEFAULT_THEME, stubAtlas, colorCache, null);
     // Both should return valid data (buffer is reused internally)
     expect(result1.length).toBe(result2.length);
-    expect(result2[0]).toBe(0xCCCCCCFF);
+    expect(result2[0]).toBe(0xC0CAF5FF);
   });
 });

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,16 +1,16 @@
 :root {
-  --bg-primary: #1e1e1e;
-  --bg-secondary: #252526;
-  --bg-tertiary: #2d2d2d;
-  --bg-active: #37373d;
-  --text-primary: #cccccc;
-  --text-secondary: #969696;
-  --text-active: #ffffff;
-  --accent: #0078d4;
-  --accent-hover: #1e8ad4;
-  --border-color: #3c3c3c;
-  --danger: #f14c4c;
-  --success: #4ec9b0;
+  --bg-primary: #1a1b26;        /* Main background (Tokyo Night) */
+  --bg-secondary: #16161e;      /* Sidebar/tab bar (darker) */
+  --bg-tertiary: #292e42;       /* Hover states */
+  --bg-active: #33467c;         /* Active/focused states */
+  --text-primary: #a9b1d6;      /* Default text */
+  --text-secondary: #565f89;    /* Dimmed text */
+  --text-active: #c0caf5;       /* Bright/active text */
+  --accent: #7aa2f7;            /* Blue accent */
+  --accent-hover: #89b4fa;      /* Lighter blue on hover */
+  --border-color: #292e42;      /* Subtle borders */
+  --danger: #f7768e;            /* Red */
+  --success: #9ece6a;           /* Green */
   --sidebar-width: 200px;
   --tabbar-height: 35px;
 }
@@ -76,7 +76,9 @@ html, body {
 }
 
 .workspace-item.active {
-  background: var(--bg-active);
+  background: transparent;
+  border-left: 2px solid var(--accent);
+  color: var(--text-active);
 }
 
 .workspace-item.dragging {
@@ -192,7 +194,8 @@ html, body {
 
 .tab.active {
   background: var(--bg-primary);
-  border-bottom: 2px solid var(--accent);
+  border-top: 2px solid var(--accent);
+  border-bottom: none;
 }
 
 .tab.in-split {
@@ -272,7 +275,7 @@ html, body {
   inset: 4px;
   border: 2px dashed var(--accent);
   border-radius: 8px;
-  background: rgba(0, 120, 212, 0.08);
+  background: rgba(122, 162, 247, 0.08);
   pointer-events: none;
   z-index: 10;
 }
@@ -344,7 +347,7 @@ html, body {
   position: absolute;
   z-index: 10;
   pointer-events: none;
-  background: rgba(0, 120, 212, 0.1);
+  background: rgba(122, 162, 247, 0.1);
   border: 2px dashed var(--accent);
   display: none;
   align-items: center;
@@ -363,10 +366,11 @@ html, body {
   position: fixed;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: 6px;
   padding: 4px 0;
   min-width: 150px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(8px);
   z-index: 1000;
 }
 
@@ -541,13 +545,13 @@ html, body {
 
 .worktree-toggle.active {
   background: var(--success);
-  color: #1e1e1e;
+  color: #1a1b26;
   border-color: var(--success);
 }
 
 .worktree-toggle.active:hover {
-  background: #3bb89a;
-  border-color: #3bb89a;
+  background: #b9db7a;
+  border-color: #b9db7a;
 }
 
 /* Claude Code toggle button */
@@ -809,7 +813,7 @@ html, body {
 
 /* Scrollbar styling */
 ::-webkit-scrollbar {
-  width: 10px;
+  width: 8px;
 }
 
 ::-webkit-scrollbar-track {
@@ -818,7 +822,7 @@ html, body {
 
 ::-webkit-scrollbar-thumb {
   background: var(--border-color);
-  border-radius: 5px;
+  border-radius: 8px;
 }
 
 ::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
## Summary

- Replace VS Code default dark theme with Tokyo Night color palette across CSS variables and terminal ANSI colors
- Reduce terminal font size from 14px to 13px for cleaner text rendering
- Polish UI: active tab top-border, sidebar left accent bar, context menu backdrop blur, thinner/rounder scrollbars
- Update hardcoded rgba overlay colors to match the new accent blue
- Update CellDataEncoder test assertions to reflect new default theme colors

## Files changed

- `src/styles/main.css` — CSS variables + UI polish
- `src/components/TerminalRenderer.ts` — Terminal theme colors + font size
- `src/components/renderer/CellDataEncoder.test.ts` — Updated color assertions

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 240/243 pass (3 pre-existing failures in tab-switch tests, unrelated)
- [ ] `npm run tauri dev` — visual verification of Tokyo Night palette