### PR TITLE
fix: tab name not updating when Claude Code process starts

### DIFF
--- a/src/components/TabBar.test.ts
+++ b/src/components/TabBar.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { getDisplayName } from './TabBar';
-import { Terminal } from '../state/store';
+import { Terminal, store } from '../state/store';
 
 function terminal(overrides: Partial<Terminal> = {}): Terminal {
   return {
@@ -80,5 +80,111 @@ describe('getDisplayName', () => {
       oscTitle: 'vim',
       userRenamed: false,
     }))).toBe('vim');
+  });
+});
+
+// Bug: "autopick from claude code to the terminal name" broken.
+// When a terminal is created with the default name 'Terminal' and the process
+// changes (e.g. powershell -> node when Claude Code starts), the tab should
+// show the current process name. Instead, getDisplayName() returned 'Terminal'
+// because the default name was truthy and blocked processName.
+describe('getDisplayName - process name autopick', () => {
+  it('should show processName when name is the generic default "Terminal"', () => {
+    // Bug: tab stayed "Terminal" even after process changes to "node" (Claude Code)
+    const t = terminal({
+      name: 'Terminal',
+      processName: 'node',
+    });
+    expect(getDisplayName(t)).toBe('node');
+  });
+
+  it('should show processName "claude" when Claude Code is running', () => {
+    const t = terminal({
+      name: 'Terminal',
+      processName: 'claude',
+    });
+    expect(getDisplayName(t)).toBe('claude');
+  });
+
+  it('should update display when process changes from powershell to node', () => {
+    const t = terminal({
+      name: 'Terminal',
+      processName: 'powershell',
+    });
+    const updated = { ...t, processName: 'node' };
+    expect(getDisplayName(updated)).toBe('node');
+  });
+
+  it('should prefer oscTitle over processName when both available', () => {
+    const t = terminal({
+      name: 'Terminal',
+      processName: 'node',
+      oscTitle: 'claude: fixing scrollback bug',
+    });
+    expect(getDisplayName(t)).toBe('claude: fixing scrollback bug');
+  });
+
+  it('should still show worktree branch name over processName', () => {
+    const t = terminal({
+      name: 'feat/search',
+      processName: 'node',
+    });
+    expect(getDisplayName(t)).toBe('feat/search');
+  });
+});
+
+// Full flow: claudeCodeMode workspace -> terminal created -> process changes
+describe('claudeCodeMode tab naming flow', () => {
+  beforeEach(() => {
+    store.reset();
+    store.addWorkspace({
+      id: 'ws-claude', name: 'Claude WS', folderPath: 'C:\\Projects',
+      tabOrder: [], shellType: { type: 'windows' },
+      worktreeMode: false, claudeCodeMode: true,
+    });
+  });
+
+  it('should reflect process change in tab display name', () => {
+    store.addTerminal({
+      id: 'cc-term', workspaceId: 'ws-claude',
+      name: 'Terminal',
+      processName: 'powershell',
+      order: 0,
+    });
+
+    // Claude Code starts - process-changed event fires
+    store.updateTerminal('cc-term', { processName: 'node', oscTitle: undefined });
+
+    const t = store.getState().terminals.find(t => t.id === 'cc-term')!;
+    expect(getDisplayName(t)).toBe('node');
+  });
+
+  it('should show OSC title from Claude Code when available', () => {
+    store.addTerminal({
+      id: 'cc-term', workspaceId: 'ws-claude',
+      name: 'Terminal',
+      processName: 'powershell',
+      order: 0,
+    });
+
+    store.updateTerminal('cc-term', { oscTitle: 'claude: running tests' });
+
+    const t = store.getState().terminals.find(t => t.id === 'cc-term')!;
+    expect(getDisplayName(t)).toBe('claude: running tests');
+  });
+
+  it('should fall back to processName when OSC title is cleared', () => {
+    store.addTerminal({
+      id: 'cc-term', workspaceId: 'ws-claude',
+      name: 'Terminal',
+      processName: 'node',
+      order: 0,
+    });
+
+    store.updateTerminal('cc-term', { oscTitle: 'claude: working' });
+    store.updateTerminal('cc-term', { processName: 'powershell', oscTitle: undefined });
+
+    const t = store.getState().terminals.find(t => t.id === 'cc-term')!;
+    expect(getDisplayName(t)).toBe('powershell');
   });
 });

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -10,7 +10,10 @@ import {
 
 export function getDisplayName(terminal: Terminal): string {
   if (terminal.userRenamed) return terminal.name;
-  return terminal.oscTitle || terminal.name || terminal.processName || 'Terminal';
+  // Skip the generic default 'Terminal' so processName can show through.
+  // Worktree branch names and other intentional names still take priority.
+  const name = terminal.name === 'Terminal' ? '' : terminal.name;
+  return terminal.oscTitle || name || terminal.processName || 'Terminal';
 }
 
 const DRAG_THRESHOLD = 5; // px of movement before drag starts

--- a/src/components/osc-title.integration.test.ts
+++ b/src/components/osc-title.integration.test.ts
@@ -65,8 +65,9 @@ describe('OSC title integration (godly-vt pipeline)', () => {
     simulateTitleFromSnapshot('');
     expect(getStoredTerminal().oscTitle).toBeUndefined();
 
-    // Display falls back to name since oscTitle is cleared
-    expect(getDisplayName(getStoredTerminal())).toBe('Terminal');
+    // Display falls back to processName since oscTitle is cleared and
+    // default name 'Terminal' is not a meaningful name
+    expect(getDisplayName(getStoredTerminal())).toBe('powershell');
   });
 
   it('userRenamed tab is not affected by OSC titles', () => {


### PR DESCRIPTION
## Summary

- `getDisplayName()` treated the generic default name `'Terminal'` as meaningful, blocking `processName` from ever being displayed
- When the process changed (e.g. powershell -> node/claude), the tab stayed stuck on "Terminal"
- Now the generic default is skipped so `processName` shows through. Worktree branch names and user-renamed tabs are unaffected.

## Test plan

- [x] New tests: `getDisplayName - process name autopick` (5 tests) verify processName is shown when name is the generic default
- [x] New tests: `claudeCodeMode tab naming flow` (3 tests) verify full store flow with process changes
- [x] Updated `osc-title.integration.test.ts` to expect `processName` fallback instead of generic "Terminal"
- [x] All 414 frontend tests pass (`npm test`)