### PR TITLE
feat: push grid diffs from daemon instead of pull snapshots

### DIFF
--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -106,6 +106,7 @@ pub enum Event {
     Output { session_id: String, data: Vec<u8> },
     SessionClosed { session_id: String },
     ProcessChanged { session_id: String, process_name: String },
+    GridDiff { session_id: String, diff: crate::types::RichGridDiff },
 }
 
 /// Top-level message from daemon to client (can be a response or async event)


### PR DESCRIPTION
## Summary

- Daemon now pushes `RichGridDiff` alongside output events via new `Event::GridDiff` protocol variant, eliminating the ~85ms IPC round-trip per rendering update
- Frontend applies diffs directly via `terminal-grid-diff` Tauri event with `requestAnimationFrame` coalescing for 60fps rendering
- Bridge coalesces multiple diffs and suppresses redundant `terminal-output` events when a diff is available for the same terminal
- Existing pull path (`terminal-output` → IPC fetch) remains as fallback for initial load and edge cases

### Changes across the stack

| Layer | File | Change |
|-------|------|--------|
| Protocol | `messages.rs` | Add `Event::GridDiff` variant |
| Session | `session.rs` | `SessionOutput` enum, diff extraction in PTY reader thread |
| Server | `server.rs` | Forward `SessionOutput::GridDiff` as `Event::GridDiff` |
| Bridge | `bridge.rs` | Coalesce diffs, suppress redundant output events, emit `terminal-grid-diff` |
| Frontend | `terminal-service.ts` | Grid diff listener registration |
| Frontend | `TerminalPane.ts` | `applyPushedDiff()` + RAF-based render scheduling |

### Edge cases handled

- **Initial attach (no cache)**: Falls back to pull path for full snapshot
- **Resize**: All rows dirty → `full_repaint=true` → full snapshot replacement
- **Channel full (backpressure)**: GridDiff skipped via `try_send`, dirty flags accumulate for next read
- **Tab switch**: Background tabs update cache in memory; already current on activate

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p godly-protocol` (42 tests)
- [x] `cargo test -p godly-daemon "session_closed"` (3 forwarding tests)
- [x] `npm test` (487 tests)
- [x] `npx tsc --noEmit`
- [ ] Manual: type in terminal, run `ls`, run heavy output (`seq 1 1000`), verify smooth rendering