### PR TITLE
feat: add version display in settings and bump-version skill

### DIFF
--- a/.claude/skills/bump-version.md
+++ b/.claude/skills/bump-version.md
@@ -1,0 +1,34 @@
+# Bump Version
+
+Bump the project version across all crates and config files, then build to verify.
+
+## Usage
+
+```
+/bump-version <patch|minor|major|X.Y.Z>
+```
+
+## Steps
+
+1. Run `npm run version:bump -- <arg>` where `<arg>` is the bump type or explicit version from the user's input.
+2. Verify the output shows all files updated successfully.
+3. Run `npm run build` to confirm the frontend builds with the new version constant.
+4. Run `cd src-tauri && cargo check --workspace` to confirm all Rust crates compile.
+5. Commit directly to the current branch with message `chore: bump version to X.Y.Z` and push.
+
+## Files Updated
+
+The bump script updates these files:
+- `package.json`
+- `src-tauri/tauri.conf.json`
+- `src-tauri/Cargo.toml`
+- `src-tauri/protocol/Cargo.toml`
+- `src-tauri/daemon/Cargo.toml`
+- `src-tauri/mcp/Cargo.toml`
+- `src-tauri/godly-vt/Cargo.toml`
+- `src-tauri/notify/Cargo.toml`
+
+## Notes
+
+- This is a `chore:` change — commit and push directly to the current branch, no PR needed.
+- The version is injected into the frontend at build time via Vite's `define` (`__APP_VERSION__`) and displayed in the Settings dialog.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:e2e": "wdio run e2e/wdio.conf.ts",
     "test:e2e:no-build": "cross-env SKIP_BUILD=1 wdio run e2e/wdio.conf.ts",
     "test:all": "npm run test && npm run test:rust && npm run test:e2e",
-    "check:persistence": "npx ts-node e2e/check-persistence.ts"
+    "check:persistence": "npx ts-node e2e/check-persistence.ts",
+    "version:bump": "node scripts/bump-version.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+const VERSION_FILES = [
+  {
+    path: "package.json",
+    type: "json",
+    field: "version",
+  },
+  {
+    path: "src-tauri/tauri.conf.json",
+    type: "json",
+    field: "version",
+  },
+  {
+    path: "src-tauri/Cargo.toml",
+    type: "cargo",
+  },
+  {
+    path: "src-tauri/protocol/Cargo.toml",
+    type: "cargo",
+  },
+  {
+    path: "src-tauri/daemon/Cargo.toml",
+    type: "cargo",
+  },
+  {
+    path: "src-tauri/mcp/Cargo.toml",
+    type: "cargo",
+  },
+  {
+    path: "src-tauri/godly-vt/Cargo.toml",
+    type: "cargo",
+  },
+  {
+    path: "src-tauri/notify/Cargo.toml",
+    type: "cargo",
+  },
+];
+
+function readCurrentVersion() {
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+  return pkg.version;
+}
+
+function bumpVersion(current, bump) {
+  if (SEMVER_RE.test(bump)) {
+    return bump;
+  }
+
+  const [major, minor, patch] = current.split(".").map(Number);
+
+  switch (bump) {
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "major":
+      return `${major + 1}.0.0`;
+    default:
+      console.error(
+        `Error: Invalid bump type "${bump}". Use patch, minor, major, or an explicit X.Y.Z version.`
+      );
+      process.exit(1);
+  }
+}
+
+function updateJsonFile(filePath, field, newVersion) {
+  const fullPath = join(root, filePath);
+  const content = readFileSync(fullPath, "utf-8");
+  const json = JSON.parse(content);
+  json[field] = newVersion;
+  writeFileSync(fullPath, JSON.stringify(json, null, 2) + "\n", "utf-8");
+}
+
+function updateCargoToml(filePath, oldVersion, newVersion) {
+  const fullPath = join(root, filePath);
+  let content = readFileSync(fullPath, "utf-8");
+
+  // Replace the first `version = "X.Y.Z"` under [package]
+  const packageRe = /(\[package\][\s\S]*?version\s*=\s*")([^"]+)(")/;
+  const match = content.match(packageRe);
+
+  if (!match) {
+    console.error(`Error: Could not find version in [package] section of ${filePath}`);
+    process.exit(1);
+  }
+
+  if (match[2] !== oldVersion) {
+    console.error(
+      `Error: Version mismatch in ${filePath}: expected "${oldVersion}", found "${match[2]}"`
+    );
+    process.exit(1);
+  }
+
+  content = content.replace(packageRe, `$1${newVersion}$3`);
+  writeFileSync(fullPath, content, "utf-8");
+}
+
+// --- Main ---
+
+const bump = process.argv[2];
+
+if (!bump) {
+  console.error("Usage: npm run version:bump -- <patch|minor|major|X.Y.Z>");
+  process.exit(1);
+}
+
+const oldVersion = readCurrentVersion();
+const newVersion = bumpVersion(oldVersion, bump);
+
+if (oldVersion === newVersion) {
+  console.log(`Version is already ${oldVersion}, nothing to do.`);
+  process.exit(0);
+}
+
+console.log(`Bumping version: ${oldVersion} -> ${newVersion}\n`);
+
+for (const file of VERSION_FILES) {
+  if (file.type === "json") {
+    updateJsonFile(file.path, file.field, newVersion);
+  } else {
+    updateCargoToml(file.path, oldVersion, newVersion);
+  }
+  console.log(`  Updated ${file.path}`);
+}
+
+console.log(`\nAll ${VERSION_FILES.length} files updated to ${newVersion}.`);

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -505,6 +505,11 @@ export function showSettingsDialog(): Promise<void> {
     footer.textContent = `Renderer: ${getRendererBackend()}`;
     dialog.appendChild(footer);
 
+    const versionLine = document.createElement('div');
+    versionLine.className = 'settings-footer settings-version';
+    versionLine.textContent = `Version: ${__APP_VERSION__}`;
+    dialog.appendChild(versionLine);
+
     // ── Close handling ──────────────────────────────────────────
     const close = () => {
       stopCapture();

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -976,6 +976,12 @@ body.dragging-active * {
   text-align: right;
 }
 
+.settings-version {
+  margin-top: 2px;
+  padding-top: 0;
+  border-top: none;
+}
+
 /* Notification badges */
 .tab-notification-badge {
   width: 8px;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
## Summary
- Displays the app version below the renderer info in the Settings dialog footer
- Injects the version from `package.json` at build time via Vite's `define` (`__APP_VERSION__`)
- Adds `npm run version:bump` script wiring to `scripts/bump-version.mjs`
- Extends bump script to cover `godly-vt` and `godly-notify` crates (8 files total)
- Adds `.claude/skills/bump-version.md` skill for streamlined version bumping

## Test plan
- [x] All 285 frontend tests pass
- [x] Production build succeeds (`npm run build`)
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] Open Settings dialog and verify version appears below renderer line
- [ ] Run `npm run version:bump -- patch` and verify all 8 files are updated