### PR TITLE
feat: Figma embed pane + godly-figma-mcp

### DIFF
--- a/src/components/FigmaPane.ts
+++ b/src/components/FigmaPane.ts
@@ -1,0 +1,100 @@
+import { store } from '../state/store';
+
+/**
+ * Figma embed pane — renders a Figma design in an iframe.
+ *
+ * Follows the same public interface as TerminalPane so App.ts
+ * can manage both types interchangeably.
+ */
+export class FigmaPane {
+  private container: HTMLElement;
+  private iframe: HTMLIFrameElement | null = null;
+  private terminalId: string;
+  private figmaUrl: string;
+
+  constructor(terminalId: string, figmaUrl: string) {
+    this.terminalId = terminalId;
+    this.figmaUrl = figmaUrl;
+
+    this.container = document.createElement('div');
+    this.container.className = 'figma-pane';
+    this.container.dataset.terminalId = terminalId;
+  }
+
+  mount(parent: HTMLElement) {
+    parent.appendChild(this.container);
+    this.createIframe();
+
+    // Click-to-focus in split mode
+    this.container.addEventListener('mousedown', () => {
+      if (this.container.classList.contains('split-visible')) {
+        store.setActiveTerminal(this.terminalId);
+      }
+    });
+  }
+
+  private createIframe() {
+    this.iframe = document.createElement('iframe');
+    this.iframe.src = this.buildEmbedUrl();
+    this.iframe.className = 'figma-embed-iframe';
+    this.iframe.setAttribute('allowfullscreen', '');
+    this.container.appendChild(this.iframe);
+  }
+
+  private buildEmbedUrl(): string {
+    // If already an embed URL, use as-is
+    if (this.figmaUrl.includes('/embed')) {
+      return this.figmaUrl;
+    }
+    // Convert design/file URL to embed URL
+    const encoded = encodeURIComponent(this.figmaUrl);
+    return `https://www.figma.com/embed?embed_host=godly-terminal&url=${encoded}`;
+  }
+
+  /** Update the Figma URL and reload the iframe */
+  setUrl(url: string) {
+    this.figmaUrl = url;
+    if (this.iframe) {
+      this.iframe.src = this.buildEmbedUrl();
+    }
+  }
+
+  setActive(active: boolean) {
+    this.container.classList.remove('split-visible', 'split-focused');
+    this.container.classList.toggle('active', active);
+  }
+
+  setSplitVisible(visible: boolean, focused: boolean) {
+    this.container.classList.remove('active');
+    this.container.classList.toggle('split-visible', visible);
+    this.container.classList.toggle('split-focused', focused);
+  }
+
+  focus() {
+    this.iframe?.focus();
+  }
+
+  async destroy() {
+    if (this.iframe) {
+      this.iframe.src = 'about:blank';
+      this.iframe = null;
+    }
+    this.container.remove();
+  }
+
+  getElement(): HTMLElement {
+    return this.container;
+  }
+
+  getContainer(): HTMLElement {
+    return this.container;
+  }
+
+  getTerminalId(): string {
+    return this.terminalId;
+  }
+
+  // Stubs for TerminalPane interface compatibility
+  async saveScrollback(): Promise<void> {}
+  async loadScrollback(): Promise<void> {}
+}

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -71,3 +71,89 @@ export function showWorktreeNamePrompt(): Promise<string | null> {
     input.focus();
   });
 }
