### PR TITLE
feat: Quick Claude — instant idea capture

### DIFF
--- a/docs/quick-claude.md
+++ b/docs/quick-claude.md
@@ -1,0 +1,52 @@
+# Quick Claude: Instant Idea Capture
+
+## Status: Implemented
+
+## Problem
+
+The workflow of opening a new terminal with worktree, starting Claude Code, and typing a prompt was too slow for rapid idea capture. Each step required waiting for the previous to complete, making it impossible to fire off multiple ideas in quick succession.
+
+## Solution
+
+Added "Quick Claude" — a fire-and-forget feature with 3 entry points:
+
+### 1. Keyboard Shortcut (`Ctrl+Shift+Q`)
+- Opens a dialog with a textarea for the prompt and optional branch name
+- Dialog closes immediately on Ctrl+Enter
+- Terminal + worktree + Claude Code + prompt delivery happen in a background thread
+- Toast notification appears when the session is ready
+
+### 2. MCP Tool (`quick_claude`)
+- Parameters: `workspace_id`, `prompt`, `branch_name?`, `skip_fetch?`
+- Returns immediately with `terminal_id` and `worktree_branch`
+- Multiple calls can be fired in rapid succession from a central Claude session
+- Each spawns its own background thread, no blocking
+
+### 3. Central Claude Dispatcher
+- Use the MCP tool from any Claude session (no extra code needed)
+- Say "new idea: fix the scrollback bug" and Claude calls `quick_claude`
+
+## Key Optimization: Skip Fetch
+
+Added `create_worktree_with_options(..., skip_fetch: bool)` to `worktree.rs`. When `skip_fetch=true` (default for Quick Claude), worktrees branch from local HEAD instead of fetching from origin first. This saves 100-500ms of network latency per worktree creation.
+
+## Background Task Flow
+
+1. Wait for shell to be idle (500ms idle threshold, 5s timeout)
+2. Write `claude -dangerously-skip-permissions\r`
+3. Wait for Claude to be idle (2000ms idle threshold, 60s timeout)
+4. Write the user's prompt
+5. Emit `quick-claude-ready` Tauri event (triggers toast notification)
+
+## Files Changed
+
+- `src-tauri/src/worktree.rs` — `create_worktree_with_options` with `skip_fetch`
+- `src-tauri/protocol/src/mcp_messages.rs` — `QuickClaude` variant
+- `src-tauri/src/commands/terminal.rs` — `quick_claude` command + background task
+- `src-tauri/src/mcp_server/handler.rs` — MCP handler for `QuickClaude`
+- `src-tauri/mcp/src/tools.rs` — Tool definition + dispatch
+- `src-tauri/mcp/src/daemon_direct.rs` — App-only fallback
+- `src-tauri/src/lib.rs` — Register command
+- `src/state/keybinding-store.ts` — `tabs.quickClaude` action
+- `src/components/dialogs.ts` — `showQuickClaudeDialog()`
+- `src/components/App.ts` — Shortcut handler + toast listener

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -460,6 +460,7 @@ impl Backend for DaemonDirectBackend {
             McpRequest::GetNotificationStatus { .. } => {
                 Ok(Self::app_only_error("get_notification_status"))
             }
+            McpRequest::QuickClaude { .. } => Ok(Self::app_only_error("quick_claude")),
         }
     }
 

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -394,6 +394,32 @@ pub fn list_tools() -> Value {
                     },
                     "required": ["terminal_id", "text"]
                 }
+            },
+            {
+                "name": "quick_claude",
+                "description": "Spawn a new Claude Code session with a prompt. Creates a terminal with a git worktree (skipping fetch by default for speed), starts Claude Code, waits for it to be ready, and writes the prompt — all in background. Returns immediately with the terminal ID. Fire multiple calls in rapid succession for quick idea capture.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace to create the terminal in"
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "The prompt to send to Claude Code once it is ready"
+                        },
+                        "branch_name": {
+                            "type": "string",
+                            "description": "Optional custom worktree branch name (e.g. 'fix-login-bug'). Auto-generated if omitted."
+                        },
+                        "skip_fetch": {
+                            "type": "boolean",
+                            "description": "Skip git fetch before creating worktree (default: true for speed). Set false to branch from latest remote state."
+                        }
+                    },
+                    "required": ["workspace_id", "prompt"]
+                }
             }
         ]
     })
@@ -694,6 +720,27 @@ pub fn call_tool(
                 terminal_id,
                 text,
                 timeout_ms,
+            }
+        }
+
+        "quick_claude" => {
+            let workspace_id = args
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing workspace_id")?
+                .to_string();
+            let prompt = args
+                .get("prompt")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing prompt")?
+                .to_string();
+            let branch_name = args.get("branch_name").and_then(|v| v.as_str()).map(String::from);
+            let skip_fetch = args.get("skip_fetch").and_then(|v| v.as_bool());
+            McpRequest::QuickClaude {
+                workspace_id,
+                prompt,
+                branch_name,
+                skip_fetch,
             }
         }
 

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -76,6 +76,16 @@ pub enum McpRequest {
         timeout_ms: u64,
     },
 
