### PR TITLE
feat: unsplit shortcut + fix tab switching in split mode

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -362,6 +362,12 @@ export class App {
           break;
         }
 
+        case 'split.unsplit': {
+          e.preventDefault();
+          this.handleUnsplitRequest();
+          break;
+        }
+
         case 'workspace.toggleWorktreeMode': {
           e.preventDefault();
           if (state.activeWorkspaceId) {

--- a/src/state/keybinding-store.test.ts
+++ b/src/state/keybinding-store.test.ts
@@ -348,6 +348,27 @@ describe('KeybindingStore', () => {
     });
   });
 
+  describe('split.unsplit shortcut', () => {
+    it('matches Ctrl+Shift+\\ to split.unsplit', () => {
+      const store = new KeybindingStore();
+      expect(store.matchAction(keydown('\\', { ctrlKey: true, shiftKey: true }))).toBe(
+        'split.unsplit'
+      );
+    });
+
+    it('classifies Ctrl+Shift+\\ as an app shortcut', () => {
+      const store = new KeybindingStore();
+      expect(store.isAppShortcut(keydown('\\', { ctrlKey: true, shiftKey: true }))).toBe(true);
+      expect(store.isTerminalControlKey(keydown('\\', { ctrlKey: true, shiftKey: true }))).toBe(false);
+    });
+
+    it('does not conflict with Alt+\\ (focus other pane)', () => {
+      const store = new KeybindingStore();
+      expect(store.matchAction(keydown('\\', { altKey: true }))).toBe('split.focusOtherPane');
+      expect(store.matchAction(keydown('\\', { ctrlKey: true, shiftKey: true }))).toBe('split.unsplit');
+    });
+  });
+
   describe('CapsLock edge case', () => {
     // Bug: With CapsLock on, browser sends uppercase key without shiftKey
     it('matches Ctrl+C when CapsLock sends uppercase C without shift', () => {

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -18,6 +18,7 @@ export type ActionId =
   | 'tabs.nextTab'
   | 'tabs.previousTab'
   | 'split.focusOtherPane'
+  | 'split.unsplit'
   | 'workspace.toggleWorktreeMode'
   | 'workspace.toggleClaudeCodeMode'
   | 'scroll.pageUp'
@@ -110,6 +111,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Split',
     type: 'app',
     defaultChord: { ctrlKey: false, shiftKey: false, altKey: true, key: '\\' },
+  },
+  {
+    id: 'split.unsplit',
+    label: 'Unsplit',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: '\\' },
   },
   {
     id: 'workspace.toggleWorktreeMode',

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -692,5 +692,59 @@ describe('Store', () => {
 
       expect(store.getState().splitViews).toEqual({});
     });
+
+    it('should auto-clear split when navigating to a terminal outside the split', () => {
+      // Bug: clicking a tab not in the split left the split active,
+      // so the clicked tab was never displayed
+      store.setActiveWorkspace('ws-1');
+      store.setSplitView('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t1');
+
+      // Navigate to t3 which is NOT in the split
+      store.setActiveTerminal('t3');
+
+      expect(store.getSplitView('ws-1')).toBeNull();
+      expect(store.getState().activeTerminalId).toBe('t3');
+    });
+
+    it('should preserve split when navigating within the split', () => {
+      store.setActiveWorkspace('ws-1');
+      store.setSplitView('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t1');
+
+      // Navigate to t2 which IS in the split (e.g. Alt+\ focus other pane)
+      store.setActiveTerminal('t2');
+
+      expect(store.getSplitView('ws-1')).not.toBeNull();
+      expect(store.getState().activeTerminalId).toBe('t2');
+    });
+
+    it('should preserve split when navigating to leftTerminalId', () => {
+      store.setActiveWorkspace('ws-1');
+      store.setSplitView('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t2');
+
+      store.setActiveTerminal('t1');
+
+      expect(store.getSplitView('ws-1')).not.toBeNull();
+      expect(store.getState().activeTerminalId).toBe('t1');
+    });
+
+    it('should not clear split when setting active terminal to null', () => {
+      store.setActiveWorkspace('ws-1');
+      store.setSplitView('ws-1', 't1', 't2', 'horizontal');
+
+      store.setActiveTerminal(null);
+
+      expect(store.getSplitView('ws-1')).not.toBeNull();
+    });
+
+    it('should not throw when no active workspace and navigating outside split', () => {
+      store.setSplitView('ws-1', 't1', 't2', 'horizontal');
+      // No active workspace set — setActiveTerminal should not crash
+      store.setActiveTerminal('t3');
+
+      expect(store.getState().activeTerminalId).toBe('t3');
+    });
   });
 });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -226,6 +226,16 @@ class Store {
   setActiveTerminal(id: string | null) {
     if (id && this.state.activeWorkspaceId) {
       this.lastActiveTerminalByWorkspace.set(this.state.activeWorkspaceId, id);
+
+      // If navigating to a terminal outside the current split → auto-clear the split
+      const split = this.state.splitViews[this.state.activeWorkspaceId];
+      if (split && id !== split.leftTerminalId && id !== split.rightTerminalId) {
+        const { [this.state.activeWorkspaceId]: _, ...rest } = this.state.splitViews;
+        this.setState({ activeTerminalId: id, splitViews: rest });
+        invoke('clear_split_view', { workspaceId: this.state.activeWorkspaceId }).catch(() => {});
+        invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+        return;
+      }
     }
     this.setState({ activeTerminalId: id });
     invoke('sync_active_terminal', { terminalId: id }).catch(() => {});


### PR DESCRIPTION
## Summary

- **Bug fix**: Navigating to a terminal outside the current split (tab click, Ctrl+Tab, Ctrl+Shift+Tab, MCP focus, toast click) now auto-clears the split so the target terminal is displayed. Previously the split stayed active and the clicked tab was invisible.
- **Feature**: Added `Ctrl+Shift+\` keyboard shortcut for unsplit, pairing with existing `Alt+\` (focus other pane). Also available in Settings dialog under the Split category.

## Test plan

- [x] `npm test` — all TypeScript tests pass (91/91 in modified files)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — production build succeeds
- [ ] Manual: split two terminals → click a third tab → split clears, third terminal shown
- [ ] Manual: in split mode → press `Ctrl+Shift+\` → unsplit
- [ ] Manual: in split mode → `Alt+\` still switches focus between panes (no regression)
- [ ] Manual: Settings dialog shows "Unsplit" under Split category