### PR TITLE
style: refine UI for minimal aesthetic

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,9 +9,10 @@
   --accent: #7aa2f7;            /* Blue accent */
   --accent-hover: #89b4fa;      /* Lighter blue on hover */
   --border-color: #292e42;      /* Subtle borders */
+  --border-subtle: rgba(41, 46, 66, 0.4); /* Softer borders for reduced noise */
   --danger: #f7768e;            /* Red */
   --success: #9ece6a;           /* Green */
-  --sidebar-width: 200px;
+  --sidebar-width: 220px;
   --tabbar-height: 35px;
 }
 
@@ -40,33 +41,35 @@ html, body {
 .sidebar {
   width: var(--sidebar-width);
   background: var(--bg-secondary);
-  border-right: 1px solid var(--border-color);
+  box-shadow: 1px 0 16px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
 }
 
 .sidebar-header {
-  padding: 12px;
-  font-weight: 600;
+  padding: 14px 16px 10px 16px;
+  font-weight: 500;
   font-size: 11px;
   text-transform: uppercase;
   color: var(--text-secondary);
-  letter-spacing: 0.5px;
-  border-bottom: 1px solid var(--border-color);
+  letter-spacing: 1px;
 }
 
 .workspace-list {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 0;
+  padding: 4px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .workspace-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
+  padding: 10px 12px;
   cursor: pointer;
   transition: background 0.1s;
 }
@@ -139,7 +142,7 @@ html, body {
   padding: 8px 12px;
   color: var(--text-secondary);
   cursor: pointer;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-subtle);
   margin-top: auto;
 }
 
