### PR TITLE
feat: add performance profiling HUD overlay

### DIFF
--- a/src/components/PerfOverlay.ts
+++ b/src/components/PerfOverlay.ts
@@ -1,0 +1,151 @@
+/**
+ * Performance HUD overlay.
+ *
+ * Displays real-time latency percentiles for key operations.
+ * Toggled via Ctrl+Shift+P (debug.togglePerfOverlay shortcut).
+ */
+
+import { perfTracer, type SpanStats } from '../utils/PerfTracer';
+
+/** Preferred display order and human-readable labels for span names. */
+const SPAN_LABELS: [string, string][] = [
+  ['keydown_to_paint', 'keydown\u2192paint'],
+  ['write_to_terminal_ipc', 'write ipc'],
+  ['keydown_to_output', 'key\u2192output'],
+  ['snapshot_ipc', 'snapshot ipc'],
+  ['paint_duration', 'paint'],
+  ['raf_wait', 'raf wait'],
+  ['create_terminal', 'new terminal'],
+  ['tab_switch', 'tab switch'],
+  ['workspace_switch', 'ws switch'],
+  ['app_startup', 'app startup'],
+  ['reconnect_sessions', 'reconnect'],
+];
+
+const LABEL_MAP = new Map(SPAN_LABELS);
+const ORDERED_KEYS = SPAN_LABELS.map(([k]) => k);
+
+function fmt(ms: number): string {
+  if (ms >= 1000) return (ms / 1000).toFixed(1) + 's';
+  if (ms >= 100) return ms.toFixed(0);
+  if (ms >= 10) return ms.toFixed(1);
+  return ms.toFixed(1);
+}
+
+export class PerfOverlay {
+  private el: HTMLElement;
+  private tableBody: HTMLElement;
+  private fpsLine: HTMLElement;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private lastTickTime = performance.now();
+  private lastFrameCount = 0;
+
+  constructor() {
+    this.el = document.createElement('div');
+    this.el.className = 'perf-overlay';
+
+    // Header
+    const header = document.createElement('div');
+    header.className = 'perf-overlay-header';
+    header.textContent = 'Perf';
+
+    // Export button
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'perf-overlay-export';
+    exportBtn.textContent = 'Export';
+    exportBtn.title = 'Export Chrome trace (open in chrome://tracing)';
+    exportBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.exportTrace();
+    });
+    header.appendChild(exportBtn);
+
+    this.el.appendChild(header);
+
+    // Table header
+    const thead = document.createElement('div');
+    thead.className = 'perf-overlay-row perf-overlay-thead';
+    thead.innerHTML =
+      '<span class="perf-col-name">metric</span>' +
+      '<span class="perf-col-num">p50</span>' +
+      '<span class="perf-col-num">p95</span>' +
+      '<span class="perf-col-num">max</span>' +
+      '<span class="perf-col-num">n</span>';
+    this.el.appendChild(thead);
+
+    // Table body
+    this.tableBody = document.createElement('div');
+    this.tableBody.className = 'perf-overlay-body';
+    this.el.appendChild(this.tableBody);
+
+    // FPS line
+    this.fpsLine = document.createElement('div');
+    this.fpsLine.className = 'perf-overlay-fps';
+    this.fpsLine.textContent = 'FPS: --';
+    this.el.appendChild(this.fpsLine);
+  }
+
+  mount(parent: HTMLElement): void {
+    parent.appendChild(this.el);
+    this.lastTickTime = performance.now();
+    this.lastFrameCount = perfTracer.getFrameCount();
+    this.interval = setInterval(() => this.refresh(), 1000);
+    this.refresh();
+  }
+
+  destroy(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.el.remove();
+  }
+
+  private refresh(): void {
+    const stats = perfTracer.getStats();
+
+    // Build rows: ordered keys first, then any unknown spans
+    const rows: [string, SpanStats][] = [];
+    for (const key of ORDERED_KEYS) {
+      const s = stats.get(key);
+      if (s) rows.push([key, s]);
+    }
+    for (const [key, s] of stats) {
+      if (!LABEL_MAP.has(key)) rows.push([key, s]);
+    }
+
+    this.tableBody.textContent = '';
+    for (const [name, s] of rows) {
+      const row = document.createElement('div');
+      row.className = 'perf-overlay-row';
+      const label = LABEL_MAP.get(name) ?? name;
+      row.innerHTML =
+        `<span class="perf-col-name">${label}</span>` +
+        `<span class="perf-col-num">${fmt(s.p50)}</span>` +
+        `<span class="perf-col-num">${fmt(s.p95)}</span>` +
+        `<span class="perf-col-num">${fmt(s.max)}</span>` +
+        `<span class="perf-col-num">${s.count}</span>`;
+      this.tableBody.appendChild(row);
+    }
+
+    // FPS
+    const now = performance.now();
+    const elapsed = (now - this.lastTickTime) / 1000;
+    const frames = perfTracer.getFrameCount() - this.lastFrameCount;
+    const fps = elapsed > 0 ? Math.round(frames / elapsed) : 0;
+    this.lastTickTime = now;
+    this.lastFrameCount = perfTracer.getFrameCount();
+    this.fpsLine.textContent = `FPS: ${fps}`;
+  }
+
+  private exportTrace(): void {
+    const json = perfTracer.exportChromeTrace();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `godly-perf-${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -822,7 +822,7 @@ export function showSettingsDialog(): Promise<void> {
     function renderShortcuts() {
       shortcutsContainer.textContent = '';
 
-      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace', 'Scroll'];
+      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace', 'Scroll', 'Debug'];
 
       for (const category of categories) {
         const defs = DEFAULT_SHORTCUTS.filter((d) => d.category === category);

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -567,9 +567,11 @@ export class TerminalPane {
    */
   private async fetchFullSnapshot(scrollSeqAtStart?: number) {
     try {
+      perfTracer.mark('snapshot_ipc_start');
       const snapshot = await invoke<RichGridData>('get_grid_snapshot', {
         terminalId: this.terminalId,
       });
+      perfTracer.measure('snapshot_ipc', 'snapshot_ipc_start');
       // Discard stale response if the user scrolled while we were fetching
       if (scrollSeqAtStart !== undefined && scrollSeqAtStart !== this.scrollSeq) return;
       this.cachedSnapshot = snapshot;

--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -279,6 +279,7 @@ export class TerminalRenderer {
 
     if (!this.renderScheduled) {
       this.renderScheduled = true;
+      perfTracer.mark('render_start');
       requestAnimationFrame(() => {
         this.renderScheduled = false;
         if (this.pendingSnapshot) {
@@ -286,6 +287,8 @@ export class TerminalRenderer {
           this.pendingSnapshot = null;
           perfTracer.measure('raf_wait', 'render_start');
           this.paint();
+          perfTracer.measure('paint_duration', 'paint_start');
+          perfTracer.measure('keydown_to_paint', 'keydown');
           perfTracer.tick();
         }
       });

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { store, ShellType } from '../state/store';
+import { perfTracer } from '../utils/PerfTracer';
 
 
 // Backend shell type format - matches Rust serde externally tagged enum
@@ -154,9 +155,13 @@ class TerminalService {
 
   /** List live daemon sessions (for reconnection on app restart) */
   async reconnectSessions(): Promise<SessionInfo[]> {
+    perfTracer.mark('reconnect_start');
     try {
-      return await invoke<SessionInfo[]>('reconnect_sessions');
+      const result = await invoke<SessionInfo[]>('reconnect_sessions');
+      perfTracer.measure('reconnect_sessions', 'reconnect_start');
+      return result;
     } catch {
+      perfTracer.measure('reconnect_sessions', 'reconnect_start');
       return [];
     }
   }

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -27,9 +27,10 @@ export type ActionId =
   | 'scroll.toTop'
   | 'scroll.toBottom'
   | 'tabs.renameTerminal'
-  | 'tabs.quickClaude';
+  | 'tabs.quickClaude'
+  | 'debug.togglePerfOverlay';
 
-export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll';
+export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll' | 'Debug';
 
 /** Whether the shortcut is an app-level action or a terminal control key. */
 export type ShortcutType = 'app' | 'terminal-control';
@@ -184,6 +185,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Tabs',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'q' },
+  },
+  {
+    id: 'debug.togglePerfOverlay',
+    label: 'Toggle Perf Overlay',
+    category: 'Debug',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'p' },
   },
 ];
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1554,3 +1554,83 @@ body.dragging-active * {
   font-size: 12px;
   color: var(--text-secondary);
 }
+
+/* Performance HUD overlay */
+.perf-overlay {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.85);
+  color: #ccc;
+  font-family: 'Cascadia Code', Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.4;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 6px 10px;
+  min-width: 320px;
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+}
+
+.perf-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 12px;
+  color: #fff;
+  margin-bottom: 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.perf-overlay-export {
+  pointer-events: auto;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+  color: #aaa;
+  font-size: 10px;
+  padding: 1px 6px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.perf-overlay-export:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.perf-overlay-row {
+  display: flex;
+  gap: 4px;
+}
+
+.perf-overlay-thead {
+  color: #888;
+  font-size: 10px;
+  margin-bottom: 2px;
+}
+
+.perf-col-name {
+  flex: 1;
+  min-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.perf-col-num {
+  width: 48px;
+  text-align: right;
+}
+
+.perf-overlay-fps {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  color: #888;
+  font-size: 10px;
+}

--- a/src/utils/PerfTracer.test.ts
+++ b/src/utils/PerfTracer.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Import the class directly since the singleton is always-on
+// We'll test through the singleton export
+import { perfTracer } from './PerfTracer';
+
+describe('PerfTracer', () => {
+  beforeEach(() => {
+    // Reset by getting and discarding stats
+    perfTracer.getAndReset();
+  });
+
+  describe('mark and measure', () => {
+    it('should record a span duration between mark and measure', () => {
+      perfTracer.mark('test_start');
+      // Small delay to ensure non-zero duration
+      const result = perfTracer.measure('test_span', 'test_start');
+      expect(result).toBeGreaterThanOrEqual(0);
+
+      const stats = perfTracer.getStats();
+      expect(stats.has('test_span')).toBe(true);
+      const span = stats.get('test_span')!;
+      expect(span.count).toBe(1);
+      expect(span.avg).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should return -1 when start mark is missing', () => {
+      const result = perfTracer.measure('missing_span', 'nonexistent_mark');
+      expect(result).toBe(-1);
+    });
+
+    it('should accumulate multiple measurements', () => {
+      for (let i = 0; i < 5; i++) {
+        perfTracer.mark('multi_start');
+        perfTracer.measure('multi_span', 'multi_start');
+      }
+
+      const stats = perfTracer.getStats();
+      const span = stats.get('multi_span')!;
+      expect(span.count).toBe(5);
+    });
+  });
+
+  describe('record', () => {
+    it('should record pre-computed durations', () => {
+      perfTracer.record('manual_span', 10);
+      perfTracer.record('manual_span', 20);
+      perfTracer.record('manual_span', 30);
+
+      const stats = perfTracer.getStats();
+      const span = stats.get('manual_span')!;
+      expect(span.count).toBe(3);
+      expect(span.avg).toBeCloseTo(20, 0);
+      expect(span.min).toBe(10);
+      expect(span.max).toBe(30);
+    });
+  });
+
+  describe('percentile calculation', () => {
+    it('should compute correct P50/P95/P99 for known data', () => {
+      // Record 100 samples: values 1 through 100
+      for (let i = 1; i <= 100; i++) {
+        perfTracer.record('percentile_test', i);
+      }
+
+      const stats = perfTracer.getStats();
+      const span = stats.get('percentile_test')!;
+      expect(span.count).toBe(100);
+      expect(span.min).toBe(1);
+      expect(span.max).toBe(100);
+      // Math.floor(100 * 0.5) = index 50 → value 51 (1-indexed data)
+      expect(span.p50).toBe(51);
+      expect(span.p95).toBe(96);
+      expect(span.p99).toBe(100);
+    });
+
+    it('should handle single sample correctly', () => {
+      perfTracer.record('single', 42);
+
+      const stats = perfTracer.getStats();
+      const span = stats.get('single')!;
+      expect(span.p50).toBe(42);
+      expect(span.p95).toBe(42);
+      expect(span.p99).toBe(42);
+      expect(span.avg).toBe(42);
+      expect(span.min).toBe(42);
+      expect(span.max).toBe(42);
+    });
+  });
+
+  describe('rolling window', () => {
+    it('should evict old samples when window is full', () => {
+      // Fill beyond the 200-sample window with value 1, then add value 1000
+      for (let i = 0; i < 200; i++) {
+        perfTracer.record('rolling_test', 1);
+      }
+      // Now push 10 large values — oldest values should be evicted
+      for (let i = 0; i < 10; i++) {
+        perfTracer.record('rolling_test', 1000);
+      }
+
+      const stats = perfTracer.getStats();
+      const span = stats.get('rolling_test')!;
+      // Window is 200 samples — the 10 large values replaced 10 small ones
+      expect(span.count).toBe(200);
+      // Min should still be 1 (190 samples of 1 remain)
+      expect(span.min).toBe(1);
+      // Max should be 1000
+      expect(span.max).toBe(1000);
+    });
+  });
+
+  describe('getAndReset', () => {
+    it('should return stats and clear all windows', () => {
+      perfTracer.record('reset_test', 5);
+
+      const stats = perfTracer.getAndReset();
+      expect(stats.has('reset_test')).toBe(true);
+      expect(stats.get('reset_test')!.count).toBe(1);
+
+      // After reset, stats should be empty
+      const afterReset = perfTracer.getStats();
+      // Windows still exist but are empty
+      const span = afterReset.get('reset_test');
+      expect(span).toBeUndefined();
+    });
+  });
+
+  describe('tick and frame count', () => {
+    it('should increment frame count on tick', () => {
+      const before = perfTracer.getFrameCount();
+      perfTracer.tick();
+      perfTracer.tick();
+      perfTracer.tick();
+      expect(perfTracer.getFrameCount()).toBe(before + 3);
+    });
+
+    it('should reset frame count on getAndReset', () => {
+      perfTracer.tick();
+      perfTracer.tick();
+      perfTracer.getAndReset();
+      expect(perfTracer.getFrameCount()).toBe(0);
+    });
+  });
+
+  describe('exportChromeTrace', () => {
+    it('should return valid JSON with traceEvents array', () => {
+      perfTracer.mark('export_start');
+      perfTracer.measure('export_span', 'export_start');
+
+      const json = perfTracer.exportChromeTrace();
+      const parsed = JSON.parse(json);
+      expect(parsed).toHaveProperty('traceEvents');
+      expect(Array.isArray(parsed.traceEvents)).toBe(true);
+
+      // Should contain our measure (with perf: prefix stripped)
+      const ourEvent = parsed.traceEvents.find(
+        (e: { name: string }) => e.name === 'export_span'
+      );
+      expect(ourEvent).toBeDefined();
+      expect(ourEvent.ph).toBe('X');
+      expect(ourEvent.cat).toBe('perf');
+      expect(typeof ourEvent.ts).toBe('number');
+      expect(typeof ourEvent.dur).toBe('number');
+    });
+  });
+
+  describe('multiple independent spans', () => {
+    it('should track independent spans separately', () => {
+      perfTracer.record('span_a', 10);
+      perfTracer.record('span_b', 100);
+      perfTracer.record('span_a', 20);
+      perfTracer.record('span_b', 200);
+
+      const stats = perfTracer.getStats();
+      expect(stats.get('span_a')!.avg).toBeCloseTo(15);
+      expect(stats.get('span_b')!.avg).toBeCloseTo(150);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Rewrite `PerfTracer` as an always-on profiling system with rolling window percentiles (P50/P95/P99), `getStats`/`getAndReset` APIs, and Chrome trace export
- Add `PerfOverlay` HUD component showing real-time latency metrics for `snapshot_ipc`, `paint_duration`, and `keydown_to_paint` (toggled with Ctrl+Shift+P)
- Instrument key hot paths: terminal creation, tab switch, app startup, session reconnect, and the full render pipeline (IPC fetch, Canvas2D paint, keydown-to-paint)
- Register `debug.togglePerfOverlay` keybinding in the Debug shortcut category and expose it in the Settings dialog
- Add 12 unit tests for the rewritten PerfTracer

## Files changed

| File | Change |
|------|--------|
| `src/utils/PerfTracer.ts` | Rewritten: always-on, rolling window, percentile stats, Chrome trace export |
| `src/components/PerfOverlay.ts` | New: HUD overlay rendering real-time latency metrics |
| `src/utils/PerfTracer.test.ts` | New: 12 unit tests for PerfTracer |
| `src/styles/main.css` | Added `.perf-overlay` CSS styles |
| `src/state/keybinding-store.ts` | Added `debug.togglePerfOverlay` action + Debug category |
| `src/components/SettingsDialog.ts` | Added Debug category to shortcuts section |
| `src/components/App.ts` | Handle perf overlay shortcut, add marks for terminal creation/tab switch/startup |
| `src/components/TerminalPane.ts` | Added `snapshot_ipc` instrumentation mark |
| `src/components/TerminalRenderer.ts` | Added `paint_duration` and `keydown_to_paint` marks |
| `src/services/terminal-service.ts` | Added `reconnect_sessions` instrumentation mark |

## Test plan

- [x] All 414 tests pass (frontend + backend)
- [ ] Toggle HUD with Ctrl+Shift+P — verify overlay appears with live metrics
- [ ] Verify metrics update in real time during typing and tab switching
- [ ] Verify HUD dismisses cleanly on second Ctrl+Shift+P press
- [ ] Verify Debug category appears in Settings > Shortcuts