### PR TITLE
fix: freeze display during text selection

### DIFF
--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -142,6 +142,9 @@ export class TerminalRenderer {
   };
   private isSelecting = false;
 
+  // Callback fired when a mouse drag selection ends (mouseup after selecting)
+  private onSelectionEndCallback?: () => void;
+
   // URL hover
   private hoveredUrl: string | null = null;
   private hoveredUrlRow = -1;
@@ -263,6 +266,16 @@ export class TerminalRenderer {
   /** Set absolute scroll-to callback (used by scrollbar drag). */
   setOnScrollTo(cb: (absoluteOffset: number) => void) {
     this.onScrollToCallback = cb;
+  }
+
+  /** Set callback for when a drag selection ends (mouseup after drag). */
+  setOnSelectionEnd(cb: () => void) {
+    this.onSelectionEndCallback = cb;
+  }
+
+  /** Returns true while the user is actively dragging to select text. */
+  isActivelySelecting(): boolean {
+    return this.isSelecting;
   }
 
   /**
@@ -691,7 +704,11 @@ export class TerminalRenderer {
     });
 
     this.canvas.addEventListener('mouseup', () => {
+      const wasSelecting = this.isSelecting;
       this.isSelecting = false;
+      if (wasSelecting && this.selection.active && this.onSelectionEndCallback) {
+        this.onSelectionEndCallback();
+      }
     });
 
     // Ctrl+click to open URLs


### PR DESCRIPTION
## Summary

- Freezes terminal canvas rendering while the user is dragging to select text
- New output from the daemon is still received (no data loss), but the display stays frozen
- On mouseup, a catch-up snapshot fetch updates the display with the latest state
- Prevents the frustrating UX where trying to copy text while a command is running causes the selection to break

## Changes

- **TerminalRenderer**: Expose `isActivelySelecting()` and `setOnSelectionEnd()` callback
- **TerminalPane**: Check `renderer.isActivelySelecting()` in both grid diff and output event handlers — skip rendering if true
- **Tests**: 5 new tests covering selection freeze, resume, multi-event suppression, and auto-scroll interaction

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 487 tests pass (5 new)
- [ ] Manual: run a long-output command (e.g. `seq 10000`), try to select text mid-output — selection should stay stable