### PR TITLE
fix: speed up worktree terminal creation

### DIFF
--- a/docs/slow-worktree-creation.md
+++ b/docs/slow-worktree-creation.md
@@ -1,0 +1,26 @@
+# Slow Worktree Terminal Creation
+
+## Symptom
+Creating a new terminal with worktree mode enabled has a noticeable delay (2-10+ seconds depending on network conditions).
+
+## Root Cause
+`create_worktree()` in `src-tauri/src/worktree.rs` called `pull_latest()` which ran `git pull origin <branch>` before creating the worktree. This performed:
+
+1. A full network fetch from the remote
+2. A merge into the local default branch
+
+The merge step was completely unnecessary since the worktree creates a new branch — it only needs up-to-date remote tracking refs, not a merged local branch.
+
+Additionally, `commands/terminal.rs` made two sequential subprocess calls (`is_git_repo` + `get_repo_root`) where one sufficed.
+
+## Fix
+1. **Replaced `git pull` with `git fetch origin <branch> --no-tags`** — eliminates the merge step and `--no-tags` skips tag negotiation overhead.
+2. **Branch worktree from `origin/<branch>` start point** — `git worktree add <path> -b <name> origin/<branch>` creates the worktree directly from the remote tracking ref, no local merge needed.
+3. **Combined `is_git_repo` + `get_repo_root`** into a single `get_repo_root()` call (it already fails on non-git dirs).
+
+## Files Changed
+- `src-tauri/src/worktree.rs` — replaced `pull_latest()` with `fetch_latest()`, updated `create_worktree()` to use start point
+- `src-tauri/src/commands/terminal.rs` — removed redundant `is_git_repo()` call
+
+## Regression Risk
+Low. The worktree still branches from the latest remote state. The only behavioral difference is that the local default branch is no longer merged as a side effect (which was unnecessary).


### PR DESCRIPTION
## Summary

- Replaced `git pull origin <branch>` with `git fetch origin <branch> --no-tags` during worktree terminal creation — eliminates the unnecessary merge step and uses single-branch fetch with `--no-tags` for faster network operations
- Worktree now branches directly from `origin/<branch>` start point instead of requiring a merged local branch
- Removed redundant `is_git_repo()` subprocess call by relying on `get_repo_root()` which already fails on non-git directories

## Test plan

- [x] All 26 worktree unit tests pass (`cargo test -p godly-terminal -- worktree`)
- [x] All 249 TypeScript tests pass (`npm test`)
- [x] Full workspace compiles cleanly (`cargo check --workspace`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: create a new worktree terminal in Godly and verify it opens faster than before
- [ ] Manual: verify the worktree branches from the latest remote state