### PR TITLE
feat: theme system with settings UI and eye-saver theme

### DIFF
--- a/src/components/ThemePreview.ts
+++ b/src/components/ThemePreview.ts
@@ -1,0 +1,94 @@
+/**
+ * Self-contained mini terminal preview rendered onto a canvas.
+ * Shows how a theme's terminal colors look in a realistic layout.
+ */
+
+import type { ThemeDefinition } from '../themes/types';
+
+/**
+ * Create a canvas element that draws a miniature terminal preview
+ * using the given theme's terminal color palette.
+ */
+export function createThemePreview(
+  theme: ThemeDefinition,
+  width: number,
+  height: number,
+): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return canvas;
+
+  const t = theme.terminal;
+  const font = "11px 'Cascadia Code', Consolas, monospace";
+  const lineHeight = 16;
+  const startX = 8;
+  let y = 16;
+
+  // Background fill
+  ctx.fillStyle = t.background;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.font = font;
+  ctx.textBaseline = 'alphabetic';
+
+  // Line 1:  $ git status
+  drawSegments(ctx, startX, y, [
+    { text: '$', color: t.green },
+    { text: ' git status', color: t.foreground },
+  ]);
+  y += lineHeight;
+
+  // Line 2:  On branch main
+  drawSegments(ctx, startX, y, [
+    { text: 'On branch ', color: t.foreground },
+    { text: 'main', color: t.cyan },
+  ]);
+  y += lineHeight;
+
+  // Line 3:  Changes:
+  drawSegments(ctx, startX, y, [
+    { text: 'Changes:', color: t.yellow },
+  ]);
+  y += lineHeight;
+
+  // Line 4:    modified: src/app.ts
+  drawSegments(ctx, startX, y, [
+    { text: '  modified: ', color: t.foreground },
+    { text: 'src/app.ts', color: t.red },
+  ]);
+  y += lineHeight;
+
+  // Line 5:  $ + cursor block
+  const dollarWidth = drawSegments(ctx, startX, y, [
+    { text: '$ ', color: t.green },
+  ]);
+  // Draw cursor block
+  ctx.fillStyle = t.cursor;
+  ctx.fillRect(startX + dollarWidth, y - 10, 7, 13);
+
+  return canvas;
+}
+
+interface TextSegment {
+  text: string;
+  color: string;
+}
+
+/** Draw text segments sequentially, returning the total width drawn. */
+function drawSegments(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  segments: TextSegment[],
+): number {
+  let offsetX = 0;
+  for (const seg of segments) {
+    ctx.fillStyle = seg.color;
+    ctx.fillText(seg.text, x + offsetX, y);
+    offsetX += ctx.measureText(seg.text).width;
+  }
+  return offsetX;
+}

