### PR TITLE
fix: show dead terminal indicator instead of silently removing exited tabs

### DIFF
--- a/docs/daemon-session-leak.md
+++ b/docs/daemon-session-leak.md
@@ -1,0 +1,36 @@
+# Dead Terminal Visibility + Daemon Session Memory Leak
+
+## Problem
+
+When a terminal process exits (crash, `exit` command, or Claude exits), two things went wrong:
+
+1. **No visual feedback**: The tab was silently removed from the UI. Users had no indication that a process crashed vs. being intentionally closed.
+2. **Daemon memory leak**: Dead sessions stayed in the daemon's `HashMap` forever (~60MB+ per session: vt_parser, ring_buffer, output_history, blocked reader thread).
+
+## Root Cause
+
+The `terminal-closed` event handler in `terminal-service.ts` called `store.removeTerminal()`, which immediately removed the tab from the UI. There was no `close_terminal` invoke to tell the daemon to clean up the session resources.
+
+## Fix
+
+### Frontend changes
+
+- **`store.ts`**: Added `exited?: boolean` property to the `Terminal` interface.
+- **`terminal-service.ts`**: Changed `terminal-closed` handler to call `store.updateTerminal(id, { exited: true })` instead of `store.removeTerminal(id)`. Also fires `invoke('close_terminal', ...)` to free daemon resources.
+- **`TabBar.ts`**: Dead tabs get a `dead` CSS class (dimmed + line-through).
+- **`TerminalPane.ts`**: Added `showExitedOverlay()` method that displays a "Process exited" overlay. Keyboard input is blocked for exited terminals.
+- **`App.ts`**: Wires up overlay display in `handleStateChange()`.
+- **`main.css`**: Added `.tab.dead` and `.terminal-exited-overlay` styles.
+
+### Daemon resource cleanup
+
+The fire-and-forget `close_terminal` invoke tells the daemon to drop the session from its HashMap, freeing:
+- `vt_parser` (~20MB with scrollback)
+- `ring_buffer` (~16MB)
+- `output_history` (variable)
+- Reader thread resources
+
+## Regression Risk
+
+- Tab close behavior: The close button (`handleCloseTab`) still calls `store.removeTerminal()` directly, so manually closing a tab works as before.
+- Tests updated to verify `exited: true` instead of removal.

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -220,6 +220,16 @@ export class App {
       });
     }
 
+    // Show exited overlay on dead terminals
+    for (const terminal of state.terminals) {
+      if (terminal.exited) {
+        const pane = this.terminalPanes.get(terminal.id);
+        if (pane instanceof TerminalPane) {
+          pane.showExitedOverlay();
+        }
+      }
+    }
+
     // Clear notification badge for the now-active terminal
     if (state.activeTerminalId) {
       notificationStore.clearBadge(state.activeTerminalId);

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -231,6 +231,9 @@ export class TabBar {
       tab.classList.toggle('active', isActive);
     }
 
+    // Dead tab indicator
+    tab.classList.toggle('dead', !!terminal.exited);
+
     // Split indicator: highlight tabs that are part of a split
     const state = store.getState();
     const split = state.activeWorkspaceId
@@ -280,6 +283,9 @@ export class TabBar {
     tab.className = `tab${isActive ? ' active' : ''}`;
     if (terminal.paneType === 'figma') {
       tab.classList.add('figma-tab');
+    }
+    if (terminal.exited) {
+      tab.classList.add('dead');
     }
     tab.dataset.terminalId = terminal.id;
 

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -81,7 +81,9 @@ class TerminalService {
       (event) => {
         const { terminal_id } = event.payload;
         this.outputListeners.delete(terminal_id);
-        store.removeTerminal(terminal_id);
+        store.updateTerminal(terminal_id, { exited: true });
+        // Free daemon session resources (fire-and-forget)
+        invoke('close_terminal', { terminalId: terminal_id }).catch(() => {});
       }
     );
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -12,6 +12,7 @@ export interface Terminal {
   userRenamed?: boolean;
   paneType?: PaneType;
   figmaUrl?: string;
+  exited?: boolean;
 }
 
 export type ShellType =

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -844,10 +844,35 @@ body.dragging-active * {
   background: var(--bg-primary);
 }
 
+/* Dead tab indicator */
+.tab.dead {
+  opacity: 0.5;
+}
+
+.tab.dead .tab-title {
+  text-decoration: line-through;
+}
+
 /* Figma tab indicator */
 .tab.figma-tab .tab-title::before {
   content: '\25C6 ';
   color: var(--accent);
+}
+
+/* Process exited overlay */
+.terminal-exited-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10;
+  color: var(--text-secondary);
+  font-size: 14px;
 }
 
 /* WebGL overlay canvas for scrollbar and URL hover */


### PR DESCRIPTION
## Summary

- When a terminal process exits, the tab now stays visible with a dimmed/strikethrough indicator and a "Process exited" overlay, instead of being silently removed
- Fires `close_terminal` on process exit to free daemon session resources (vt_parser, ring_buffer, reader thread ~60MB per session)
- Keyboard input is blocked on dead terminals while app shortcuts (close tab, etc.) still work

## Test plan

- [x] `npm test` — 341 frontend tests pass (8 updated terminal-service tests)
- [x] `cargo test -p godly-protocol` — 32 tests pass
- [x] `cargo test -p godly-daemon` — 58 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — production build succeeds