### PR TITLE
feat: add Copy (Clean) dialog for terminal text selection

### DIFF
--- a/src/components/CopyDialog.test.ts
+++ b/src/components/CopyDialog.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { cleanTerminalText } from './CopyDialog';
+
+describe('cleanTerminalText', () => {
+  it('trims trailing whitespace per line', () => {
+    const input = 'hello   \nworld  \n';
+    expect(cleanTerminalText(input)).toBe('hello\nworld');
+  });
+
+  it('collapses 3+ consecutive blank lines into 2', () => {
+    const input = 'a\n\n\n\n\nb';
+    expect(cleanTerminalText(input)).toBe('a\n\n\nb');
+  });
+
+  it('preserves exactly 2 consecutive blank lines', () => {
+    const input = 'a\n\n\nb';
+    expect(cleanTerminalText(input)).toBe('a\n\n\nb');
+  });
+
+  it('strips leading blank lines', () => {
+    const input = '\n\n\nhello';
+    expect(cleanTerminalText(input)).toBe('hello');
+  });
+
+  it('strips trailing blank lines', () => {
+    const input = 'hello\n\n\n';
+    expect(cleanTerminalText(input)).toBe('hello');
+  });
+
+  it('strips both leading and trailing blank lines', () => {
+    const input = '\n\nhello\nworld\n\n';
+    expect(cleanTerminalText(input)).toBe('hello\nworld');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(cleanTerminalText('')).toBe('');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(cleanTerminalText('   \n   \n   ')).toBe('');
+  });
+
+  it('handles single line without trailing whitespace', () => {
+    expect(cleanTerminalText('hello')).toBe('hello');
+  });
+
+  it('handles single line with trailing whitespace', () => {
+    expect(cleanTerminalText('hello   ')).toBe('hello');
+  });
+
+  it('preserves leading indentation', () => {
+    const input = '  function foo() {\n    return 1;\n  }';
+    expect(cleanTerminalText(input)).toBe('  function foo() {\n    return 1;\n  }');
+  });
+
+  it('preserves a single blank line between paragraphs', () => {
+    const input = 'paragraph one\n\nparagraph two';
+    expect(cleanTerminalText(input)).toBe('paragraph one\n\nparagraph two');
+  });
+
+  it('handles terminal-padded lines with mixed content', () => {
+    // Simulates typical terminal output: lines padded to 80 cols with spaces
+    const input = 'ls -la                                                                          \ntotal 42                                                                        \ndrwxr-xr-x  5 user user 4096 Jan 01 12:00 .                                     \n';
+    const result = cleanTerminalText(input);
+    expect(result).toBe('ls -la\ntotal 42\ndrwxr-xr-x  5 user user 4096 Jan 01 12:00 .');
+  });
+
+  it('collapses multiple groups of excessive blank lines', () => {
+    const input = 'a\n\n\n\n\nb\n\n\n\nc';
+    expect(cleanTerminalText(input)).toBe('a\n\n\nb\n\n\nc');
+  });
+});

