### PR TITLE
test: reproduce tab drag-drop block cursor bug

### DIFF
--- a/docs/tab-drag-block-cursor.md
+++ b/docs/tab-drag-block-cursor.md
@@ -1,0 +1,29 @@
+# Tab Drag Reorder Shows Block Cursor
+
+## Status: Investigating
+
+## Symptom
+When trying to drag tabs to reorder them, a block/forbidden (🚫) cursor icon appears immediately, preventing the drag-and-drop reorder from working.
+
+## Root Cause Analysis
+
+Two contributing factors identified:
+
+### 1. Missing `dragover` handler on tab-bar container elements
+The `tabsContainer` div (flex wrapper for tabs) and the outer `.tab-bar` container have no `dragover` event handler. In HTML5 DnD, any element that doesn't call `e.preventDefault()` in its `dragover` handler is considered a non-drop-target, causing the browser to show the block cursor.
+
+When the mouse moves to any gap/empty area in the tab bar (not directly over a `.tab` element), no `preventDefault()` is called, and the block cursor appears.
+
+**Affected code**: `src/components/TabBar.ts` — constructor (container setup) and `createTab()` (event handlers only on individual tabs).
+
+### 2. Potential Tauri `dragDropEnabled: true` interference (Windows/WebView2)
+With `dragDropEnabled: true` in `tauri.conf.json`, Tauri registers a native `IDropTarget` COM interface on the WebView2 host window. This native handler may intercept intra-webview HTML5 drag operations on Windows, returning `DROPEFFECT_NONE` for drags it doesn't recognize, which overrides the HTML5 `dropEffect` setting and shows the block cursor.
+
+**Affected config**: `src-tauri/tauri.conf.json` line 24.
+
+## Regression Risk
+- Any change to the Tauri window configuration or WebView2 version could re-trigger this.
+- Adding new elements to the tab bar without dragover handlers would also cause this.
+
+## Reproduction
+See test suite: `src/components/TabBar.drag.test.ts`