@@ -160,7 +163,6 @@ html, body {
 .tab-bar {
   display: flex;
   background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
   height: var(--tabbar-height);
   overflow-x: auto;
   overflow-y: hidden;
@@ -178,11 +180,11 @@ html, body {
   display: flex;
   align-items: center;
   padding: 0 12px;
+  gap: 6px;
   min-width: 120px;
   max-width: 200px;
   height: 100%;
   background: var(--bg-secondary);
-  border-right: 1px solid var(--border-color);
   cursor: pointer;
   transition: background 0.1s;
   user-select: none;
@@ -195,7 +197,6 @@ html, body {
 .tab.active {
   background: var(--bg-primary);
   border-top: 2px solid var(--accent);
-  border-bottom: none;
 }
 
 .tab.in-split {
@@ -322,22 +323,22 @@ html, body {
 
 /* Focus indicator */
 .terminal-pane.split-focused {
-  border-top: 2px solid var(--accent);
+  border-top: 1px solid var(--accent);
 }
 
 /* Divider */
 .split-divider {
   flex-shrink: 0;
-  background: var(--bg-tertiary);
+  background: var(--border-color);
 }
 
 .split-divider.horizontal {
-  width: 4px;
+  width: 2px;
   cursor: col-resize;
 }
 
 .split-divider.vertical {
-  height: 4px;
+  height: 2px;
   cursor: row-resize;
 }
 
@@ -389,8 +390,8 @@ body.dragging-active * {
 .context-menu {
   position: fixed;
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
   padding: 4px 0;
   min-width: 150px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
@@ -417,7 +418,7 @@ body.dragging-active * {
 
 .context-menu-separator {
   height: 1px;
-  background: var(--border-color);
+  background: var(--border-subtle);
   margin: 4px 0;
 }
 
@@ -437,25 +438,25 @@ body.dragging-active * {
 
 .dialog {
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 20px;
+  border-radius: 12px;
+  padding: 24px;
   min-width: 300px;
   max-width: 400px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 
 .dialog-title {
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 600;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .dialog-input {
   width: 100%;
-  padding: 8px 12px;
+  padding: 10px 12px;
   background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
   color: var(--text-primary);
   font-size: 13px;
   margin-bottom: 16px;
@@ -469,13 +470,13 @@ body.dragging-active * {
 .dialog-buttons {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 10px;
 }
 
 .dialog-btn {
-  padding: 6px 16px;
+  padding: 8px 20px;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
 }
@@ -509,7 +510,7 @@ body.dragging-active * {
   gap: 8px;
   padding: 8px;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: 6px;
   transition: background 0.1s;
 }
 
@@ -537,8 +538,8 @@ body.dragging-active * {
   width: 100%;
   padding: 6px 10px;
   background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
   color: var(--text-primary);
   font-size: 13px;
 }
@@ -610,7 +611,7 @@ body.dragging-active * {
 
 /* Worktree panel */
 .worktree-panel {
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-subtle);
   flex-shrink: 0;
 }
 
@@ -620,10 +621,10 @@ body.dragging-active * {
   justify-content: space-between;
   padding: 8px 12px;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   text-transform: uppercase;
   color: var(--text-secondary);
-  letter-spacing: 0.5px;
+  letter-spacing: 1px;
   cursor: pointer;
 }
 
@@ -907,7 +908,7 @@ body.dragging-active * {
 
 /* Scrollbar styling */
 ::-webkit-scrollbar {
-  width: 8px;
+  width: 7px;
 }
 
 ::-webkit-scrollbar-track {
@@ -931,7 +932,7 @@ body.dragging-active * {
   padding: 8px 12px;
   color: var(--text-secondary);
   cursor: pointer;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-subtle);
   margin-top: auto;
 }
 
@@ -952,7 +953,7 @@ body.dragging-active * {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .settings-header .dialog-title {
@@ -962,16 +963,14 @@ body.dragging-active * {
 .settings-shortcuts {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
 }
 
 .settings-section-title {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--text-secondary);
-  letter-spacing: 0.5px;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
 .shortcut-row {
@@ -991,8 +990,8 @@ body.dragging-active * {
   font-size: 12px;
   padding: 4px 10px;
   background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s;
   user-select: none;
@@ -1041,9 +1040,9 @@ body.dragging-active * {
 }
 
 .settings-footer {
-  margin-top: 16px;
+  margin-top: 20px;
   padding-top: 12px;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-subtle);
   font-size: 11px;
   color: var(--text-secondary);
   text-align: right;
@@ -1111,7 +1110,7 @@ body.dragging-active * {
 
 /* CLAUDE.md sidebar buttons */
 .claude-md-buttons {
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-subtle);
   padding: 4px 0;
 }
 
@@ -1345,12 +1344,12 @@ body.dragging-active * {
 .settings-tabs {
   display: flex;
   gap: 0;
-  border-bottom: 1px solid var(--border-color);
-  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 20px;
 }
 
 .settings-tab {
-  padding: 8px 16px;
+  padding: 10px 16px;
   font-size: 12px;
   color: var(--text-secondary);
   cursor: pointer;


### PR DESCRIPTION
## Summary

CSS-only refinement pass to reduce visual noise and give the app a cleaner, more minimal look.

### Changes

**CSS Variables**
- Added `--border-subtle` (semi-transparent border for reduced visual noise)
- Increased `--sidebar-width` from 200px to 220px

**Sidebar**
- Replaced hard `border-right` with soft `box-shadow`
- Refined header padding, weight, and letter spacing; removed bottom border
- Workspace list uses flex column with 2px gap; items have more vertical padding
- Bottom action borders softened to `--border-subtle`

**Tab Bar**
- Removed bottom border from tab bar and right borders from individual tabs
- Added `gap: 6px` for cleaner tab spacing

**Split View**
- Divider thinned from 4px to 2px, focus indicator from 2px to 1px
- Divider background changed to `--border-color` (subtler)

**Dialogs**
- Removed outer border, added soft `box-shadow`
- Corner radius 8 -> 12px, padding 20 -> 24px, title font size 14 -> 16px
- Input and button borders softened, corner radii increased

**Settings Dialog**
- Section titles: removed uppercase, lighter weight (600 -> 500), larger font (11 -> 12px)
- Tabs: softened bottom border, more padding
- Shortcut bindings: softened border, rounded corners
- More generous spacing throughout

**Context Menu**
- Softened border, increased corner radius (6 -> 8px), softened separator

**Scrollbar**
- Width 8 -> 7px

**Worktree Panel & CLAUDE.md Buttons**
- Borders softened to `--border-subtle`
- Panel header: lighter font weight, wider letter spacing