### PR TITLE
fix: prevent terminal content erasure when switching tabs

### DIFF
--- a/docs/tab-switch-content-erased.md
+++ b/docs/tab-switch-content-erased.md
@@ -1,0 +1,47 @@
+# Bug: Terminal content erased when switching tabs
+
+## Problem
+
+When switching from one terminal to another in the same workspace, the content of the previously-active terminal is completely erased. Switching back shows a blank terminal.
+
+## Root Cause
+
+Two-part failure:
+
+### 1. Frontend sends degenerate resize (trigger)
+
+When switching tabs, the hidden pane's CSS changes to `display: none` (0x0 dimensions). The `ResizeObserver` fires for the hidden pane, calling `fit()`. Inside `fit()`:
+
+1. `getGridSize()` reads `getBoundingClientRect()` on the hidden container -> `{width: 0, height: 0}`
+2. Grid size is computed as `{rows: 1, cols: 1}` due to `Math.max(1, Math.floor(0 / cellSize))`
+3. `resizeTerminal(terminalId, 1, 1)` is sent to the daemon
+
+### 2. Grid truncation destroys content (data loss)
+
+When the daemon receives `Resize(1, 1)`, `grid.set_size()` physically truncates:
+
+- `row.resize(1, ...)` — each row truncated to 1 column
+- `rows.resize(1, ...)` — all rows except the first are dropped
+
+After the round-trip `24x80 -> 1x1 -> 24x80`, only the letter "L" (first character of the first line) survives.
+
+## Fix
+
+Added a visibility guard at the top of `TerminalPane.fit()`:
+
+```typescript
+if (!this.container.offsetWidth || !this.container.offsetHeight) {
+  return;
+}
+```
+
+`offsetWidth` and `offsetHeight` are 0 for elements with `display: none`, which catches exactly the hidden-pane scenario without affecting normal resize behavior.
+
+## Files Changed
+
+- `src/components/TerminalPane.ts` — added visibility guard in `fit()`
+
+## Tests
+
+- `src/components/TerminalPane.tab-switch.test.ts` — 5 frontend tests verifying the guard
+- `src-tauri/godly-vt/tests/tab_switch_resize.rs` — 5 Rust tests documenting grid truncation behavior

