### PR TITLE
fix: add .taurignore to prevent infinite dev build loop

### DIFF
--- a/src-tauri/.taurignore
+++ b/src-tauri/.taurignore
@@ -1,0 +1,10 @@
+# Tauri dev watcher exclusions
+# Without this file, the Tauri CLI's built-in ignore patterns (target/,
+# node_modules/, gen/, etc.) are NOT loaded — causing the watcher to detect
+# cargo build artifacts in target/ and trigger an infinite rebuild loop.
+
+target/
+node_modules/
+gen/
+Cargo.lock
+*.pdb


### PR DESCRIPTION
## Summary

- Adds `src-tauri/.taurignore` to activate the Tauri CLI's built-in ignore patterns for the dev file watcher

## Root Cause

The Tauri CLI's `build_ignore_matcher()` function ([source](https://github.com/tauri-apps/tauri/blob/dev/crates/tauri-cli/src/interface/rust.rs)) only loads built-in ignore patterns (`target/`, `node_modules/`, `gen/`, `Cargo.lock`) **when a `.taurignore` file exists** in the watched directory. Without it, the `IgnoreMatcher` has zero matchers, so nothing is excluded from watching — including `target/`.

This causes the infinite rebuild loop:
1. Watcher watches all of `src-tauri/` (including `target/`)
2. `cargo build` writes to `target/debug/.fingerprint/`, `target/debug/build/`, etc.
3. Watcher detects changes → triggers rebuild
4. Rebuild writes more to `target/` → triggers another rebuild
5. Loop

Related Tauri issues: [#11150](https://github.com/tauri-apps/tauri/issues/11150), [#4617](https://github.com/tauri-apps/tauri/issues/4617)

## Fix

Creating a `.taurignore` file activates the built-in exclusion patterns. Even an empty file would work, but explicit patterns are included for clarity.

## Test plan

- [ ] Run `npm run tauri dev` — app should build once and stay running
- [ ] Edit a `.rs` file in `src-tauri/src/` — should trigger exactly one rebuild, not loop
- [ ] Verify no "Rebuilding application..." spam in the console