### PR TITLE
fix: sound pack dropdown empty and test buttons not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godly-terminal",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ features = [
 
 [package]
 name = "godly-terminal"
-version = "0.3.3"
+version = "0.3.4"
 description = "A Windows terminal application with workspaces"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/daemon/Cargo.toml
+++ b/src-tauri/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godly-daemon"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "BUSL-1.1"
 

--- a/src-tauri/godly-vt/Cargo.toml
+++ b/src-tauri/godly-vt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godly-vt"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "High-performance terminal state engine with SIMD parsing and image support"

--- a/src-tauri/mcp/Cargo.toml
+++ b/src-tauri/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godly-mcp"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "BUSL-1.1"
 

--- a/src-tauri/notify/Cargo.toml
+++ b/src-tauri/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godly-notify"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "BUSL-1.1"
 

--- a/src-tauri/protocol/Cargo.toml
+++ b/src-tauri/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godly-protocol"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "BUSL-1.1"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Godly Terminal",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "com.godly.terminal",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Embed default sound pack via `include_str!`/`include_bytes!` so it installs even when Tauri's resource dir is unavailable (dev mode)
- Add "Loading..." placeholder + `min-width: 140px` to the sound pack `<select>` so it doesn't collapse when empty
- Map all 5 sound categories to `work_complete.mp3` in the default manifest so all Test buttons work

Fixes #200