### PR TITLE
fix: prevent Quick Claude terminal from stealing focus

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -506,7 +506,7 @@ export class App {
               name: result.worktree_branch ?? 'Quick Claude',
               processName: shellTypeToProcessName(terminalSettingsStore.getDefaultShell()),
               order: 0,
-            });
+            }, { background: true });
           } catch (error) {
             console.error('[App] Quick Claude failed:', error);
           }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -168,17 +168,23 @@ class Store {
   }
 
   // Terminal operations
-  addTerminal(terminal: Terminal) {
+  addTerminal(terminal: Terminal, opts?: { background?: boolean }) {
     const workspaceTerminals = this.state.terminals.filter(
       t => t.workspaceId === terminal.workspaceId
     );
     const order = workspaceTerminals.length;
 
-    this.lastActiveTerminalByWorkspace.set(terminal.workspaceId, terminal.id);
-    this.setState({
-      terminals: [...this.state.terminals, { ...terminal, order }],
-      activeTerminalId: terminal.id,
-    });
+    if (opts?.background) {
+      this.setState({
+        terminals: [...this.state.terminals, { ...terminal, order }],
+      });
+    } else {
+      this.lastActiveTerminalByWorkspace.set(terminal.workspaceId, terminal.id);
+      this.setState({
+        terminals: [...this.state.terminals, { ...terminal, order }],
+        activeTerminalId: terminal.id,
+      });
+    }
   }
 
   updateTerminal(id: string, updates: Partial<Terminal>) {


### PR DESCRIPTION
## Summary

- Quick Claude (Ctrl+Shift+Q) is fire-and-forget, but `store.addTerminal()` always switched `activeTerminalId` to the new terminal, stealing focus from the user's current tab
- Added `{ background: true }` option to `addTerminal()` that creates the terminal without changing focus
- Quick Claude handler now uses this option so the Claude tab spins up silently in the background

## Test plan

- [x] New unit test: `addTerminal` with `{ background: true }` does not change `activeTerminalId`
- [x] All 49 store tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: press Ctrl+Shift+Q, verify current tab stays focused while Claude tab appears in tab bar