--- a/src/components/TabBar.drag.test.ts
+++ b/src/components/TabBar.drag.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { store } from '../state/store';
+
+// Mock Tauri APIs
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('../services/terminal-service', () => ({
+  terminalService: {
+    createTerminal: vi.fn(),
+    closeTerminal: vi.fn(),
+    writeToTerminal: vi.fn(),
+    renameTerminal: vi.fn(),
+  },
+}));
+
+vi.mock('../services/workspace-service', () => ({
+  workspaceService: {
+    reorderTabs: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+import { TabBar } from './TabBar';
+import { workspaceService } from '../services/workspace-service';
+
+// Make store notifications synchronous in jsdom (avoid requestAnimationFrame batching)
+const origRAF = globalThis.requestAnimationFrame;
+
+/**
+ * Helper: create a mock DragEvent with a spyable dataTransfer and preventDefault.
+ */
+function createDragEvent(type: string, data?: Record<string, string>): DragEvent {
+  const preventDefaultSpy = vi.fn();
+  const storedData: Record<string, string> = { ...data };
+  const types = Object.keys(storedData);
+
+  const dataTransfer = {
+    effectAllowed: 'uninitialized' as string,
+    dropEffect: 'none' as string,
+    types,
+    setData(format: string, value: string) {
+      storedData[format] = value;
+      types.push(format);
+    },
+    getData(format: string) {
+      return storedData[format] ?? '';
+    },
+    setDragImage: vi.fn(),
+  };
+
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+  Object.defineProperty(event, 'dataTransfer', { value: dataTransfer, writable: false });
+  Object.defineProperty(event, 'preventDefault', { value: preventDefaultSpy, writable: false });
+
+  return event;
+}
+
+describe('TabBar drag-and-drop reorder', () => {
+  let tabBar: TabBar;
+  let mountPoint: HTMLElement;
+
+  beforeEach(() => {
+    // Make requestAnimationFrame synchronous for test predictability
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => { cb(0); return 0; };
+
+    store.reset();
+
+    store.addWorkspace({
+      id: 'ws-1',
+      name: 'Test Workspace',
+      folderPath: 'C:\\test',
+      tabOrder: [],
+      shellType: { type: 'windows' },
+      worktreeMode: false,
+      claudeCodeMode: false,
+    });
+
+    store.setActiveWorkspace('ws-1');
+
+    store.addTerminal({ id: 't1', workspaceId: 'ws-1', name: 'Tab 1', processName: 'cmd', order: 0 });
+    store.addTerminal({ id: 't2', workspaceId: 'ws-1', name: 'Tab 2', processName: 'cmd', order: 0 });
+    store.addTerminal({ id: 't3', workspaceId: 'ws-1', name: 'Tab 3', processName: 'cmd', order: 0 });
+
+    tabBar = new TabBar();
+    mountPoint = document.createElement('div');
+    document.body.appendChild(mountPoint);
+    tabBar.mount(mountPoint);
+  });
+
+  afterEach(() => {
+    document.body.textContent = '';
+    globalThis.requestAnimationFrame = origRAF;
+    vi.restoreAllMocks();
+  });
+
+  function getTabBarContainer(): HTMLElement {
+    return mountPoint.querySelector('.tab-bar')!;
+  }
+
+  function getTabsContainer(): HTMLElement {
+    // The tabsContainer is the first child div of .tab-bar (flex wrapper for tabs)
+    return getTabBarContainer().firstElementChild as HTMLElement;
+  }
+
+  function getTabElements(): HTMLElement[] {
+    return Array.from(mountPoint.querySelectorAll('.tab'));
+  }
+
+  // -- Bug: block cursor appears when dragging over tab bar gap --
+  // When dragging a tab over the tab-bar container area (empty space not covered
+  // by a .tab element), no dragover handler calls preventDefault(), so the browser
+  // shows a forbidden/block cursor instead of the move cursor.
+
+  it('should render all three tabs', () => {
+    const tabs = getTabElements();
+    expect(tabs.length).toBe(3);
+  });
+
+  it('tab bar container should call preventDefault on dragover for tab drags', () => {
+    // Bug: the tab-bar container has no dragover handler, so dragging over the
+    // empty area (gaps, right side of tab bar) shows the block cursor.
+    const tabBarEl = getTabBarContainer();
+    const dragOverEvent = createDragEvent('dragover', { 'text/plain': 't1' });
+
+    tabBarEl.dispatchEvent(dragOverEvent);
+
+    // Must call preventDefault to allow drops (shows move cursor, not block)
+    expect(dragOverEvent.preventDefault).toHaveBeenCalled();
+  });
+
+  it('tabs container should call preventDefault on dragover for tab drags', () => {
+    // Bug: the flex-wrapper div that holds tabs has no dragover handler,
+    // so dragging over the empty space between/after tabs shows block cursor.
+    const tabsContainer = getTabsContainer();
+    const dragOverEvent = createDragEvent('dragover', { 'text/plain': 't1' });
+
+    tabsContainer.dispatchEvent(dragOverEvent);
+
+    expect(dragOverEvent.preventDefault).toHaveBeenCalled();
+  });
+
+  it('tab bar container should set dropEffect to move on dragover', () => {
+    const tabBarEl = getTabBarContainer();
+    const dragOverEvent = createDragEvent('dragover', { 'text/plain': 't1' });
+
+    tabBarEl.dispatchEvent(dragOverEvent);
+
+    expect(dragOverEvent.dataTransfer!.dropEffect).toBe('move');
+  });
+
+  it('tabs container should set dropEffect to move on dragover', () => {
+    const tabsContainer = getTabsContainer();
+    const dragOverEvent = createDragEvent('dragover', { 'text/plain': 't1' });
+
+    tabsContainer.dispatchEvent(dragOverEvent);
+
+    expect(dragOverEvent.dataTransfer!.dropEffect).toBe('move');
+  });
+
+  it('should NOT call preventDefault for non-tab drags on the container', () => {
+    // Drags that don't include text/plain (e.g., workspace reorders) should
+    // not be intercepted by the tab bar.
+    const tabBarEl = getTabBarContainer();
+    const dragOverEvent = createDragEvent('dragover', { 'application/x-workspace-id': 'ws-99' });
+
+    tabBarEl.dispatchEvent(dragOverEvent);
+
+    expect(dragOverEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('individual tabs should still call preventDefault on dragover', () => {
+    // Sanity check: existing per-tab dragover handlers should work.
+    const tabs = getTabElements();
+    expect(tabs.length).toBeGreaterThan(0);
+
+    const dragOverEvent = createDragEvent('dragover', { 'text/plain': 't1' });
+    tabs[1].dispatchEvent(dragOverEvent);
+
+    expect(dragOverEvent.preventDefault).toHaveBeenCalled();
+    expect(dragOverEvent.dataTransfer!.dropEffect).toBe('move');
+  });
+
+  it('should complete a drag-reorder when dropping on the tab bar container', () => {
+    // Bug: dropping on the tab bar container (not directly on a tab) does nothing
+    // because there is no drop handler on the container.
+    const tabs = getTabElements();
+    const tabBarEl = getTabBarContainer();
+
+    // Simulate: drag t1, drop on the tab bar container
+    const dragStartEvent = createDragEvent('dragstart');
+    tabs[0].dispatchEvent(dragStartEvent);
+
+    const dropEvent = createDragEvent('drop', { 'text/plain': 't1' });
+    tabBarEl.dispatchEvent(dropEvent);
+
+    // The drop on the container should at least not produce an error.
+    // (The reorder might need a target tab, but the container should handle gracefully.)
+    expect(dropEvent.preventDefault).toHaveBeenCalled();
+  });
+
+  it('dragging tab over another tab should add drag-over class', () => {
+    const tabs = getTabElements();
+
+    // Start drag on first tab
+    const dragStartEvent = createDragEvent('dragstart');
+    tabs[0].dispatchEvent(dragStartEvent);
+
+    // Drag over the second tab
+    const dragOverEvent = createDragEvent('dragover', { 'text/plain': 't1' });
+    tabs[1].dispatchEvent(dragOverEvent);
+
+    expect(tabs[1].classList.contains('drag-over')).toBe(true);
+  });
+
+  it('dropping tab on another tab should trigger reorder', async () => {
+    const tabs = getTabElements();
+
+    // Start drag on first tab (t1)
+    const dragStartEvent = createDragEvent('dragstart');
+    tabs[0].dispatchEvent(dragStartEvent);
+
+    // Drop on second tab (t2)
+    const dropEvent = createDragEvent('drop', { 'text/plain': 't1' });
+    tabs[1].dispatchEvent(dropEvent);
+
+    // workspaceService.reorderTabs should have been called with new order
+    // Original order: t1, t2, t3
+    // After dragging t1 to t2's position: t2, t1, t3
+    await vi.waitFor(() => {
+      expect(workspaceService.reorderTabs).toHaveBeenCalledWith(
+        'ws-1',
+        expect.arrayContaining(['t1', 't2', 't3'])
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add failing test suite (`TabBar.drag.test.ts`) that reproduces the block cursor bug when dragging tabs to reorder
- Add investigation doc (`docs/tab-drag-block-cursor.md`) documenting root cause analysis
- 5 tests fail confirming the tab-bar container and tabsContainer lack `dragover` handlers, causing the browser to show a forbidden cursor instead of accepting drops

## Test plan
- [x] 5 new tests fail consistently (verified 4 runs)
- [x] All 249 existing tests still pass
- [x] No source code modified — test-only change