--- a/src/state/theme-store.ts
+++ b/src/state/theme-store.ts
@@ -1,0 +1,131 @@
+import type { ThemeDefinition, TerminalTheme, UiTheme } from '../themes/types';
+import { BUILTIN_THEMES, TOKYO_NIGHT } from '../themes/builtin';
+
+const STORAGE_KEY = 'godly-theme-settings';
+
+interface ThemeSettings {
+  activeThemeId: string;
+  customThemes: ThemeDefinition[];
+}
+
+type Subscriber = () => void;
+
+class ThemeStore {
+  private activeThemeId: string = 'tokyo-night';
+  private customThemes: ThemeDefinition[] = [];
+  private subscribers: Subscriber[] = [];
+
+  constructor() {
+    this.loadFromStorage();
+    this.applyUiTheme();
+  }
+
+  // ── Queries ──────────────────────────────────────────────────────
+
+  getActiveTheme(): ThemeDefinition {
+    const all = this.getAllThemes();
+    return all.find(t => t.id === this.activeThemeId) ?? TOKYO_NIGHT;
+  }
+
+  getTerminalTheme(): TerminalTheme {
+    return this.getActiveTheme().terminal;
+  }
+
+  getUiTheme(): UiTheme {
+    return this.getActiveTheme().ui;
+  }
+
+  getAllThemes(): ThemeDefinition[] {
+    return [...BUILTIN_THEMES, ...this.customThemes];
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────
+
+  setActiveTheme(id: string): void {
+    this.activeThemeId = id;
+    this.saveToStorage();
+    this.applyUiTheme();
+    this.notify();
+  }
+
+  addCustomTheme(theme: ThemeDefinition): void {
+    this.customThemes.push(theme);
+    this.saveToStorage();
+    this.notify();
+  }
+
+  removeCustomTheme(id: string): void {
+    const isBuiltin = BUILTIN_THEMES.some(t => t.id === id);
+    if (isBuiltin) return;
+    this.customThemes = this.customThemes.filter(t => t.id !== id);
+    if (this.activeThemeId === id) {
+      this.activeThemeId = 'tokyo-night';
+      this.applyUiTheme();
+    }
+    this.saveToStorage();
+    this.notify();
+  }
+
+  // ── Subscriptions ────────────────────────────────────────────────
+
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.push(fn);
+    return () => {
+      this.subscribers = this.subscribers.filter(s => s !== fn);
+    };
+  }
+
+  private notify(): void {
+    for (const fn of this.subscribers) fn();
+  }
+
+  // ── Persistence ──────────────────────────────────────────────────
+
+  private loadFromStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw) as Partial<ThemeSettings>;
+      if (typeof data.activeThemeId === 'string') this.activeThemeId = data.activeThemeId;
+      if (Array.isArray(data.customThemes)) this.customThemes = data.customThemes;
+    } catch {
+      // Corrupt data — use defaults
+    }
+  }
+
+  private saveToStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const data: ThemeSettings = {
+        activeThemeId: this.activeThemeId,
+        customThemes: this.customThemes,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      // No localStorage available
+    }
+  }
+
+  // ── UI theme application ─────────────────────────────────────────
+
+  private applyUiTheme(): void {
+    if (typeof document === 'undefined') return;
+    const ui = this.getUiTheme();
+    const style = document.documentElement.style;
+    style.setProperty('--bg-primary', ui.bgPrimary);
+    style.setProperty('--bg-secondary', ui.bgSecondary);
+    style.setProperty('--bg-tertiary', ui.bgTertiary);
+    style.setProperty('--bg-active', ui.bgActive);
+    style.setProperty('--text-primary', ui.textPrimary);
+    style.setProperty('--text-secondary', ui.textSecondary);
+    style.setProperty('--text-active', ui.textActive);
+    style.setProperty('--accent', ui.accent);
+    style.setProperty('--accent-hover', ui.accentHover);
+    style.setProperty('--border-color', ui.borderColor);
+    style.setProperty('--danger', ui.danger);
+    style.setProperty('--success', ui.success);
+  }
+}
+
+export const themeStore = new ThemeStore();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -848,8 +848,8 @@ html, body {
 
 /* Settings dialog */
 .settings-dialog {
-  max-width: 500px;
-  min-width: 400px;
+  max-width: 640px;
+  min-width: 560px;
   max-height: 80vh;
   overflow-y: auto;
 }
@@ -1239,4 +1239,105 @@ html, body {
 
 @keyframes toast-fade-out {
   to { opacity: 0; transform: translateX(30%); }
+}
+
+/* Settings tabs */
+.settings-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 16px;
+}
+
+.settings-tab {
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border: none;
+  background: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.settings-tab:hover {
+  color: var(--text-primary);
+}
+
+.settings-tab.active {
+  color: var(--text-active);
+  border-bottom-color: var(--accent);
+}
+
+.settings-tab-content {
+  display: none;
+}
+
+.settings-tab-content.active {
+  display: block;
+}
+
+/* Theme grid */
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.theme-card {
+  background: var(--bg-primary);
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.1s;
+}
+
+.theme-card:hover {
+  border-color: var(--text-secondary);
+  transform: translateY(-1px);
+}
+
+.theme-card.active {
+  border-color: var(--accent);
+}
+
+.theme-card canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.theme-card-info {
+  padding: 10px 12px;
+}
+
+.theme-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-active);
+  margin-bottom: 2px;
+}
+
+.theme-card-description {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.theme-card-author {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.theme-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 12px 8px;
+}
+
+.theme-import-btn {
+  margin-top: 8px;
 }

--- a/src/themes/builtin.ts
+++ b/src/themes/builtin.ts
@@ -1,0 +1,98 @@
+/**
+ * Built-in themes that ship with Godly Terminal.
+ */
+
+import type { ThemeDefinition } from './types';
+
+export const TOKYO_NIGHT: ThemeDefinition = {
+  id: 'tokyo-night',
+  name: 'Tokyo Night',
+  description: 'Cool-toned dark theme with vibrant accents',
+  author: 'Godly Terminal',
+  builtin: true,
+  terminal: {
+    background: '#1a1b26',
+    foreground: '#c0caf5',
+    cursor: '#c0caf5',
+    cursorAccent: '#1a1b26',
+    selectionBackground: '#283457',
+    black: '#15161e',
+    red: '#f7768e',
+    green: '#9ece6a',
+    yellow: '#e0af68',
+    blue: '#7aa2f7',
+    magenta: '#bb9af7',
+    cyan: '#7dcfff',
+    white: '#a9b1d6',
+    brightBlack: '#414868',
+    brightRed: '#f7768e',
+    brightGreen: '#9ece6a',
+    brightYellow: '#e0af68',
+    brightBlue: '#7aa2f7',
+    brightMagenta: '#bb9af7',
+    brightCyan: '#7dcfff',
+    brightWhite: '#c0caf5',
+  },
+  ui: {
+    bgPrimary: '#1a1b26',
+    bgSecondary: '#16161e',
+    bgTertiary: '#292e42',
+    bgActive: '#33467c',
+    textPrimary: '#a9b1d6',
+    textSecondary: '#565f89',
+    textActive: '#c0caf5',
+    accent: '#7aa2f7',
+    accentHover: '#89b4fa',
+    borderColor: '#292e42',
+    danger: '#f7768e',
+    success: '#9ece6a',
+  },
+};
+
+export const DUSK: ThemeDefinition = {
+  id: 'dusk',
+  name: 'Dusk',
+  description: 'Warm, low-contrast theme designed for long sessions',
+  author: 'Godly Terminal',
+  builtin: true,
+  terminal: {
+    background: '#1d1f21',
+    foreground: '#c5c0b6',
+    cursor: '#e8a87c',
+    cursorAccent: '#1d1f21',
+    selectionBackground: '#3a3632',
+    black: '#2c2a27',
+    red: '#c27070',
+    green: '#8fad7e',
+    yellow: '#d4a96a',
+    blue: '#7b9bb5',
+    magenta: '#b58b9e',
+    cyan: '#7fb5aa',
+    white: '#c5c0b6',
+    brightBlack: '#5a564f',
+    brightRed: '#d49090',
+    brightGreen: '#a8c49a',
+    brightYellow: '#e0be88',
+    brightBlue: '#96b4cc',
+    brightMagenta: '#caa4b5',
+    brightCyan: '#99ccc2',
+    brightWhite: '#d8d3c9',
+  },
+  ui: {
+    bgPrimary: '#1d1f21',
+    bgSecondary: '#181a1b',
+    bgTertiary: '#2e2b28',
+    bgActive: '#3d3733',
+    textPrimary: '#b0ab9f',
+    textSecondary: '#6b665c',
+    textActive: '#c5c0b6',
+    accent: '#d4a96a',
+    accentHover: '#e0be88',
+    borderColor: '#2e2b28',
+    danger: '#c27070',
+    success: '#8fad7e',
+  },
+};
+
+/** All built-in themes, in display order. */
+export const BUILTIN_THEMES: ThemeDefinition[] = [TOKYO_NIGHT, DUSK];

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Theme type definitions for Godly Terminal.
+ *
+ * Themes control both the terminal ANSI color palette and the surrounding
+ * UI chrome (sidebar, tabs, dialogs). A single ThemeDefinition bundles
+ * both layers so switching themes feels cohesive.
+ */
+
+/** Terminal color palette — the 16 ANSI colors plus cursor/selection. */
+export interface TerminalTheme {
+  background: string;
+  foreground: string;
+  cursor: string;
+  cursorAccent: string;
+  selectionBackground: string;
+  black: string;
+  red: string;
+  green: string;
+  yellow: string;
+  blue: string;
+  magenta: string;
+  cyan: string;
+  white: string;
+  brightBlack: string;
+  brightRed: string;
+  brightGreen: string;
+  brightYellow: string;
+  brightBlue: string;
+  brightMagenta: string;
+  brightCyan: string;
+  brightWhite: string;
+}
+
+/** UI chrome colors derived from (or complementing) the terminal palette. */
+export interface UiTheme {
+  bgPrimary: string;
+  bgSecondary: string;
+  bgTertiary: string;
+  bgActive: string;
+  textPrimary: string;
+  textSecondary: string;
+  textActive: string;
+  accent: string;
+  accentHover: string;
+  borderColor: string;
+  danger: string;
+  success: string;
+}
+
+/** Full theme definition with metadata. */
+export interface ThemeDefinition {
+  /** Machine-readable id (e.g. 'tokyo-night', 'dusk'). Must be unique. */
+  id: string;
+  /** Human-readable name shown in settings UI. */
+  name: string;
+  /** Short description shown below the name. */
+  description: string;
+  /** Author / attribution. */
+  author: string;
+  /** True for themes that ship with the app. User themes are false. */
+  builtin: boolean;
+  /** Terminal ANSI palette. */
+  terminal: TerminalTheme;
+  /** UI chrome colors. */
+  ui: UiTheme;
+}


### PR DESCRIPTION
## Summary

- Adds a complete theme system with two built-in themes: **Tokyo Night** (default) and **Dusk** (warm, low-contrast eye-saver for long sessions)
- Settings dialog now has tabbed navigation (Themes / Notifications / Shortcuts) with canvas-based theme previews
- Users can import custom themes from JSON files at runtime — no rebuild needed
- Theme changes apply instantly to all open terminals and the entire UI chrome

## Architecture

| File | Purpose |
|------|---------|
| `src/themes/types.ts` | `ThemeDefinition`, `TerminalTheme`, `UiTheme` interfaces |
| `src/themes/builtin.ts` | Tokyo Night + Dusk definitions |
| `src/state/theme-store.ts` | Store with localStorage persistence + CSS variable updates |
| `src/components/ThemePreview.ts` | Canvas-based mini terminal preview |
| `src/components/SettingsDialog.ts` | Tabbed settings with theme grid |
| `src/components/TerminalRenderer.ts` | `setTheme()` method, imports from store |
| `src/components/TerminalPane.ts` | Subscribes to theme changes for live updates |

## Custom theme JSON format

```json
{
  "id": "my-theme",
  "name": "My Theme",
  "description": "A custom theme",
  "author": "Me",
  "builtin": false,
  "terminal": { "background": "#1a1b26", "foreground": "#c0caf5", ... },
  "ui": { "bgPrimary": "#1a1b26", "bgSecondary": "#16161e", ... }
}
```

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 249 tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: open Settings, verify Themes tab shows two theme cards with previews
- [ ] Manual: click Dusk theme, verify terminal + UI chrome update instantly
- [ ] Manual: switch back to Tokyo Night, verify restoration
- [ ] Manual: import a custom JSON theme, verify it appears and is selectable
- [ ] Manual: remove a custom theme, verify it disappears
- [ ] Manual: restart app, verify theme selection persists