### PR TITLE
feat: add keyboard shortcuts to create split terminals

### DIFF
--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -18,6 +18,8 @@ export type ActionId =
   | 'tabs.closeTerminal'
   | 'tabs.nextTab'
   | 'tabs.previousTab'
+  | 'split.splitRight'
+  | 'split.splitDown'
   | 'split.focusOtherPane'
   | 'split.unsplit'
   | 'workspace.toggleWorktreeMode'
@@ -115,6 +117,20 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Tabs',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'tab' },
+  },
+  {
+    id: 'split.splitRight',
+    label: 'Split Right',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: false, key: '\\' },
+  },
+  {
+    id: 'split.splitDown',
+    label: 'Split Down',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: true, key: '\\' },
   },
   {
     id: 'split.focusOtherPane',


### PR DESCRIPTION
## Summary

- Add `Ctrl+\` (Split Right) and `Ctrl+Alt+\` (Split Down) keyboard shortcuts that create a new terminal and immediately split it with the active pane
- Extract shared terminal creation logic into a `createNewTerminal()` helper to avoid duplication between `tabs.newTerminal` and the new split actions
- New shortcuts follow the existing `\`-key convention: `Alt+\` = Focus Other Pane, `Ctrl+Shift+\` = Unsplit

Fixes #223

## Test plan

- [x] `npx tsc --noEmit` passes (clean)
- [x] `npm test` passes (670 tests, 52 files)
- [ ] Manual: `Ctrl+\` creates a new terminal in horizontal split
- [ ] Manual: `Ctrl+Alt+\` creates a new terminal in vertical split
- [ ] Settings dialog shows both new shortcuts under the Split category
- [ ] Works with worktree mode enabled (prompts for name)
- [ ] Split state persists across app restart