### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+  GODLY_NO_DETACH: "1"
+
+jobs:
+  check-and-lint:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
+      - run: cd src-tauri && cargo check --workspace
+
+  rust-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+      - run: cd src-tauri && cargo test -p godly-protocol
+      - run: cd src-tauri && cargo test -p godly-vt
+      - run: cd src-tauri && cargo test -p godly-daemon
+      - run: cd src-tauri && cargo test -p godly-terminal
+
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: cd src-tauri && cargo build -p godly-daemon -p godly-mcp -p godly-notify --release
+      - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,20 +79,34 @@ These extend the global CLAUDE.md workflows (bug fix, feature development):
 
 ## Verification Requirements
 
-**IMPORTANT**: After making any code changes, always verify the project builds and tests pass before considering work complete. Loop until all checks pass:
+**IMPORTANT**: CI runs full builds and tests on every PR. Locally, run only lightweight checks:
 
-1. **Run all tests**:
+### Local checks (required before considering work complete):
+
+1. **Cargo check** (type-check, no codegen):
    ```bash
-   cd src-tauri && cargo test -p godly-protocol && cargo test -p godly-daemon && cargo test -p godly-terminal
+   cd src-tauri && cargo check --workspace
+   ```
+
+2. **Run tests for changed crates only**:
+   ```bash
+   cd src-tauri && cargo test -p <crate-you-modified>
+   ```
+
+3. **Frontend tests**:
+   ```bash
    npm test
    ```
 
-2. **Verify production build**:
-   ```bash
-   npm run build
-   ```
+4. If any step fails, fix and repeat.
 
-3. If any step fails, fix the issues and repeat until everything passes.
+### CI checks (GitHub Actions, runs automatically on PR):
+- Full `cargo test` for all workspace crates
+- `tsc --noEmit` (TypeScript strict check)
+- `npm run build` (production Vite build)
+- Full release build of daemon/mcp/notify binaries
+
+Do NOT run `npm run build` or `cargo test --workspace` locally unless debugging a CI failure.
 
 ## Architecture Overview
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) with 3 parallel jobs on `windows-latest`: type-checking/lint, Rust tests, and full builds
- Relaxes CLAUDE.md local verification to lightweight checks (`cargo check` + targeted crate tests), since CI now handles full builds and cross-crate testing
- Pins Rust toolchain to `stable` via `rust-toolchain.toml` for reproducible CI builds

## Test plan
- [ ] Verify all 3 CI jobs (`check-and-lint`, `rust-tests`, `build`) trigger and pass on this PR
- [ ] Confirm Rust cache hits on subsequent pushes to the same PR
- [ ] Optionally enable branch protection requiring these status checks before merge