+    // Quick Claude (fire-and-forget idea capture)
+    QuickClaude {
+        workspace_id: String,
+        prompt: String,
+        #[serde(default)]
+        branch_name: Option<String>,
+        #[serde(default)]
+        skip_fetch: Option<bool>,
+    },
+
     // Notifications
     Notify {
         terminal_id: String,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use tauri::State;
+use tauri::{Emitter, State};
 use uuid::Uuid;
 
 use crate::daemon_client::DaemonClient;
@@ -348,6 +348,261 @@ pub fn sync_active_terminal(
 ) -> Result<(), String> {
     state.set_active_terminal_id(terminal_id);
     Ok(())
+}
+
+// ── Quick Claude ─────────────────────────────────────────────────────
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct QuickClaudeResult {
+    pub terminal_id: String,
+    pub worktree_branch: Option<String>,
+}
+
+/// Create a terminal with a worktree, start Claude Code, and write a prompt — all
+/// in the background. Returns immediately with the terminal ID so the caller can
+/// fire multiple in rapid succession without waiting.
+#[tauri::command]
+pub fn quick_claude(
+    workspace_id: String,
+    prompt: String,
+    branch_name: Option<String>,
+    skip_fetch: Option<bool>,
+    state: State<Arc<AppState>>,
+    daemon: State<Arc<DaemonClient>>,
+    auto_save: State<Arc<AutoSaveManager>>,
+    app_handle: tauri::AppHandle,
+) -> Result<QuickClaudeResult, String> {
+    let terminal_id = Uuid::new_v4().to_string();
+
+    let workspace = state
+        .get_workspace(&workspace_id)
+        .ok_or("Workspace not found")?;
+
+    // Determine working directory (worktree or fallback to workspace folder)
+    let mut worktree_path_result: Option<String> = None;
+    let mut worktree_branch: Option<String> = None;
+    let should_skip_fetch = skip_fetch.unwrap_or(true);
+
+    let working_dir = {
+        let wsl = crate::worktree::WslConfig::from_path(&workspace.folder_path);
+        match crate::worktree::get_repo_root(&workspace.folder_path, wsl.as_ref()) {
+            Ok(repo_root) => {
+                let custom_name = branch_name.as_deref();
+                match crate::worktree::create_worktree_with_options(
+                    &repo_root,
+                    &terminal_id,
+                    custom_name,
+                    wsl.as_ref(),
+                    should_skip_fetch,
+                ) {
+                    Ok(wt_result) => {
+                        eprintln!(
+                            "[quick_claude] Created worktree at: {} (branch: {})",
+                            wt_result.path, wt_result.branch
+                        );
+                        worktree_path_result = Some(wt_result.path.clone());
+                        worktree_branch = Some(wt_result.branch);
+                        Some(wt_result.path)
+                    }
+                    Err(e) => {
+                        return Err(format!("Worktree creation failed: {}", e));
+                    }
+                }
+            }
+            Err(_) => {
+                // Not a git repo — fall back to workspace directory
+                Some(workspace.folder_path.clone())
+            }
+        }
+    };
+
+    // Shell type from workspace
+    let shell_type = workspace.shell_type.clone();
+    let process_name = shell_type.display_name();
+
+    // Build env vars
+    let mut env_vars = HashMap::new();
+    env_vars.insert("GODLY_SESSION_ID".to_string(), terminal_id.clone());
+    env_vars.insert("GODLY_WORKSPACE_ID".to_string(), workspace_id.clone());
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(exe_dir) = current_exe.parent() {
+            let mcp_name = if cfg!(windows) { "godly-mcp.exe" } else { "godly-mcp" };
+            let mcp_path = exe_dir.join(mcp_name);
+            if mcp_path.exists() {
+                env_vars.insert(
+                    "GODLY_MCP_BINARY".to_string(),
+                    mcp_path.to_string_lossy().to_string(),
+                );
+            }
+        }
+    }
+
+    // Create session via daemon
+    let request = Request::CreateSession {
+        id: terminal_id.clone(),
+        shell_type: to_protocol_shell_type(&shell_type),
+        cwd: working_dir.clone(),
+        rows: 24,
+        cols: 80,
+        env: Some(env_vars),
+    };
+
+    let response = daemon.send_request(&request)?;
+    match response {
+        Response::SessionCreated { .. } => {}
+        Response::Error { message } => return Err(message),
+        other => return Err(format!("Unexpected response: {:?}", other)),
+    }
+
+    // Attach
+    let attach_request = Request::Attach {
+        session_id: terminal_id.clone(),
+    };
+    let attach_response = daemon.send_request(&attach_request)?;
+    match attach_response {
+        Response::Ok | Response::Buffer { .. } => {}
+        Response::Error { message } => return Err(format!("Failed to attach: {}", message)),
+        other => return Err(format!("Unexpected attach response: {:?}", other)),
+    }
+
+    daemon.track_attach(terminal_id.clone());
+
+    // Store metadata
+    state.add_session_metadata(
+        terminal_id.clone(),
+        SessionMetadata {
+            shell_type,
+            cwd: working_dir,
+            worktree_path: worktree_path_result,
+            worktree_branch: worktree_branch.clone(),
+        },
+    );
+
+    let terminal_name = worktree_branch
+        .clone()
+        .unwrap_or_else(|| "Quick Claude".to_string());
+
+    state.add_terminal(Terminal {
+        id: terminal_id.clone(),
+        workspace_id,
+        name: terminal_name.clone(),
+        process_name,
+    });
+
+    auto_save.mark_dirty();
+
+    // Spawn background thread: start dclaude → wait for ready → write prompt
+    let daemon_bg = daemon.inner().clone();
+    let app_handle_bg = app_handle.clone();
+    let terminal_id_bg = terminal_id.clone();
+    std::thread::spawn(move || {
+        quick_claude_background(daemon_bg, app_handle_bg, terminal_id_bg, prompt, terminal_name);
+    });
+
+    Ok(QuickClaudeResult {
+        terminal_id,
+        worktree_branch,
+    })
+}
+
+/// Background task: waits for shell, starts Claude Code, waits for ready, writes prompt.
+/// Called from both the Tauri command and MCP handler.
+pub(crate) fn quick_claude_background(
+    daemon: Arc<DaemonClient>,
+    app_handle: tauri::AppHandle,
+    terminal_id: String,
+    prompt: String,
+    display_name: String,
+) {
+    // Step 1: Wait for shell to be ready (idle for 500ms, timeout 5s)
+    let shell_ready = poll_idle(&daemon, &terminal_id, 500, 5_000);
+    if !shell_ready {
+        eprintln!("[quick_claude] Shell did not become idle in time, writing claude command anyway");
+    }
+
+    // Step 2: Write claude command
+    let claude_cmd = Request::Write {
+        session_id: terminal_id.clone(),
+        data: "claude -dangerously-skip-permissions\r".as_bytes().to_vec(),
+    };
+    if let Err(e) = daemon.send_request(&claude_cmd) {
+        eprintln!("[quick_claude] Failed to write claude command: {}", e);
+        return;
+    }
+
+    // Step 3: Wait for Claude to be ready (idle for 2000ms after startup burst, timeout 60s)
+    let claude_ready = poll_idle(&daemon, &terminal_id, 2_000, 60_000);
+    if !claude_ready {
+        eprintln!("[quick_claude] Claude did not become idle within timeout, writing prompt anyway");
+    }
+
+    // Step 4: Small delay to ensure Claude is fully accepting input
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    // Step 5: Write the prompt (convert \n → \r for PTY)
+    let prompt_data = format!("{}\r", prompt.replace("\r\n", "\r").replace('\n', "\r"));
+    let prompt_req = Request::Write {
+        session_id: terminal_id.clone(),
+        data: prompt_data.into_bytes(),
+    };
+    if let Err(e) = daemon.send_request(&prompt_req) {
+        eprintln!("[quick_claude] Failed to write prompt: {}", e);
+        return;
+    }
+
+    eprintln!("[quick_claude] Prompt delivered to {}", display_name);
+
+    // Step 6: Emit toast notification
+    #[derive(serde::Serialize, Clone)]
+    struct QuickClaudeReadyPayload {
+        terminal_id: String,
+        display_name: String,
+    }
+    let _ = app_handle.emit(
+        "quick-claude-ready",
+        QuickClaudeReadyPayload {
+            terminal_id,
+            display_name,
+        },
+    );
+}
+
+/// Poll until the terminal has been idle for `idle_ms` milliseconds, or timeout.
+fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, timeout_ms: u64) -> bool {
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    let poll_interval = (idle_ms / 4).min(500).max(50);
+
+    loop {
+        let req = Request::GetLastOutputTime {
+            session_id: session_id.to_string(),
+        };
+        match daemon.send_request(&req) {
+            Ok(Response::LastOutputTime { epoch_ms, running }) => {
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                let ago = now_ms.saturating_sub(epoch_ms);
+
+                if ago >= idle_ms {
+                    return true;
+                }
+                if !running {
+                    return true;
+                }
+            }
+            Ok(_) | Err(_) => {
+                // Can't reach daemon or unexpected response — bail out
+                return false;
+            }
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(poll_interval));
+    }
 }
 
 /// Detach all sessions (called on window close instead of killing them)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub fn run() {
             commands::reconnect_sessions,
             commands::attach_session,
             commands::sync_active_terminal,