+
+/**
+ * Show a prompt dialog for entering a Figma file URL.
+ * Returns the URL string, or null if cancelled.
+ */
+export function showFigmaUrlPrompt(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'dialog-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+
+    const title = document.createElement('div');
+    title.className = 'dialog-title';
+    title.textContent = 'Open Figma Design';
+    dialog.appendChild(title);
+
+    const hint = document.createElement('div');
+    hint.style.cssText = 'font-size: 12px; color: var(--text-secondary); margin-bottom: 12px;';
+    hint.textContent = 'Paste a Figma file URL (e.g. https://figma.com/design/...)';
+    dialog.appendChild(hint);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'dialog-input';
+    input.placeholder = 'https://figma.com/design/...';
+    dialog.appendChild(input);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'dialog-buttons';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'dialog-btn dialog-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    buttons.appendChild(cancelBtn);
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'dialog-btn dialog-btn-primary';
+    okBtn.textContent = 'Open';
+    buttons.appendChild(okBtn);
+
+    dialog.appendChild(buttons);
+    overlay.appendChild(dialog);
+
+    const close = () => overlay.remove();
+
+    const submit = () => {
+      const url = input.value.trim();
+      close();
+      if (url && url.includes('figma.com')) {
+        resolve(url);
+      } else if (url) {
+        // Not a valid Figma URL
+        resolve(null);
+      } else {
+        resolve(null);
+      }
+    };
+
+    cancelBtn.onclick = () => {
+      close();
+      resolve(null);
+    };
+
+    okBtn.onclick = submit;
+
+    input.onkeydown = (e) => {
+      if (e.key === 'Enter') submit();
+      if (e.key === 'Escape') {
+        close();
+        resolve(null);
+      }
+    };
+
+    overlay.onclick = (e) => {
+      if (e.target === overlay) {
+        close();
+        resolve(null);
+      }
+    };
+
+    document.body.appendChild(overlay);
+    input.focus();
+  });
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+export type PaneType = 'terminal' | 'figma';
+
 export interface Terminal {
   id: string;
   workspaceId: string;
@@ -8,6 +10,8 @@ export interface Terminal {
   order: number;
   oscTitle?: string;
   userRenamed?: boolean;
+  paneType?: PaneType;
+  figmaUrl?: string;
 }
 
 export type ShellType =

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -802,6 +802,51 @@ body.dragging-active * {
   color: var(--text-secondary);
 }
 
+/* Figma pane — shares layout with terminal-pane */
+.figma-pane {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: none;
+  background: var(--bg-primary);
+}
+
+.figma-pane.active {
+  display: block;
+}
+
+/* In split mode, figma panes behave the same as terminal panes */
+.terminal-container.split-horizontal .figma-pane.split-visible,
+.terminal-container.split-vertical .figma-pane.split-visible {
+  position: relative;
+  top: auto;
+  left: auto;
+  right: auto;
+  bottom: auto;
+  display: block;
+  min-width: 0;
+  min-height: 0;
+}
+
+.figma-pane.split-focused {
+  border-top: 2px solid var(--accent);
+}
+
+.figma-embed-iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg-primary);
+}
+
+/* Figma tab indicator */
+.tab.figma-tab .tab-title::before {
+  content: '\25C6 ';
+  color: var(--accent);
+}
+
 /* WebGL overlay canvas for scrollbar and URL hover */
 .terminal-overlay-canvas {
   position: absolute;


### PR DESCRIPTION
## Summary

- Add Figma embed pane type to Godly Terminal for side-by-side design + terminal workflows
- New `FigmaPane` component renders Figma designs in an iframe, sharing the same layout system as terminal panes (split, tabs, activation)
- Right-click the "+" button to open a Figma design URL as a new tab
- Diamond icon distinguishes Figma tabs from terminal tabs

### Files changed (Godly Terminal)
- `src/state/store.ts` — Extended `Terminal` interface with `paneType` and `figmaUrl` fields
- `src/components/FigmaPane.ts` — New iframe-based pane component
- `src/components/App.ts` — Routes pane creation by type, guards Figma panes from PTY operations
- `src/components/TabBar.ts` — Right-click menu on "+" for new terminal vs Figma, Figma tab indicator
- `src/components/dialogs.ts` — Figma URL prompt dialog
- `src/styles/main.css` — Figma pane and tab styles

### Separate repo: godly-figma-mcp
A companion MCP monorepo was created at `C:\Users\alanm\dev\godly-claude\godly-figma-mcp` with:
- `@godly/figma-shared` — WebSocket protocol types
- `@godly/figma-mcp` — MCP server (28 tools) with embedded WebSocket bridge
- `@godly/figma-plugin` — Figma plugin that executes figma.* API calls via MCP tools

## Test plan
- [ ] Build passes: `tsc && vite build`
- [ ] Existing tests pass (no regressions — pre-existing TabBar.drag failures unrelated)
- [ ] Right-click "+" button shows context menu with Terminal and Figma options
- [ ] Pasting a Figma URL creates a new tab with diamond indicator
- [ ] Figma embed loads and renders the design
- [ ] Figma pane works in split mode alongside terminal panes
- [ ] Closing a Figma tab does not attempt to close a daemon session
- [ ] File drag-drop is ignored on Figma panes