### PR TITLE
fix: handle Ctrl+Alt+letter combos instead of leaking bare character

### DIFF
--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -338,6 +338,16 @@ export class TerminalPane {
       if (key === ' ' || event.code === 'Space') return '\x00';
     }
 
+    // Ctrl+Alt combinations -> ESC + control character
+    // Standard terminal behavior: Ctrl+Alt+letter sends ESC followed by the
+    // control character for that letter (e.g. Ctrl+Alt+C → ESC + \x03).
+    if (event.ctrlKey && event.altKey && !event.shiftKey) {
+      const key = event.key.toLowerCase();
+      if (key.length === 1 && key >= 'a' && key <= 'z') {
+        return '\x1b' + String.fromCharCode(key.charCodeAt(0) - 96);
+      }
+    }
+
     // Alt combinations -> ESC + key
     if (event.altKey && !event.ctrlKey && event.key.length === 1) {
       return '\x1b' + event.key;


### PR DESCRIPTION
## Summary

- **Bug**: Pressing Ctrl+Alt+letter (e.g. Ctrl+Alt+C) typed the bare letter ("c") instead of sending the correct terminal escape sequence. The `keyToTerminalData` handler had a Ctrl-only branch guarded by `!altKey` and an Alt-only branch guarded by `!ctrlKey`, so Ctrl+Alt combos fell through both, returned `null`, and the textarea input event fired with the raw character.
- **Fix**: Added a Ctrl+Alt+letter handler that sends ESC + control character (e.g. Ctrl+Alt+C → `\x1b\x03`), which is the standard terminal behavior for this modifier combination.
- **Tests**: Added 6 new tests across `TerminalPane.dead-keys.test.ts` and `TerminalPane.keyboard.test.ts` covering Ctrl+Alt+letter data encoding and preventDefault behavior.

## Test plan

- [x] All 6 new tests pass (Ctrl+Alt+C/D/A/Z encoding, keydown source, preventDefault called)
- [x] Full frontend test suite passes (400 tests across 29 files)
- [ ] Manual: press Ctrl+Alt+C in a terminal pane — should not type "c"