--- a/src-tauri/godly-vt/tests/tab_switch_resize.rs
+++ b/src-tauri/godly-vt/tests/tab_switch_resize.rs
@@ -1,0 +1,120 @@
+/// Tests documenting grid behavior during tab-switch resize scenarios.
+///
+/// Bug: When switching terminal tabs, the hidden pane's container has display:none
+/// (0×0 dimensions). The frontend's fit() method reads 0×0, computes grid size as
+/// 1×1 (clamped by Math.max(1)), and sends Resize(1, 1) to the daemon. This causes
+/// the godly-vt grid to be physically truncated to 1 row × 1 column, destroying
+/// all content.
+///
+/// Fix: The frontend's fit() guards against hidden containers by checking
+/// offsetWidth/offsetHeight before sending resize. These tests verify:
+/// 1. The grid DOES lose content on 1×1 resize (confirming the guard is needed)
+/// 2. The grid preserves content for reasonable resize scenarios
+
+/// Helper: create a parser with a specific grid size.
+fn parser_with_size(rows: u16, cols: u16) -> godly_vt::Parser {
+    let mut parser = godly_vt::Parser::new(rows, cols, 0);
+    parser.process(b""); // ensure rows are allocated
+    parser
+}
+
+/// Helper: write several lines of text to the parser.
+fn write_multiline_content(parser: &mut godly_vt::Parser) {
+    parser.process(b"Line 1: Hello World\r\n");
+    parser.process(b"Line 2: Cargo build\r\n");
+    parser.process(b"Line 3: npm install\r\n");
+    parser.process(b"Line 4: git status\r\n");
+    parser.process(b"Line 5: test output");
+}
+
+// ── Tests confirming why the frontend guard is necessary ─────────────
+
+#[test]
+fn resize_to_1x1_destroys_content() {
+    // Confirms that the grid physically truncates to 1×1, losing all content.
+    // This is WHY the frontend must guard against sending resize(1,1) to the
+    // daemon when a pane is hidden.
+    let mut parser = parser_with_size(24, 80);
+    write_multiline_content(&mut parser);
+
+    let before = parser.screen().contents();
+    assert!(before.contains("Line 1: Hello World"));
+
+    // Simulate what happens when the daemon receives resize(1, 1)
+    parser.screen_mut().set_size(1, 1);
+
+    let after = parser.screen().contents();
+    // Only the first character survives (grid truncated to 1 cell)
+    assert_eq!(after.trim(), "L", "Grid truncated to 1×1 keeps only first char");
+}
+
+#[test]
+fn resize_round_trip_1x1_loses_all_lines() {
+    // After 24×80 → 1×1 → 24×80, all lines except partial first are gone.
+    // This confirms the data loss is permanent and irreversible.
+    let mut parser = parser_with_size(24, 80);
+    write_multiline_content(&mut parser);
+
+    parser.screen_mut().set_size(1, 1);
+    parser.screen_mut().set_size(24, 80);
+
+    let contents = parser.screen().contents();
+    let non_empty: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+
+    // Only 1 line remains (with just "L" padded by spaces from resize)
+    assert_eq!(
+        non_empty.len(), 1,
+        "Only 1 partial line survives 1×1 round-trip; got: {:?}", non_empty
+    );
+    assert!(
+        !contents.contains("Hello World"),
+        "Full text is gone after 1×1 round-trip"
+    );
+}
+
+// ── Tests confirming content survives reasonable resize ──────────────
+
+#[test]
+fn content_survives_moderate_shrink_and_expand() {
+    // Resizing to a smaller-but-reasonable size preserves visible rows.
+    let mut parser = parser_with_size(24, 80);
+    write_multiline_content(&mut parser);
+
+    // Shrink to 5 rows × 20 cols — first 5 rows survive
+    parser.screen_mut().set_size(5, 20);
+    parser.screen_mut().set_size(24, 80);
+
+    let contents = parser.screen().contents();
+    assert!(
+        contents.contains("Line 1"),
+        "First line should survive moderate resize. Got: {:?}", contents
+    );
+}
+
+#[test]
+fn same_size_resize_preserves_all_content() {
+    // Resizing to the same dimensions must not lose any content.
+    // This is what happens when the frontend sends resize with unchanged dimensions.
+    let mut parser = parser_with_size(24, 80);
+    write_multiline_content(&mut parser);
+
+    let before = parser.screen().contents();
+
+    // Same-size resize (e.g., tab switch where pane dimensions haven't changed)
+    parser.screen_mut().set_size(24, 80);
+
+    let after = parser.screen().contents();
+    assert_eq!(before, after, "Same-size resize must not alter content");
+}
+
+#[test]
+fn grid_dimensions_restored_after_round_trip() {
+    let mut parser = parser_with_size(24, 80);
+    write_multiline_content(&mut parser);
+
+    parser.screen_mut().set_size(1, 1);
+    assert_eq!(parser.screen().size(), (1, 1));
+
+    parser.screen_mut().set_size(24, 80);
+    assert_eq!(parser.screen().size(), (24, 80), "Dimensions restored correctly");
+}