--- a/src/components/CopyDialog.ts
+++ b/src/components/CopyDialog.ts
@@ -1,0 +1,136 @@
+/**
+ * Clean up terminal text and present it in an editable dialog for copying.
+ */
+
+/**
+ * Clean terminal text by removing formatting artifacts:
+ * 1. Trim trailing whitespace per line (terminal rows are space-padded)
+ * 2. Collapse 3+ consecutive blank lines into 2
+ * 3. Strip leading/trailing blank lines from the whole block
+ */
+export function cleanTerminalText(raw: string): string {
+  // Trim trailing whitespace per line
+  const lines = raw.split('\n').map((line) => line.trimEnd());
+
+  // Collapse 3+ consecutive blank lines into 2
+  const collapsed: string[] = [];
+  let consecutiveBlanks = 0;
+  for (const line of lines) {
+    if (line === '') {
+      consecutiveBlanks++;
+      if (consecutiveBlanks <= 2) {
+        collapsed.push(line);
+      }
+    } else {
+      consecutiveBlanks = 0;
+      collapsed.push(line);
+    }
+  }
+
+  // Strip leading blank lines
+  while (collapsed.length > 0 && collapsed[0] === '') {
+    collapsed.shift();
+  }
+  // Strip trailing blank lines
+  while (collapsed.length > 0 && collapsed[collapsed.length - 1] === '') {
+    collapsed.pop();
+  }
+
+  return collapsed.join('\n');
+}
+
+/**
+ * Show a dialog with cleaned terminal text for editing and copying.
+ * Follows the existing dialog pattern from dialogs.ts.
+ */
+export function showCopyDialog(text: string): Promise<void> {
+  const cleaned = cleanTerminalText(text);
+
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'dialog-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog copy-dialog';
+
+    const title = document.createElement('div');
+    title.className = 'dialog-title';
+    title.textContent = 'Copy Text';
+    dialog.appendChild(title);
+
+    const subtitle = document.createElement('div');
+    subtitle.className = 'copy-dialog-subtitle';
+    subtitle.textContent = 'Edit the text below, then copy to clipboard.';
+    dialog.appendChild(subtitle);
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'copy-dialog-textarea';
+    textarea.value = cleaned;
+    textarea.spellcheck = false;
+    dialog.appendChild(textarea);
+
+    const footer = document.createElement('div');
+    footer.className = 'copy-dialog-footer';
+
+    const lineCount = document.createElement('span');
+    lineCount.className = 'copy-dialog-line-count';
+    const updateLineCount = () => {
+      const count = textarea.value.split('\n').length;
+      lineCount.textContent = `${count} line${count !== 1 ? 's' : ''}`;
+    };
+    updateLineCount();
+    textarea.addEventListener('input', updateLineCount);
+    footer.appendChild(lineCount);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'dialog-buttons';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'dialog-btn dialog-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    buttons.appendChild(cancelBtn);
+
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'dialog-btn dialog-btn-primary';
+    copyBtn.textContent = 'Copy';
+    buttons.appendChild(copyBtn);
+
+    footer.appendChild(buttons);
+    dialog.appendChild(footer);
+    overlay.appendChild(dialog);
+
+    const close = () => {
+      overlay.remove();
+      resolve();
+    };
+
+    const copyAndClose = () => {
+      navigator.clipboard.writeText(textarea.value);
+      close();
+    };
+
+    cancelBtn.onclick = close;
+    copyBtn.onclick = copyAndClose;
+
+    textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+      if (e.key === 'Enter' && e.ctrlKey) {
+        e.preventDefault();
+        copyAndClose();
+      }
+    });
+
+    overlay.onclick = (e) => {
+      if (e.target === overlay) {
+        close();
+      }
+    };
+
+    document.body.appendChild(overlay);
+    textarea.focus();
+    textarea.select();
+  });
+}

--- a/src/components/TerminalPane.keyboard.test.ts
+++ b/src/components/TerminalPane.keyboard.test.ts
@@ -69,6 +69,15 @@ function simulateCustomKeyHandler(event: ReturnType<typeof createMockKeyboardEve
     };
   }
 
+  if (action === 'clipboard.copyClean') {
+    event.preventDefault();
+    return {
+      handlerReturn: false,
+      preventDefaultCalled: event.preventDefaultCalled,
+      pasteTriggered: false,
+    };
+  }
+
   if (action === 'clipboard.paste') {
     event.preventDefault();
     pasteTriggered = true;
@@ -187,6 +196,36 @@ describe('TerminalPane custom key event handler bugs', () => {
 
       expect(result.handlerReturn).toBe(true);
       expect(result.preventDefaultCalled).toBe(true);
+    });
+  });
+
+  describe('clipboard.copyClean (Ctrl+Shift+Alt+C)', () => {
+    it('must call preventDefault and return false', () => {
+      const event = createMockKeyboardEvent('C', {
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: true,
+      });
+      const result = simulateCustomKeyHandler(event);
+
+      expect(result.handlerReturn).toBe(false);
+      expect(result.preventDefaultCalled).toBe(true);
+      expect(result.pasteTriggered).toBe(false);
+    });
+
+    it('does not conflict with clipboard.copy (Ctrl+Shift+C)', () => {
+      const copyEvent = createMockKeyboardEvent('C', {
+        ctrlKey: true,
+        shiftKey: true,
+      });
+      const copyCleanEvent = createMockKeyboardEvent('C', {
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: true,
+      });
+
+      expect(keybindingStore.matchAction(copyEvent)).toBe('clipboard.copy');
+      expect(keybindingStore.matchAction(copyCleanEvent)).toBe('clipboard.copyClean');
     });
   });
 

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -4,6 +4,7 @@ import { store } from '../state/store';
 import { isAppShortcut, isTerminalControlKey } from './keyboard';
 import { keybindingStore } from '../state/keybinding-store';
 import { TerminalRenderer, RichGridData, RichGridDiff } from './TerminalRenderer';
+import { showCopyDialog } from './CopyDialog';
 import { perfTracer } from '../utils/PerfTracer';
 import { themeStore } from '../state/theme-store';
 
