### PR TITLE
feat: add CMD aliases editor in Settings with AutoRun registry setup

### DIFF
--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 #[cfg(windows)]
@@ -24,5 +25,112 @@ pub fn is_pwsh_available() -> bool {
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
+    }
+}
+
+/// Return the path to the CMD aliases file: `%USERPROFILE%\cmd-aliases.cmd`.
+#[tauri::command]
+pub fn get_cmd_aliases_path() -> Result<String, String> {
+    let home = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .map_err(|_| "Could not determine home directory".to_string())?;
+    let path = PathBuf::from(home).join("cmd-aliases.cmd");
+    path.to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| "Invalid path encoding".to_string())
+}
+
+/// Idempotently ensure the CMD aliases file is registered as the AutoRun
+/// script for cmd.exe via the Windows registry.
+///
+/// Returns a status string: "already_configured", "configured", or "appended".
+#[tauri::command]
+pub fn ensure_cmd_autorun() -> Result<String, String> {
+    #[cfg(windows)]
+    {
+        let aliases_path = get_cmd_aliases_path()?;
+
+        // Query current AutoRun value
+        let query = Command::new("reg")
+            .args([
+                "query",
+                r"HKCU\Software\Microsoft\Command Processor",
+                "/v",
+                "AutoRun",
+            ])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+            .map_err(|e| format!("Failed to query registry: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&query.stdout);
+
+        if query.status.success() {
+            // Parse existing value — format: "    AutoRun    REG_SZ    <value>"
+            if let Some(existing) = parse_reg_value(&stdout) {
+                // Already contains our path (case-insensitive comparison)
+                if existing.to_lowercase().contains(&aliases_path.to_lowercase()) {
+                    return Ok("already_configured".to_string());
+                }
+                // Append to existing value
+                let new_value = format!("{existing} & \"{aliases_path}\"");
+                reg_set_autorun(&new_value)?;
+                return Ok("appended".to_string());
+            }
+        }
+
+        // No AutoRun value exists — create it
+        reg_set_autorun(&format!("\"{aliases_path}\""))?;
+        Ok("configured".to_string())
+    }
+
+    #[cfg(not(windows))]
+    {
+        Err("CMD AutoRun is only supported on Windows".to_string())
+    }
+}
+
+/// Parse the value from `reg query` output.
+/// The output format is: `    AutoRun    REG_SZ    <value>`
+#[cfg(windows)]
+fn parse_reg_value(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("AutoRun") {
+            // Split on REG_SZ and take everything after it
+            if let Some(idx) = trimmed.find("REG_SZ") {
+                let value = trimmed[idx + "REG_SZ".len()..].trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Set the AutoRun registry value.
+#[cfg(windows)]
+fn reg_set_autorun(value: &str) -> Result<(), String> {
+    let status = Command::new("reg")
+        .args([
+            "add",
+            r"HKCU\Software\Microsoft\Command Processor",
+            "/v",
+            "AutoRun",
+            "/t",
+            "REG_SZ",
+            "/d",
+            value,
+            "/f",
+        ])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map_err(|e| format!("Failed to set registry: {e}"))?;
+
+    if status.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&status.stderr);
+        Err(format!("Failed to set AutoRun: {stderr}"))
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,8 @@ pub fn run() {
             commands::get_wsl_distributions,
             commands::is_wsl_available,
             commands::is_pwsh_available,
+            commands::get_cmd_aliases_path,
+            commands::ensure_cmd_autorun,
             commands::toggle_worktree_mode,
             commands::toggle_claude_code_mode,
             commands::is_git_repo,

--- a/src/components/FileEditorDialog.test.ts
+++ b/src/components/FileEditorDialog.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
-import { renderMarkdown } from './FileEditorDialog';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderMarkdown, showFileEditorDialog } from './FileEditorDialog';
 
 describe('renderMarkdown', () => {
   it('renders basic markdown to HTML', () => {
@@ -42,5 +42,78 @@ describe('renderMarkdown', () => {
   it('returns empty string for empty input', () => {
     const html = renderMarkdown('');
     expect(html).toBe('');
+  });
+});
+
+// Mock @tauri-apps/api/core
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+describe('showFileEditorDialog with defaultContent', () => {
+  beforeEach(() => {
+    document.body.textContent = '';
+  });
+
+  it('uses defaultContent when file is empty (new file)', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const mockInvoke = vi.mocked(invoke);
+    // read_file returns empty string for non-existent file
+    mockInvoke.mockResolvedValueOnce('');
+
+    const defaultContent = '@echo off\ndoskey dclaude=claude --dangerously-skip-permissions $*\n';
+    // Don't await — dialog is modal, we need to inspect it while open
+    const dialogPromise = showFileEditorDialog('CMD Aliases', 'C:\\test\\cmd-aliases.cmd', defaultContent);
+
+    // Wait for the dialog to render
+    await new Promise(r => setTimeout(r, 50));
+
+    const textarea = document.querySelector('.file-editor-textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+    expect(textarea.value).toBe(defaultContent);
+
+    // Close the dialog via cancel
+    const cancelBtn = document.querySelector('.dialog-btn-secondary') as HTMLButtonElement;
+    cancelBtn?.click();
+    await dialogPromise;
+  });
+
+  it('uses existing file content when file is not empty', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const mockInvoke = vi.mocked(invoke);
+    const existingContent = '@echo off\ndoskey myalias=echo hello $*\n';
+    mockInvoke.mockResolvedValueOnce(existingContent);
+
+    const defaultContent = '@echo off\ndoskey dclaude=claude --dangerously-skip-permissions $*\n';
+    const dialogPromise = showFileEditorDialog('CMD Aliases', 'C:\\test\\cmd-aliases.cmd', defaultContent);
+
+    await new Promise(r => setTimeout(r, 50));
+
+    const textarea = document.querySelector('.file-editor-textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+    // Should use existing content, not default
+    expect(textarea.value).toBe(existingContent);
+
+    const cancelBtn = document.querySelector('.dialog-btn-secondary') as HTMLButtonElement;
+    cancelBtn?.click();
+    await dialogPromise;
+  });
+
+  it('does not apply defaultContent when not provided', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockResolvedValueOnce('');
+
+    const dialogPromise = showFileEditorDialog('Test', 'C:\\test\\empty.md');
+
+    await new Promise(r => setTimeout(r, 50));
+
+    const textarea = document.querySelector('.file-editor-textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+    expect(textarea.value).toBe('');
+
+    const cancelBtn = document.querySelector('.dialog-btn-secondary') as HTMLButtonElement;
+    cancelBtn?.click();
+    await dialogPromise;
   });
 });

--- a/src/components/FileEditorDialog.ts
+++ b/src/components/FileEditorDialog.ts
@@ -13,10 +13,14 @@ export function renderMarkdown(src: string): string {
 /**
  * Show a file editor dialog for editing a text file (e.g. CLAUDE.md).
  * Auto-creates the file if it doesn't exist (starts with empty content).
+ * If `defaultContent` is provided, new files are pre-populated with it.
  */
-export async function showFileEditorDialog(title: string, filePath: string): Promise<void> {
+export async function showFileEditorDialog(title: string, filePath: string, defaultContent?: string): Promise<void> {
   // Read current content (returns empty string if file doesn't exist)
-  const content = await invoke<string>('read_file', { path: filePath });
+  let content = await invoke<string>('read_file', { path: filePath });
+  if (!content && defaultContent) {
+    content = defaultContent;
+  }
 
   return new Promise((resolve) => {
     const overlay = document.createElement('div');


### PR DESCRIPTION
## Summary

- Add a **CMD Aliases** section to Settings > Terminal tab that lets users define doskey aliases for Command Prompt sessions
- New `FileEditorDialog` `defaultContent` parameter pre-populates the editor with a template when creating a new aliases file
- Two new Tauri commands (`get_cmd_aliases_path`, `ensure_cmd_autorun`) manage the aliases file path and idempotently configure the Windows `HKCU\...\Command Processor\AutoRun` registry key
- Includes 3 unit tests covering the `defaultContent` behavior (new file, existing file, omitted)

## Changed files

| File | Change |
|------|--------|
| `src-tauri/src/commands/shell.rs` | Added `get_cmd_aliases_path` and `ensure_cmd_autorun` commands |
| `src-tauri/src/lib.rs` | Registered the two new commands in the invoke handler |
| `src/components/FileEditorDialog.ts` | Added optional `defaultContent` parameter |
| `src/components/SettingsDialog.ts` | Added CMD Aliases section with Edit Aliases button |
| `src/components/FileEditorDialog.test.ts` | Added 3 tests for defaultContent feature |

## How it works

1. User clicks **Edit Aliases** in Settings > Terminal
2. `get_cmd_aliases_path` resolves `%USERPROFILE%\cmd-aliases.cmd`
3. `FileEditorDialog` opens with the file content (or a default template for new files)
4. On save, `ensure_cmd_autorun` checks the Windows AutoRun registry key and configures it if needed (idempotent -- won't duplicate if already present)

## Test plan

- [ ] Verify `npm test` passes (FileEditorDialog defaultContent tests)
- [ ] Open Settings > Terminal and confirm CMD Aliases section appears
- [ ] Click Edit Aliases on a machine without an existing aliases file -- editor should show the default template
- [ ] Save and verify `%USERPROFILE%\cmd-aliases.cmd` is created
- [ ] Confirm AutoRun registry key is set: `reg query "HKCU\Software\Microsoft\Command Processor" /v AutoRun`
- [ ] Open a new CMD session and verify aliases are loaded
- [ ] Click Edit Aliases again -- existing content should appear (not the default template)