+            commands::quick_claude,
             commands::detach_all_sessions,
             commands::create_workspace,
             commands::delete_workspace,

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -157,3 +157,94 @@ export function showFigmaUrlPrompt(): Promise<string | null> {
     input.focus();
   });
 }
+
+/**
+ * Quick Claude dialog: capture an idea to dispatch to a new Claude Code session.
+ * Returns { prompt, branchName? } or null if cancelled.
+ */
+export interface QuickClaudeInput {
+  prompt: string;
+  branchName?: string;
+}
+
+export function showQuickClaudeDialog(): Promise<QuickClaudeInput | null> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'dialog-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+
+    const title = document.createElement('div');
+    title.className = 'dialog-title';
+    title.textContent = 'Quick Claude';
+    dialog.appendChild(title);
+
+    const hint = document.createElement('div');
+    hint.style.cssText = 'font-size: 12px; color: var(--text-secondary); margin-bottom: 8px;';
+    hint.textContent = 'Ctrl+Enter to launch \u00b7 Escape to cancel';
+    dialog.appendChild(hint);
+
+    const promptArea = document.createElement('textarea');
+    promptArea.className = 'dialog-input';
+    promptArea.placeholder = 'Describe your idea...';
+    promptArea.rows = 4;
+    promptArea.style.cssText = 'resize: vertical; min-height: 80px; font-family: inherit; font-size: 13px;';
+    dialog.appendChild(promptArea);
+
+    const branchInput = document.createElement('input');
+    branchInput.type = 'text';
+    branchInput.className = 'dialog-input';
+    branchInput.placeholder = 'Branch name (optional, auto-generated if empty)';
+    branchInput.style.marginTop = '8px';
+    dialog.appendChild(branchInput);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'dialog-buttons';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'dialog-btn dialog-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    buttons.appendChild(cancelBtn);
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'dialog-btn dialog-btn-primary';
+    okBtn.textContent = 'Launch';
+    buttons.appendChild(okBtn);
+
+    dialog.appendChild(buttons);
+    overlay.appendChild(dialog);
+
+    const close = () => overlay.remove();
+
+    const submit = () => {
+      const prompt = promptArea.value.trim();
+      if (!prompt) return;
+      close();
+      resolve({
+        prompt,
+        branchName: branchInput.value.trim() || undefined,
+      });
+    };
+
+    cancelBtn.onclick = () => { close(); resolve(null); };
+    okBtn.onclick = submit;
+
+    promptArea.onkeydown = (e) => {
+      if (e.key === 'Enter' && e.ctrlKey) { e.preventDefault(); submit(); }
+      if (e.key === 'Escape') { close(); resolve(null); }
+    };
+
+    branchInput.onkeydown = (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); submit(); }
+      if (e.key === 'Escape') { close(); resolve(null); }
+    };
+
+    overlay.onclick = (e) => {
+      if (e.target === overlay) { close(); resolve(null); }
+    };
+
+    document.body.appendChild(overlay);
+    promptArea.focus();
+  });
+}

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -25,7 +25,8 @@ export type ActionId =
   | 'scroll.pageDown'
   | 'scroll.toTop'
   | 'scroll.toBottom'
