### PR TITLE
feat: reorderable settings dialog tabs

### DIFF
--- a/src/state/settings-tab-store.ts
+++ b/src/state/settings-tab-store.ts
@@ -1,0 +1,71 @@
+const STORAGE_KEY = 'godly-settings-tab-order';
+
+const DEFAULT_ORDER: string[] = ['themes', 'terminal', 'notifications', 'shortcuts'];
+
+type Subscriber = () => void;
+
+class SettingsTabStore {
+  private tabOrder: string[] = [...DEFAULT_ORDER];
+  private subscribers: Subscriber[] = [];
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  getTabOrder(): string[] {
+    return [...this.tabOrder];
+  }
+
+  setTabOrder(order: string[]): void {
+    this.tabOrder = this.reconcile(order);
+    this.saveToStorage();
+    this.notify();
+  }
+
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.push(fn);
+    return () => {
+      this.subscribers = this.subscribers.filter(s => s !== fn);
+    };
+  }
+
+  private notify(): void {
+    for (const fn of this.subscribers) fn();
+  }
+
+  /** Ensure stored order contains exactly the known tab IDs. */
+  private reconcile(order: string[]): string[] {
+    const known = new Set(DEFAULT_ORDER);
+    // Keep only known IDs, preserving the user's order
+    const result = order.filter(id => known.has(id));
+    // Append any missing tabs (e.g. newly added)
+    for (const id of DEFAULT_ORDER) {
+      if (!result.includes(id)) result.push(id);
+    }
+    return result;
+  }
+
+  private loadFromStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw) as unknown;
+      if (!Array.isArray(data)) return;
+      this.tabOrder = this.reconcile(data.filter((x): x is string => typeof x === 'string'));
+    } catch {
+      // Corrupt data — use defaults
+    }
+  }
+
+  private saveToStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.tabOrder));
+    } catch {
+      // No localStorage available
+    }
+  }
+}
+
+export const settingsTabStore = new SettingsTabStore();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1358,11 +1358,16 @@ body.dragging-active * {
   padding: 10px 16px;
   font-size: 12px;
   color: var(--text-secondary);
-  cursor: pointer;
+  cursor: grab;
   border: none;
   background: none;
   border-bottom: 2px solid transparent;
   transition: color 0.15s, border-color 0.15s;
+}
+
+.settings-tab.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
 }
 
 .settings-tab:hover {


### PR DESCRIPTION
## Summary
- Settings dialog tabs can now be reordered via drag-and-drop
- Tab order persists across sessions via localStorage (`godly-settings-tab-order`)
- Default tab on open respects the user's preferred order (first tab in list)
- Resilient storage: unknown IDs are discarded, newly added tabs are appended

## Changes
- **New**: `src/state/settings-tab-store.ts` — localStorage-backed store following the existing subscriber pattern
- **Edit**: `src/components/SettingsDialog.ts` — tab bar reads from store, pointer-event-based drag reorder
- **Edit**: `src/styles/main.css` — `cursor: grab` on tabs, `.dragging` opacity feedback

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 487 tests pass
- [ ] Manual: open settings, drag tabs to reorder, close and reopen — order persists
- [ ] Manual: clear `godly-settings-tab-order` from localStorage, reopen — falls back to default order