### PR TITLE
feat: add F2 hotkey for renaming the active terminal tab

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -348,6 +348,12 @@ export class App {
           break;
         }
 
+        case 'tabs.renameTerminal': {
+          e.preventDefault();
+          this.tabBar.startRenameActive();
+          break;
+        }
+
         case 'split.focusOtherPane': {
           e.preventDefault();
           if (state.activeWorkspaceId && state.activeTerminalId) {

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -461,6 +461,22 @@ export class TabBar {
     await workspaceService.reorderTabs(state.activeWorkspaceId, ids);
   }
 
+  /** Programmatically start renaming the active terminal tab. */
+  startRenameActive() {
+    const state = store.getState();
+    if (!state.activeTerminalId) return;
+    const terminal = state.workspaces
+      .flatMap(w => store.getWorkspaceTerminals(w.id))
+      .find(t => t.id === state.activeTerminalId);
+    if (!terminal) return;
+    const titleEl = this.container.querySelector(
+      `.tab[data-terminal-id="${terminal.id}"] .tab-title`
+    ) as HTMLSpanElement | null;
+    if (titleEl) {
+      this.startRename(titleEl, terminal);
+    }
+  }
+
   setOnSplit(callback: (terminalId: string, direction: 'horizontal' | 'vertical') => void) {
     this.onSplitCallback = callback;
   }

--- a/src/state/keybinding-store.test.ts
+++ b/src/state/keybinding-store.test.ts
@@ -94,6 +94,16 @@ describe('KeybindingStore', () => {
       );
     });
 
+    it('matches F2 to tabs.renameTerminal', () => {
+      const store = new KeybindingStore();
+      expect(store.matchAction(keydown('F2'))).toBe('tabs.renameTerminal');
+    });
+
+    it('classifies tabs.renameTerminal as an app shortcut', () => {
+      const store = new KeybindingStore();
+      expect(store.isAppShortcut(keydown('F2'))).toBe(true);
+    });
+
     it('returns null for unbound keys', () => {
       const store = new KeybindingStore();
       expect(store.matchAction(keydown('a', { ctrlKey: true }))).toBeNull();

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -23,7 +23,8 @@ export type ActionId =
   | 'scroll.pageUp'
   | 'scroll.pageDown'
   | 'scroll.toTop'
-  | 'scroll.toBottom';
+  | 'scroll.toBottom'
+  | 'tabs.renameTerminal';
 
 export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll';
 
@@ -153,6 +154,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     type: 'app',
     defaultChord: { ctrlKey: false, shiftKey: true, altKey: false, key: 'end' },
   },
+  {
+    id: 'tabs.renameTerminal',
+    label: 'Rename Terminal',
+    category: 'Tabs',
+    type: 'app',
+    defaultChord: { ctrlKey: false, shiftKey: false, altKey: false, key: 'f2' },
+  },
 ];
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -200,6 +208,7 @@ export function formatChord(chord: KeyChord): string {
     pagedown: 'PageDown',
     home: 'Home',
     end: 'End',
+    f2: 'F2',
   };
   const displayKey = keyDisplayMap[chord.key] ?? chord.key.toUpperCase();
   parts.push(displayKey);


### PR DESCRIPTION
## Summary

- Adds a new `tabs.renameTerminal` keyboard shortcut (default: **F2**) that triggers inline rename on the active terminal tab
- Registers the action in the keybinding store so it appears in Settings and is customizable
- Adds `TabBar.startRenameActive()` public method for programmatic rename triggering
- Includes tests verifying F2 matches the action and is classified as an app shortcut

## Test plan

- [x] `npm run build` passes (tsc + vite)
- [x] `npx vitest run src/state/keybinding-store.test.ts` — 42/42 pass (2 new)
- [ ] Manual: press F2 with a terminal tab active → inline rename input appears
- [ ] Manual: verify F2 appears in Settings > Keyboard Shortcuts under Tabs category
- [ ] Manual: rebind F2 to another key in Settings → new key triggers rename, F2 passes through to terminal