-  | 'tabs.renameTerminal';
+  | 'tabs.renameTerminal'
+  | 'tabs.quickClaude';
 
 export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll';
 
@@ -168,6 +169,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Tabs',
     type: 'app',
     defaultChord: { ctrlKey: false, shiftKey: false, altKey: false, key: 'f2' },
+  },
+  {
+    id: 'tabs.quickClaude',
+    label: 'Quick Claude',
+    category: 'Tabs',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'q' },
   },
 ];
 


### PR DESCRIPTION
## Summary

- **Quick Claude** (`Ctrl+Shift+Q`): Opens a dialog to capture an idea, then creates a terminal with worktree, starts Claude Code, and writes the prompt — all in background. Dialog closes instantly.
- **MCP tool** (`quick_claude`): Fire-and-forget tool that returns immediately with `terminal_id`. Multiple calls can be fired in rapid succession from a central Claude session.
- **Skip-fetch optimization**: New `create_worktree_with_options(..., skip_fetch)` branches from local HEAD instead of fetching from origin, saving 100-500ms per worktree.
- Toast notification when session is ready. Each call spawns its own background thread — no blocking.

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo test -p godly-protocol -p godly-daemon -p godly-terminal` — all 219 tests pass
- [ ] `npm test` — all 340 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run build` — production build succeeds
- [ ] Manual: Ctrl+Shift+Q opens dialog, type idea, Ctrl+Enter → tab appears, toast when ready
- [ ] Manual: MCP `quick_claude` tool returns immediately, terminal appears in Agent workspace