### PR TITLE
fix: redirect stderr to NUL after FreeConsole to prevent daemon hang

### DIFF
--- a/docs/wmi-daemon-stderr-panic.md
+++ b/docs/wmi-daemon-stderr-panic.md
@@ -1,0 +1,39 @@
+# WMI Daemon stderr Panic (test_04 hang)
+
+## Symptom
+`test_04_wmi_launch_escapes_job_object` hangs indefinitely (60+ seconds) on iteration 2+.
+The daemon reads a Ping request but never sends a Pong response.
+
+## Root Cause
+
+When the daemon is launched via WMI (`Win32_Process.Create`), it runs without a console.
+The daemon calls `FreeConsole()` which invalidates stderr/stdout handles. Any subsequent
+`eprintln!()` call panics with `ERROR_NO_DATA` (error 232: "The pipe is being closed").
+
+The panic occurs in `handle_client()` at the `eprintln!("[daemon] Entering request loop for client")` line, killing the async handler before it can process any requests.
+
+### Why it hangs instead of failing
+
+The `io_thread` detects `resp_rx` channel disconnection (since the async handler died),
+but only `break`s out of the inner response-reading loop instead of stopping the outer
+polling loop. So the io_thread keeps running forever, the pipe stays open, and the test
+client blocks on `read_message()` waiting for a response that will never come.
+
+### Why iteration 1 usually works
+
+Iteration 1 succeeds because the daemon process was freshly launched via WMI and the
+`eprintln!` calls happen before `FreeConsole()` has fully invalidated the handles.
+The timing is OS-dependent, which makes this flaky.
+
+## Fix
+
+1. **`daemon/src/main.rs`**: After `FreeConsole()`, redirect stdout/stderr to NUL using
+   `SetStdHandle()`. This makes `eprintln!` silently discard output instead of panicking.
+
+2. **`daemon/src/server.rs`**: When `resp_rx` disconnects in the io_thread, set
+   `io_running = false` to stop the io_thread. This is a defense-in-depth fix so that
+   even if the async handler dies for any reason, the io_thread won't hang forever.
+
+## Verification
+
+All 50 daemon tests pass, including 3 iterations of `test_04_wmi_launch_escapes_job_object`.

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -604,8 +604,11 @@ fn io_thread(
                 }
                 Err(mpsc::error::TryRecvError::Empty) => break,
                 Err(mpsc::error::TryRecvError::Disconnected) => {
-                    // Response channel closed — handler loop exited
-                    daemon_log!("Response channel disconnected");
+                    // Response channel closed — async handler died (possibly from
+                    // an eprintln! panic when running without a console).
+                    // Stop the io_thread so the client gets EOF instead of hanging.
+                    daemon_log!("Response channel disconnected, stopping io_thread");
+                    io_running.store(false, Ordering::Relaxed);
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

- When the daemon is launched via WMI (`Win32_Process.Create`), `FreeConsole()` invalidates stderr handles. Subsequent `eprintln!` calls panic with `ERROR_NO_DATA` (232), killing the async request handler while the io_thread keeps running — causing clients to hang indefinitely waiting for responses.
- Redirects stdout/stderr to NUL after `FreeConsole()` so print macros silently discard output instead of panicking
- Fixes io_thread to stop when the response channel disconnects (defense-in-depth: if the async handler dies for any reason, the io_thread won't hang forever)

## Test plan

- [x] `cargo test -p godly-daemon --test session_persistence` — all 3 tests pass, including `test_04_wmi_launch_escapes_job_object` (3 iterations, was hanging on iteration 2+)
- [x] `cargo test -p godly-daemon` — all 50 daemon tests pass
- [x] `cargo test -p godly-protocol` — 23 tests pass
- [x] `npm test` — 243 frontend tests pass
- [x] `npm run build` — production build succeeds