### PR TITLE
feat: terminal input notification system

### DIFF
--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -608,6 +608,7 @@ fn io_thread(
                         DaemonMessage::Event(Event::SessionClosed { .. }) => "SessionClosed",
                         DaemonMessage::Event(Event::ProcessChanged { .. }) => "ProcessChanged",
                         DaemonMessage::Event(Event::GridDiff { .. }) => "GridDiff",
+                        DaemonMessage::Event(Event::Bell { .. }) => "Bell",
                         DaemonMessage::Response(_) => "Response", // shouldn't happen
                     };
 
@@ -893,6 +894,9 @@ mod forwarding_tests {
                             session_id: sid.clone(),
                             diff,
                         }),
+                        SessionOutput::Bell => DaemonMessage::Event(Event::Bell {
+                            session_id: sid.clone(),
+                        }),
                     };
                     if event_tx.send(event).await.is_err() {
                         break;
@@ -955,6 +959,9 @@ mod forwarding_tests {
                         SessionOutput::GridDiff(diff) => DaemonMessage::Event(Event::GridDiff {
                             session_id: sid.clone(),
                             diff,
+                        }),
+                        SessionOutput::Bell => DaemonMessage::Event(Event::Bell {
+                            session_id: sid.clone(),
                         }),
                     };
                     if event_tx.send(event).await.is_err() {
@@ -1026,6 +1033,9 @@ mod forwarding_tests {
                         SessionOutput::GridDiff(diff) => DaemonMessage::Event(Event::GridDiff {
                             session_id: sid.clone(),
                             diff,
+                        }),
+                        SessionOutput::Bell => DaemonMessage::Event(Event::Bell {
+                            session_id: sid.clone(),
                         }),
                     };
                     if event_tx.send(event).await.is_err() {
@@ -1147,6 +1157,11 @@ async fn handle_request(
                                     DaemonMessage::Event(Event::GridDiff {
                                         session_id: sid.clone(),
                                         diff,
+                                    })
+                                }
+                                crate::session::SessionOutput::Bell => {
+                                    DaemonMessage::Event(Event::Bell {
+                                        session_id: sid.clone(),
                                     })
                                 }
                             };

--- a/src-tauri/godly-vt/src/parser.rs
+++ b/src-tauri/godly-vt/src/parser.rs
@@ -80,6 +80,12 @@ impl<CB: crate::callbacks::Callbacks> Parser<CB> {
     pub fn callbacks_mut(&mut self) -> &mut CB {
         &mut self.screen.callbacks
     }
+
+    /// Returns true if a bell (BEL, 0x07) was received since the last call,
+    /// and resets the flag.
+    pub fn take_bell_pending(&mut self) -> bool {
+        self.screen.screen.take_bell_pending()
+    }
 }
 
 impl Default for Parser {

--- a/src-tauri/godly-vt/src/perform.rs
+++ b/src-tauri/godly-vt/src/perform.rs
@@ -60,7 +60,10 @@ impl<CB: crate::callbacks::Callbacks> crate::state_machine::Perform for WrappedS
 
     fn execute(&mut self, b: u8) {
         match b {
-            7 => self.callbacks.audible_bell(&mut self.screen),
+            7 => {
+                self.screen.bell_pending = true;
+                self.callbacks.audible_bell(&mut self.screen);
+            }
             8 => self.screen.bs(),
             9 => self.screen.tab(),
             10 => self.screen.lf(),

--- a/src-tauri/godly-vt/src/screen.rs
+++ b/src-tauri/godly-vt/src/screen.rs
@@ -70,6 +70,8 @@ pub struct Screen {
 
     window_title: String,
     window_icon_name: String,
+
+    pub(crate) bell_pending: bool,
 }
 
 impl Screen {
@@ -92,6 +94,8 @@ impl Screen {
 
             window_title: String::new(),
             window_icon_name: String::new(),
+
+            bell_pending: false,
         }
     }
 
@@ -680,6 +684,14 @@ impl Screen {
     /// Check if any row is dirty (without consuming).
     pub fn has_dirty_rows(&self) -> bool {
         self.grid().has_dirty_rows()
+    }
+
+    /// Returns true if a bell (BEL, 0x07) was received since the last call,
+    /// and resets the flag.
+    pub fn take_bell_pending(&mut self) -> bool {
+        let was = self.bell_pending;
+        self.bell_pending = false;
+        was
     }
 
     pub(crate) fn grid(&self) -> &crate::grid::Grid {

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -113,6 +113,7 @@ pub enum Event {
     },
     ProcessChanged { session_id: String, process_name: String },
     GridDiff { session_id: String, diff: crate::types::RichGridDiff },
+    Bell { session_id: String },
 }
 
 /// Top-level message from daemon to client (can be a response or async event)

--- a/src-tauri/src/daemon_client/bridge.rs
+++ b/src-tauri/src/daemon_client/bridge.rs
@@ -25,6 +25,7 @@ pub enum EmitPayload {
     TerminalGridDiff { terminal_id: String, diff: godly_protocol::types::RichGridDiff },
     TerminalClosed { terminal_id: String, exit_code: Option<i64> },
     ProcessChanged { terminal_id: String, process_name: String },
+    TerminalBell { terminal_id: String },
 }
 
 /// Cloneable handle that enqueues Tauri emit calls into a bounded channel.
@@ -173,6 +174,14 @@ impl EventEmitter {
                     serde_json::json!({
                         "terminal_id": terminal_id,
                         "process_name": process_name,
+                    }),
+                );
+            }
+            EmitPayload::TerminalBell { terminal_id } => {
+                let _ = app_handle.emit(
+                    "terminal-bell",
+                    serde_json::json!({
+                        "terminal_id": terminal_id,
                     }),
                 );
             }
@@ -816,6 +825,9 @@ fn event_to_payload(event: Event) -> EmitPayload {
         } => EmitPayload::ProcessChanged {
             terminal_id: session_id,
             process_name,
+        },
+        Event::Bell { session_id } => EmitPayload::TerminalBell {
+            terminal_id: session_id,
         },
     }
 }

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -777,6 +777,23 @@ export function showSettingsDialog(): Promise<void> {
     folderRow.appendChild(openFolderBtn);
     notifSection.appendChild(folderRow);
 
+    // Idle activity notifications toggle
+    const idleRow = document.createElement('div');
+    idleRow.className = 'shortcut-row';
+    const idleLabel = document.createElement('span');
+    idleLabel.className = 'shortcut-label';
+    idleLabel.textContent = 'Idle activity notifications';
+    idleRow.appendChild(idleLabel);
+    const idleCheckbox = document.createElement('input');
+    idleCheckbox.type = 'checkbox';
+    idleCheckbox.className = 'notification-checkbox';
+    idleCheckbox.checked = notificationStore.getSettings().idleNotifyEnabled;
+    idleCheckbox.onchange = () => {
+      notificationStore.setIdleNotifyEnabled(idleCheckbox.checked);
+    };
+    idleRow.appendChild(idleCheckbox);
+    notifSection.appendChild(idleRow);
+
     notifContent.appendChild(notifSection);
     dialog.appendChild(notifContent);
 

--- a/src/services/idle-notification-service.test.ts
+++ b/src/services/idle-notification-service.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IdleNotificationService } from './idle-notification-service';
+
+describe('IdleNotificationService', () => {
+  let service: IdleNotificationService;
+  let onNotify: ReturnType<typeof vi.fn>;
+  let activeTerminalId: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onNotify = vi.fn();
+    activeTerminalId = undefined;
+  });
+
+  afterEach(() => {
+    service?.destroy();
+    vi.useRealTimers();
+  });
+
+  function createService(opts?: { idleThresholdMs?: number; checkIntervalMs?: number }) {
+    service = new IdleNotificationService({
+      idleThresholdMs: opts?.idleThresholdMs ?? 1000,
+      checkIntervalMs: opts?.checkIntervalMs ?? 500,
+      getActiveTerminalId: () => activeTerminalId,
+      onNotify,
+    });
+    return service;
+  }
+
+  it('notifies when a background terminal goes idle after output', () => {
+    createService();
+    service.recordOutput('term-1');
+
+    // Advance past idle threshold + check interval
+    vi.advanceTimersByTime(1500);
+
+    expect(onNotify).toHaveBeenCalledWith('term-1');
+    expect(onNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify for the active (focused) terminal', () => {
+    createService();
+    activeTerminalId = 'term-1';
+    service.recordOutput('term-1');
+
+    vi.advanceTimersByTime(2000);
+
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+
+  it('does not notify before idle threshold is reached', () => {
+    createService({ idleThresholdMs: 5000 });
+    service.recordOutput('term-1');
+
+    // Only 2 seconds — not yet idle
+    vi.advanceTimersByTime(2000);
+
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+
+  it('does not notify twice for the same idle period', () => {
+    createService();
+    service.recordOutput('term-1');
+
+    // First tick triggers notification
+    vi.advanceTimersByTime(1500);
+    expect(onNotify).toHaveBeenCalledTimes(1);
+
+    // Subsequent ticks should not re-notify
+    vi.advanceTimersByTime(5000);
+    expect(onNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-notifies after new output followed by another idle period', () => {
+    createService();
+    service.recordOutput('term-1');
+
+    vi.advanceTimersByTime(1500);
+    expect(onNotify).toHaveBeenCalledTimes(1);
+
+    // New output resets the tracker
+    service.recordOutput('term-1');
+    vi.advanceTimersByTime(1500);
+    expect(onNotify).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops tracking a closed terminal', () => {
+    createService();
+    service.recordOutput('term-1');
+    service.recordTerminalClosed('term-1');
+
+    vi.advanceTimersByTime(2000);
+
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+
+  it('tracks multiple terminals independently', () => {
+    createService();
+    service.recordOutput('term-1');
+    service.recordOutput('term-2');
+
+    vi.advanceTimersByTime(1500);
+
+    expect(onNotify).toHaveBeenCalledWith('term-1');
+    expect(onNotify).toHaveBeenCalledWith('term-2');
+    expect(onNotify).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips focused terminal but notifies others', () => {
+    createService();
+    activeTerminalId = 'term-1';
+    service.recordOutput('term-1');
+    service.recordOutput('term-2');
+
+    vi.advanceTimersByTime(1500);
+
+    expect(onNotify).toHaveBeenCalledWith('term-2');
+    expect(onNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it('continuous output keeps resetting the idle timer', () => {
+    createService({ idleThresholdMs: 1000, checkIntervalMs: 200 });
+    service.recordOutput('term-1');
+
+    // Keep producing output every 300ms — should never go idle
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(300);
+      service.recordOutput('term-1');
+    }
+
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+
+  it('destroy stops the interval timer', () => {
+    createService();
+    service.recordOutput('term-1');
+    service.destroy();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/idle-notification-service.ts
+++ b/src/services/idle-notification-service.ts
@@ -1,0 +1,89 @@
+/**
+ * Detects when a terminal transitions from active output to silence while
+ * not focused, and triggers a notification. This catches the scenario where
+ * a CLI tool (e.g., Claude Code) is waiting for user input in a background tab.
+ */
+
+export interface IdleNotificationServiceOptions {
+  /** How long (ms) a terminal must be silent after output to trigger notification. Default: 15000. */
+  idleThresholdMs?: number;
+  /** How often (ms) to check for idle terminals. Default: 5000. */
+  checkIntervalMs?: number;
+  /** Returns the currently active (focused) terminal ID, or undefined if none. */
+  getActiveTerminalId: () => string | undefined;
+  /** Called when an idle notification should be shown for a terminal. */
+  onNotify: (terminalId: string) => void;
+}
+
+interface TerminalTracker {
+  lastOutputTime: number;
+  hadRecentOutput: boolean;
+  notified: boolean;
+}
+
+export class IdleNotificationService {
+  private trackers = new Map<string, TerminalTracker>();
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private idleThresholdMs: number;
+  private getActiveTerminalId: () => string | undefined;
+  private onNotify: (terminalId: string) => void;
+
+  constructor(options: IdleNotificationServiceOptions) {
+    this.idleThresholdMs = options.idleThresholdMs ?? 15000;
+    this.getActiveTerminalId = options.getActiveTerminalId;
+    this.onNotify = options.onNotify;
+
+    const checkInterval = options.checkIntervalMs ?? 5000;
+    this.intervalId = setInterval(() => this.tick(), checkInterval);
+  }
+
+  /** Record that a terminal produced output. */
+  recordOutput(terminalId: string): void {
+    const now = Date.now();
+    const tracker = this.trackers.get(terminalId);
+    if (tracker) {
+      tracker.lastOutputTime = now;
+      tracker.hadRecentOutput = true;
+      tracker.notified = false;
+    } else {
+      this.trackers.set(terminalId, {
+        lastOutputTime: now,
+        hadRecentOutput: true,
+        notified: false,
+      });
+    }
+  }
+
+  /** Stop tracking a terminal (e.g., when it closes). */
+  recordTerminalClosed(terminalId: string): void {
+    this.trackers.delete(terminalId);
+  }
+
+  /** Periodic check: find terminals that went idle and notify. */
+  private tick(): void {
+    const now = Date.now();
+    const activeId = this.getActiveTerminalId();
+
+    for (const [terminalId, tracker] of this.trackers) {
+      // Skip the currently focused terminal
+      if (terminalId === activeId) continue;
+      // Skip if no recent output or already notified
+      if (!tracker.hadRecentOutput || tracker.notified) continue;
+
+      const idleMs = now - tracker.lastOutputTime;
+      if (idleMs >= this.idleThresholdMs) {
+        tracker.hadRecentOutput = false;
+        tracker.notified = true;
+        this.onNotify(terminalId);
+      }
+    }
+  }
+
+  /** Clean up the interval timer. */
+  destroy(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+}

--- a/src/state/notification-store.ts
+++ b/src/state/notification-store.ts
@@ -7,6 +7,7 @@ export interface NotificationSettings {
   globalEnabled: boolean;
   volume: number;       // 0–1
   soundPreset: SoundPreset;
+  idleNotifyEnabled: boolean;
 }
 
 type Subscriber = () => void;
@@ -16,6 +17,7 @@ class NotificationStore {
     globalEnabled: true,
     volume: 0.5,
     soundPreset: 'chime',
+    idleNotifyEnabled: true,
   };
 
   /** Terminal IDs that have unread notification badges */
@@ -99,6 +101,12 @@ class NotificationStore {
     this.notify();
   }
 
+  setIdleNotifyEnabled(enabled: boolean): void {
+    this.settings.idleNotifyEnabled = enabled;
+    this.saveToStorage();
+    this.notify();
+  }
+
   // ── Subscriptions ────────────────────────────────────────────────
 
   subscribe(fn: Subscriber): () => void {
@@ -125,6 +133,7 @@ class NotificationStore {
       if (data.soundPreset && (isBuiltinPreset(data.soundPreset) || isCustomPreset(data.soundPreset))) {
         this.settings.soundPreset = data.soundPreset;
       }
+      if (typeof data.idleNotifyEnabled === 'boolean') this.settings.idleNotifyEnabled = data.idleNotifyEnabled;
     } catch {
       // Corrupt data — use defaults
     }


### PR DESCRIPTION
## Summary

- **Bell character detection**: Propagates BEL (0x07) from the VT parser through the daemon→bridge→frontend pipeline (`bell_pending` flag → `SessionOutput::Bell` → `Event::Bell` → `terminal-bell` Tauri event) to trigger sound, toast, badge, taskbar flash, and native notifications
- **Idle-after-activity detection**: Frontend `IdleNotificationService` monitors background terminals for output→silence transitions (15s idle threshold, 5s check interval), catching scenarios where CLI tools like Claude Code are waiting for user input in a background tab
- **Settings toggle**: Adds "Idle activity notifications" checkbox in the Notifications section of the Settings dialog, with `localStorage` persistence via `notification-store`

## Event Flow

### Bell path
```
Shell sends BEL → godly-vt sets bell_pending → session.rs reader sends SessionOutput::Bell
  → server.rs forwarding task → Event::Bell → bridge.rs → terminal-bell Tauri event
  → App.ts listener → notification pipeline
```

### Idle path
```
terminal-output / terminal-grid-diff → IdleNotificationService.recordOutput()
  → 5s timer tick → (idle > 15s && hadRecentOutput && !isActiveTab)
  → notification pipeline
```

## Files changed

| Layer | File | Change |
|-------|------|--------|
| godly-vt | `screen.rs` | `bell_pending` flag + `take_bell_pending()` |
| godly-vt | `perform.rs` | Set `bell_pending` on BEL (byte 7) |
| godly-vt | `parser.rs` | Delegate `take_bell_pending()` |
| protocol | `messages.rs` | `Event::Bell` variant |
| daemon | `session.rs` | `SessionOutput::Bell` + reader thread bell check |
| daemon | `server.rs` | Bell forwarding in all match blocks |
| bridge | `bridge.rs` | `TerminalBell` emit payload |
| frontend | `App.ts` | `terminal-bell` listener + idle service wiring |
| frontend | `idle-notification-service.ts` | New idle detection service |
| state | `notification-store.ts` | `idleNotifyEnabled` setting |
| UI | `SettingsDialog.ts` | Idle notifications toggle |

## Test plan

- [x] `cargo test -p godly-vt` — 5 new bell_pending tests + all 55 existing pass
- [x] `cargo test -p godly-daemon` — 4 existing tests pass
- [x] `npm test` — 10 new IdleNotificationService tests + all 487 existing pass (497 total)
- [ ] Manual: Run `printf '\a'` in a background terminal tab → notification fires
- [ ] Manual: Start a command with output then switch tabs → idle notification after 15s