@@ -190,6 +191,21 @@ export class TerminalPane {
         this.renderer.getSelectedText(this.terminalId).then((text) => {
           if (text) {
             navigator.clipboard.writeText(text);
+          }
+        });
+      }
+      return;
+    }
+
+    // Copy (Clean): open dialog with cleaned text
+    if (action === 'clipboard.copyClean') {
+      event.preventDefault();
+      if (this.renderer.hasSelection()) {
+        this.renderer.getSelectedText(this.terminalId).then((text) => {
+          if (text) {
+            showCopyDialog(text).then(() => {
+              this.renderer.focus();
+            });
           }
         });
       }

--- a/src/state/keybinding-store.test.ts
+++ b/src/state/keybinding-store.test.ts
@@ -104,6 +104,28 @@ describe('KeybindingStore', () => {
       expect(store.isAppShortcut(keydown('F2'))).toBe(true);
     });
 
+    it('matches Ctrl+Shift+Alt+C to clipboard.copyClean', () => {
+      const store = new KeybindingStore();
+      expect(store.matchAction(keydown('C', { ctrlKey: true, shiftKey: true, altKey: true }))).toBe(
+        'clipboard.copyClean'
+      );
+    });
+
+    it('clipboard.copyClean does not conflict with clipboard.copy', () => {
+      const store = new KeybindingStore();
+      expect(store.matchAction(keydown('C', { ctrlKey: true, shiftKey: true }))).toBe('clipboard.copy');
+      expect(store.matchAction(keydown('C', { ctrlKey: true, shiftKey: true, altKey: true }))).toBe('clipboard.copyClean');
+      expect(store.findConflict(
+        { ctrlKey: true, shiftKey: true, altKey: true, key: 'c' },
+        'clipboard.copyClean'
+      )).toBeNull();
+    });
+
+    it('classifies clipboard.copyClean as an app shortcut', () => {
+      const store = new KeybindingStore();
+      expect(store.isAppShortcut(keydown('C', { ctrlKey: true, shiftKey: true, altKey: true }))).toBe(true);
+    });
+
     it('returns null for unbound keys', () => {
       const store = new KeybindingStore();
       expect(store.matchAction(keydown('a', { ctrlKey: true }))).toBeNull();

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -12,6 +12,7 @@ export type ActionId =
   | 'terminal.suspend'
   | 'terminal.literalNext'
   | 'clipboard.copy'
+  | 'clipboard.copyClean'
   | 'clipboard.paste'
   | 'tabs.newTerminal'
   | 'tabs.closeTerminal'
@@ -70,6 +71,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Clipboard',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'c' },
+  },
+  {
+    id: 'clipboard.copyClean',
+    label: 'Copy (Clean)',
+    category: 'Clipboard',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: true, key: 'c' },
   },
   {
     id: 'clipboard.paste',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1481,3 +1481,51 @@ body.dragging-active * {
 .theme-import-btn {
   margin-top: 8px;
 }
+
+/* Copy dialog */
+.copy-dialog {
+  min-width: 600px;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+
+.copy-dialog-subtitle {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.copy-dialog-textarea {
+  flex: 1;
+  min-height: 200px;
+  max-height: 50vh;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: 'Cascadia Code', Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: vertical;
+  tab-size: 2;
+  margin-bottom: 12px;
+}
+
+.copy-dialog-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.copy-dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.copy-dialog-line-count {
+  font-size: 12px;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary

- Adds a **Copy (Clean)** action (`Ctrl+Shift+Alt+C`) that opens an editable dialog with cleaned terminal text
- The `cleanTerminalText()` function strips trailing whitespace, collapses 3+ consecutive blank lines into 2, and trims leading/trailing blank lines
- Dialog allows editing before copying and supports `Ctrl+Enter` to copy and `Escape` to dismiss

## Changes

- `src/state/keybinding-store.ts` -- new `clipboard.copyClean` action with `Ctrl+Shift+Alt+C` chord
- `src/components/CopyDialog.ts` -- `cleanTerminalText()` function and `showCopyDialog()` dialog
- `src/components/TerminalPane.ts` -- handler for the new action in the custom key handler
- `src/styles/main.css` -- `.copy-dialog-*` CSS styles

## Tests

- `src/components/CopyDialog.test.ts` -- 14 unit tests covering all `cleanTerminalText` edge cases
- `src/components/TerminalPane.keyboard.test.ts` -- tests for the new shortcut behavior and non-conflict with `clipboard.copy`
- `src/state/keybinding-store.test.ts` -- tests for action mapping, conflict detection, and app-shortcut classification