--- a/src/components/TerminalPane.tab-switch.test.ts
+++ b/src/components/TerminalPane.tab-switch.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for terminal content preservation when switching tabs.
+ *
+ * Bug: When switching from one terminal to another in the same workspace, the
+ * content of the previously-active terminal is completely erased. This happens
+ * because:
+ *
+ * 1. The hidden pane's container goes to display:none (0×0 dimensions)
+ * 2. The ResizeObserver fires for the hidden pane → fit() is called
+ * 3. fit() calls renderer.getGridSize() which reads getBoundingClientRect()
+ *    on the hidden container → rect is {width:0, height:0}
+ * 4. getGridSize() returns {rows:1, cols:1} (Math.max(1, 0) = 1)
+ * 5. fit() sends resizeTerminal(terminalId, 1, 1) to the daemon
+ * 6. Daemon's godly-vt grid is physically truncated to 1×1 → content destroyed
+ * 7. When user switches back, the grid is resized to correct dimensions but
+ *    the content is gone forever.
+ *
+ * Expected behavior: fit() should NOT send a resize when the container is hidden
+ * (has zero or degenerate dimensions). Specifically, it should guard against
+ * sending resize with rows ≤ 1 or cols ≤ 1 when those values result from a
+ * hidden container, not an intentionally tiny terminal.
+ */
+
+// ── Simulator mirroring TerminalPane.fit() and getGridSize() logic ──────
+
+interface GridSize {
+  rows: number;
+  cols: number;
+}
+
+interface CachedSnapshot {
+  dimensions: GridSize;
+}
+
+const mockResizeTerminal = vi.fn();
+const mockUpdateSize = vi.fn();
+
+/**
+ * Simulates the fit() + getGridSize() logic from TerminalPane and
+ * TerminalRenderer, allowing us to control container dimensions.
+ */
+class FitSimulator {
+  terminalId: string;
+  cachedSnapshot: CachedSnapshot | null = null;
+
+  // Simulated container dimensions (what getBoundingClientRect() returns)
+  containerWidth = 800;
+  containerHeight = 600;
+
+  // Cell metrics (matching TerminalRenderer defaults)
+  cellWidth = 8.4; // approx for 14px Cascadia Code
+  cellHeight = 16.8;
+  devicePixelRatio = 1;
+
+  constructor(terminalId: string) {
+    this.terminalId = terminalId;
+  }
+
+  /** Mirror of TerminalRenderer.getGridSize() */
+  getGridSize(): GridSize {
+    if (this.cellWidth === 0 || this.cellHeight === 0) {
+      return { rows: 24, cols: 80 };
+    }
+    const rows = Math.max(
+      1,
+      Math.floor(
+        this.containerHeight / (this.cellHeight / this.devicePixelRatio)
+      )
+    );
+    const cols = Math.max(
+      1,
+      Math.floor(
+        this.containerWidth / (this.cellWidth / this.devicePixelRatio)
+      )
+    );
+    return { rows, cols };
+  }
+
+  /** Mirror of TerminalPane.fit() — must match the source in TerminalPane.ts */
+  fit() {
+    // Guard: skip resize when container is hidden (display:none).
+    // Mirrors the offsetWidth/offsetHeight check in TerminalPane.fit().
+    if (!this.containerWidth || !this.containerHeight) {
+      return;
+    }
+    mockUpdateSize();
+    const { rows, cols } = this.getGridSize();
+    if (rows > 0 && cols > 0) {
+      // Invalidate cache if dimensions changed
+      if (
+        this.cachedSnapshot &&
+        (this.cachedSnapshot.dimensions.rows !== rows ||
+          this.cachedSnapshot.dimensions.cols !== cols)
+      ) {
+        this.cachedSnapshot = null;
+      }
+      mockResizeTerminal(this.terminalId, rows, cols);
+    }
+  }
+
+  /** Simulate the container going to display:none (hidden). */
+  simulateHidden() {
+    this.containerWidth = 0;
+    this.containerHeight = 0;
+  }
+
+  /** Simulate the container becoming visible with normal size. */
+  simulateVisible(width = 800, height = 600) {
+    this.containerWidth = width;
+    this.containerHeight = height;
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('Terminal tab switch: resize guard against hidden containers', () => {
+  beforeEach(() => {
+    mockResizeTerminal.mockReset();
+    mockUpdateSize.mockReset();
+  });
+
+  it('should NOT resize terminal to 1×1 when container is hidden', () => {
+    // Bug: When the terminal pane is hidden (display:none), fit() computes
+    // grid size as 1×1 and sends this to the daemon, which truncates the
+    // grid and destroys all terminal content.
+    const sim = new FitSimulator('terminal-A');
+    sim.cachedSnapshot = { dimensions: { rows: 24, cols: 80 } };
+
+    // Pane goes hidden (user switches to another tab)
+    sim.simulateHidden();
+    sim.fit();
+
+    // Verify that resizeTerminal was NOT called with degenerate 1×1 dimensions.
+    // The current buggy code DOES call it with (1, 1), which is why this test fails.
+    const calls = mockResizeTerminal.mock.calls;
+    const sentDegenerate = calls.some(
+      ([_id, rows, cols]: [string, number, number]) => rows <= 1 && cols <= 1
+    );
+    expect(sentDegenerate).toBe(false);
+  });
+
+  it('hidden pane computes grid size as 1×1', () => {
+    // Verifies the root cause: getGridSize() returns {1,1} for hidden containers.
+    // This is NOT the expected behavior — it's what triggers the bug.
+    const sim = new FitSimulator('terminal-A');
+    sim.simulateHidden();
+    const size = sim.getGridSize();
+
+    // When container is hidden, the computed grid size is {1, 1} due to
+    // Math.max(1, Math.floor(0 / ...)) = Math.max(1, 0) = 1
+    // This degenerate size should NOT be sent to the daemon.
+    expect(size.rows).toBe(1);
+    expect(size.cols).toBe(1);
+  });
+
+  it('visible pane computes reasonable grid size', () => {
+    const sim = new FitSimulator('terminal-A');
+    sim.simulateVisible(800, 600);
+    const size = sim.getGridSize();
+
+    expect(size.rows).toBeGreaterThan(10);
+    expect(size.cols).toBeGreaterThan(40);
+  });
+
+  it('full tab switch cycle should not send degenerate resize for either terminal', () => {
+    // Simulates full tab switch: Terminal A → Terminal B
+    // Step 1: Both terminals start visible (A active, B hidden)
+    const simA = new FitSimulator('terminal-A');
+    const simB = new FitSimulator('terminal-B');
+    simA.cachedSnapshot = { dimensions: { rows: 35, cols: 95 } };
+    simB.cachedSnapshot = { dimensions: { rows: 35, cols: 95 } };
+
+    // Step 2: User switches to Terminal B
+    // A becomes hidden, B becomes visible
+    simA.simulateHidden();
+    simB.simulateVisible();
+
+    // ResizeObserver fires for A (now hidden) → fit() called on A
+    simA.fit();
+    // setActive(true) fires for B → fit() called on B
+    simB.fit();
+
+    // Step 3: Verify NO degenerate resize was sent for terminal A
+    const callsForA = mockResizeTerminal.mock.calls.filter(
+      ([id]: [string]) => id === 'terminal-A'
+    );
+    for (const [id, rows, cols] of callsForA) {
+      expect(
+        rows > 1 || cols > 1,
+        `Terminal A should not be resized to ${rows}×${cols} (degenerate). ` +
+        `This destroys all terminal content in the daemon's grid.`
+      ).toBe(true);
+    }
+  });
+
+  it('switching back to a previously hidden terminal preserves snapshot cache', () => {
+    // When switching back, the cached snapshot should still be available
+    // so the terminal can render immediately while the fresh snapshot loads.
+    const sim = new FitSimulator('terminal-A');
+    sim.cachedSnapshot = { dimensions: { rows: 35, cols: 95 } };
+
+    // Hide the terminal (tab switch away)
+    sim.simulateHidden();
+    sim.fit();
+
+    // The cached snapshot should NOT be invalidated just because the pane
+    // was hidden. If fit() sends resize(1,1), it would also null out the
+    // cache (since 1≠35 and 1≠95), losing the ability to render immediately.
+    expect(sim.cachedSnapshot).not.toBeNull();
+  });
+});

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -438,6 +438,13 @@ export class TerminalPane {
 
   fit() {
     try {
+      // Guard: skip resize when container is hidden (display:none).
+      // Hidden containers have 0×0 dimensions, causing getGridSize() to
+      // return 1×1. Sending resize(1,1) to the daemon truncates the
+      // godly-vt grid and permanently destroys all terminal content.
+      if (!this.container.offsetWidth || !this.container.offsetHeight) {
+        return;
+      }
       this.renderer.updateSize();
       const { rows, cols } = this.renderer.getGridSize();
       if (rows > 0 && cols > 0) {


### PR DESCRIPTION
## Summary

- Fixed bug where switching terminal tabs erased all content in the previously-active terminal
- Root cause: hidden panes (`display:none`) trigger `ResizeObserver` with 0×0 dimensions, causing `fit()` to send `resize(1,1)` to the daemon — truncating the godly-vt grid to a single cell
- Added visibility guard (`offsetWidth`/`offsetHeight` check) in `fit()` to skip resize when the container is hidden

## Test plan

- [ ] Run `npx vitest run src/components/TerminalPane.tab-switch.test.ts` — 5 tests verifying the guard
- [ ] Run `cd src-tauri && cargo test -p godly-vt --test tab_switch_resize` — 5 tests documenting grid behavior
- [ ] Manual: open 2+ terminals, type content in each, switch between tabs — content should persist