### PR TITLE
feat: pause hidden terminals (Phase 3, #213)

### DIFF
--- a/src/components/TerminalPane.pause.test.ts
+++ b/src/components/TerminalPane.pause.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for pausing/resuming hidden terminal panes (Phase 3, Issue #213).
+ *
+ * When a terminal is not visible (hidden tab, not in split view), all output
+ * processing should be suspended: the output stream is disconnected, snapshot
+ * scheduling stops, and event callbacks early-return. The daemon's godly-vt
+ * parser keeps state current, so a single snapshot fetch on resume catches up.
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const mockDisconnectOutputStream = vi.fn();
+const mockConnectOutputStream = vi.fn();
+const mockFetchAndRenderSnapshot = vi.fn();
+
+interface PauseSimulatorSnapshot {
+  rows: unknown[];
+  cursor: unknown;
+  dimensions: { rows: number; cols: number };
+}
+
+/**
+ * Simulates the pause/resume logic from TerminalPane without needing
+ * the real DOM, Tauri IPC, or renderer dependencies.
+ */
+class PauseSimulator {
+  terminalId: string;
+  paused = false;
+  snapshotPending = false;
+  snapshotTimer: ReturnType<typeof setTimeout> | null = null;
+  renderRAF: number | null = null;
+  cachedSnapshot: PauseSimulatorSnapshot | null = null;
+  scheduleSnapshotFetchCalls = 0;
+
+  constructor(terminalId: string) {
+    this.terminalId = terminalId;
+  }
+
+  pause() {
+    if (this.paused) return;
+    this.paused = true;
+    mockDisconnectOutputStream(this.terminalId);
+    if (this.snapshotTimer !== null) {
+      clearTimeout(this.snapshotTimer);
+      this.snapshotTimer = null;
+    }
+    this.snapshotPending = false;
+    if (this.renderRAF !== null) {
+      // In real code: cancelAnimationFrame(this.renderRAF)
+      this.renderRAF = null;
+    }
+  }
+
+  resume() {
+    if (!this.paused) return;
+    this.paused = false;
+    this.cachedSnapshot = null;
+    mockConnectOutputStream(this.terminalId);
+    mockFetchAndRenderSnapshot(this.terminalId);
+  }
+
+  scheduleSnapshotFetch() {
+    if (this.paused) return;
+    if (this.snapshotPending) return;
+    this.snapshotPending = true;
+    this.scheduleSnapshotFetchCalls++;
+  }
+
+  /** Simulate a grid diff event arriving from the daemon. */
+  simulateGridDiffEvent() {
+    if (this.paused) return;
+    this.scheduleSnapshotFetch();
+  }
+
+  /** Simulate a terminal-output event arriving from the daemon. */
+  simulateOutputEvent() {
+    if (this.paused) return;
+    this.scheduleSnapshotFetch();
+  }
+
+  /** Simulate an output stream chunk arriving. */
+  simulateStreamChunk() {
+    if (this.paused) return;
+    this.scheduleSnapshotFetch();
+  }
+
+  /** Simulate setActive(true) — tab becomes visible. */
+  setActive(active: boolean) {
+    if (active) {
+      this.resume();
+    } else {
+      this.pause();
+    }
+  }
+
+  /** Simulate setSplitVisible(visible, focused). */
+  setSplitVisible(visible: boolean, _focused: boolean) {
+    if (visible) {
+      this.resume();
+    } else {
+      this.pause();
+    }
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('Terminal pause/resume (Phase 3: pause hidden terminals)', () => {
+  beforeEach(() => {
+    mockDisconnectOutputStream.mockReset();
+    mockConnectOutputStream.mockReset();
+    mockFetchAndRenderSnapshot.mockReset();
+  });
+
+  describe('pause()', () => {
+    it('disconnects the output stream', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+
+      expect(mockDisconnectOutputStream).toHaveBeenCalledWith('term-1');
+    });
+
+    it('cancels pending snapshot timer', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.snapshotTimer = setTimeout(() => {}, 1000);
+      sim.snapshotPending = true;
+
+      sim.pause();
+
+      expect(sim.snapshotTimer).toBeNull();
+      expect(sim.snapshotPending).toBe(false);
+    });
+
+    it('cancels pending render RAF', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.renderRAF = 42;
+
+      sim.pause();
+
+      expect(sim.renderRAF).toBeNull();
+    });
+
+    it('sets paused flag to true', () => {
+      const sim = new PauseSimulator('term-1');
+      expect(sim.paused).toBe(false);
+
+      sim.pause();
+
+      expect(sim.paused).toBe(true);
+    });
+
+    it('is idempotent — calling pause() twice does not disconnect twice', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+      sim.pause();
+
+      expect(mockDisconnectOutputStream).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resume()', () => {
+    it('reconnects the output stream', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+      sim.resume();
+
+      expect(mockConnectOutputStream).toHaveBeenCalledWith('term-1');
+    });
+
+    it('fetches a fresh snapshot to catch up', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+      sim.resume();
+
+      expect(mockFetchAndRenderSnapshot).toHaveBeenCalledWith('term-1');
+    });
+
+    it('invalidates cached snapshot to force full fetch (not diff)', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.cachedSnapshot = {
+        rows: [],
+        cursor: { row: 0, col: 0 },
+        dimensions: { rows: 24, cols: 80 },
+      };
+      sim.pause();
+      sim.resume();
+
+      expect(sim.cachedSnapshot).toBeNull();
+    });
+
+    it('sets paused flag to false', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+      expect(sim.paused).toBe(true);
+
+      sim.resume();
+
+      expect(sim.paused).toBe(false);
+    });
+
+    it('is idempotent — calling resume() when not paused is a no-op', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.resume();
+
+      expect(mockConnectOutputStream).not.toHaveBeenCalled();
+      expect(mockFetchAndRenderSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event callbacks are no-ops when paused', () => {
+    it('grid diff events are ignored when paused', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+
+      sim.simulateGridDiffEvent();
+
+      expect(sim.scheduleSnapshotFetchCalls).toBe(0);
+    });
+
+    it('terminal-output events are ignored when paused', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+
+      sim.simulateOutputEvent();
+
+      expect(sim.scheduleSnapshotFetchCalls).toBe(0);
+    });
+
+    it('output stream chunks are ignored when paused', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+
+      sim.simulateStreamChunk();
+
+      expect(sim.scheduleSnapshotFetchCalls).toBe(0);
+    });
+
+    it('scheduleSnapshotFetch() is a no-op when paused', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+
+      sim.scheduleSnapshotFetch();
+
+      expect(sim.snapshotPending).toBe(false);
+      expect(sim.scheduleSnapshotFetchCalls).toBe(0);
+    });
+  });
+
+  describe('tab switch cycle', () => {
+    it('setActive(false) pauses, setActive(true) resumes', () => {
+      const sim = new PauseSimulator('term-1');
+
+      sim.setActive(false);
+      expect(sim.paused).toBe(true);
+      expect(mockDisconnectOutputStream).toHaveBeenCalledWith('term-1');
+
+      sim.setActive(true);
+      expect(sim.paused).toBe(false);
+      expect(mockConnectOutputStream).toHaveBeenCalledWith('term-1');
+      expect(mockFetchAndRenderSnapshot).toHaveBeenCalledWith('term-1');
+    });
+
+    it('active→inactive→active preserves terminal state availability', () => {
+      // Verifies that after a full cycle, the pane is ready to receive output
+      const sim = new PauseSimulator('term-1');
+      sim.cachedSnapshot = {
+        rows: [],
+        cursor: { row: 0, col: 0 },
+        dimensions: { rows: 24, cols: 80 },
+      };
+
+      sim.setActive(false);
+      // While paused, events are ignored
+      sim.simulateOutputEvent();
+      sim.simulateGridDiffEvent();
+      expect(sim.scheduleSnapshotFetchCalls).toBe(0);
+
+      sim.setActive(true);
+      // After resume, snapshot cache is invalidated for full fetch
+      expect(sim.cachedSnapshot).toBeNull();
+      // Events work again
+      sim.simulateOutputEvent();
+      expect(sim.scheduleSnapshotFetchCalls).toBe(1);
+    });
+
+    it('no output processing happens between pause and resume', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.setActive(false);
+
+      // Simulate a burst of output while hidden
+      for (let i = 0; i < 100; i++) {
+        sim.simulateOutputEvent();
+        sim.simulateGridDiffEvent();
+        sim.simulateStreamChunk();
+      }
+
+      // None of it should have scheduled snapshot fetches
+      expect(sim.scheduleSnapshotFetchCalls).toBe(0);
+      expect(sim.snapshotPending).toBe(false);
+    });
+  });
+
+  describe('split view', () => {
+    it('both visible panes remain unpaused', () => {
+      const simA = new PauseSimulator('term-A');
+      const simB = new PauseSimulator('term-B');
+
+      simA.setSplitVisible(true, true);
+      simB.setSplitVisible(true, false);
+
+      expect(simA.paused).toBe(false);
+      expect(simB.paused).toBe(false);
+    });
+
+    it('setSplitVisible(false) pauses the pane', () => {
+      const sim = new PauseSimulator('term-1');
+
+      sim.setSplitVisible(false, false);
+
+      expect(sim.paused).toBe(true);
+      expect(mockDisconnectOutputStream).toHaveBeenCalledWith('term-1');
+    });
+
+    it('setSplitVisible(true) resumes a paused pane', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.pause();
+
+      sim.setSplitVisible(true, false);
+
+      expect(sim.paused).toBe(false);
+      expect(mockConnectOutputStream).toHaveBeenCalledWith('term-1');
+      expect(mockFetchAndRenderSnapshot).toHaveBeenCalledWith('term-1');
+    });
+
+    it('exiting split mode pauses the non-active pane', () => {
+      const simA = new PauseSimulator('term-A');
+      const simB = new PauseSimulator('term-B');
+
+      // Both in split view
+      simA.setSplitVisible(true, true);
+      simB.setSplitVisible(true, false);
+
+      // Exit split: A becomes active tab, B becomes hidden
+      simA.setActive(true);
+      simB.setSplitVisible(false, false);
+
+      expect(simA.paused).toBe(false);
+      expect(simB.paused).toBe(true);
+    });
+  });
+
+  describe('resume after long pause catches up with full snapshot', () => {
+    it('cached snapshot is null after resume, forcing full fetch', () => {
+      const sim = new PauseSimulator('term-1');
+      sim.cachedSnapshot = {
+        rows: [{ cells: [], wrapped: false }],
+        cursor: { row: 0, col: 0 },
+        dimensions: { rows: 24, cols: 80 },
+      };
+
+      sim.pause();
+      // Cached snapshot is preserved while paused (for instant re-render if needed)
+      expect(sim.cachedSnapshot).not.toBeNull();
+
+      sim.resume();
+      // After resume, cache is invalidated so the next fetch is a full snapshot,
+      // not a diff (which could miss changes that happened while paused)
+      expect(sim.cachedSnapshot).toBeNull();
+      expect(mockFetchAndRenderSnapshot).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -65,6 +65,11 @@ export class TerminalPane {
   // Pending render scheduled via requestAnimationFrame (for pushed diffs).
   private renderRAF: number | null = null;
 
+  // When true, the pane is not visible (hidden tab, not in split view).
+  // All output processing is suspended to save CPU — the daemon's godly-vt
+  // parser keeps state current, so a single snapshot fetch on resume catches up.
+  private paused = false;
+
   // Hidden textarea for keyboard input (handles dead keys, IME composition).
   // Canvas elements don't support text composition, so dead keys (e.g. quote
   // on ABNT2 keyboards) produce event.key="Dead" and the composed character
@@ -222,6 +227,7 @@ export class TerminalPane {
     this.unsubscribeGridDiff = terminalService.onTerminalGridDiff(
       this.terminalId,
       (diff) => {
+        if (this.paused) return;
         perfTracer.mark('terminal_grid_diff_event');
         perfTracer.measure('keydown_to_diff', 'keydown');
         if (this.renderer.isActivelySelecting()) return;
@@ -239,6 +245,7 @@ export class TerminalPane {
     this.unsubscribeOutput = terminalService.onTerminalOutput(
       this.terminalId,
       () => {
+        if (this.paused) return;
         perfTracer.mark('terminal_output_event');
         perfTracer.measure('keydown_to_output', 'keydown');
         // Freeze display while the user is dragging to select text.
@@ -257,6 +264,7 @@ export class TerminalPane {
     // Tauri events because it skips JSON serialization. The terminal-output
     // event listener above remains as a fallback.
     terminalService.connectOutputStream(this.terminalId, () => {
+      if (this.paused) return;
       if (this.renderer.isActivelySelecting()) return;
       if (this.isUserScrolled && terminalSettingsStore.getAutoScrollOnOutput()) {
         this.snapToBottom();
@@ -536,6 +544,7 @@ export class TerminalPane {
   // ---- Grid snapshot fetching ----
 
   private scheduleSnapshotFetch() {
+    if (this.paused) return;
     if (this.snapshotPending) return;
     this.snapshotPending = true;
     perfTracer.mark('schedule_snapshot');
@@ -814,10 +823,59 @@ export class TerminalPane {
 
   // ---- Activation / Visibility ----
 
+  /**
+   * Pause output processing. Called when this pane becomes invisible
+   * (hidden tab, removed from split view). Disconnects the output stream,
+   * cancels pending timers, and makes event callbacks early-return.
+   * The daemon's godly-vt parser continues updating, so resume() can
+   * catch up with a single snapshot fetch.
+   */
+  pause() {
+    if (this.paused) return;
+    this.paused = true;
+    terminalService.disconnectOutputStream(this.terminalId);
+    if (this.snapshotTimer !== null) {
+      clearTimeout(this.snapshotTimer);
+      this.snapshotTimer = null;
+    }
+    this.snapshotPending = false;
+    if (this.renderRAF !== null) {
+      cancelAnimationFrame(this.renderRAF);
+      this.renderRAF = null;
+    }
+  }
+
+  /**
+   * Resume output processing. Called when this pane becomes visible again
+   * (tab activated, added to split view). Reconnects the output stream,
+   * invalidates the cached snapshot to force a full fetch, and immediately
+   * fetches the current grid state to catch up.
+   */
+  resume() {
+    if (!this.paused) return;
+    this.paused = false;
+    this.cachedSnapshot = null;
+    terminalService.connectOutputStream(this.terminalId, () => {
+      if (this.paused) return;
+      if (this.renderer.isActivelySelecting()) return;
+      if (this.isUserScrolled && terminalSettingsStore.getAutoScrollOnOutput()) {
+        this.snapToBottom();
+        return;
+      }
+      this.scheduleSnapshotFetch();
+    });
+    this.fetchAndRenderSnapshot();
+  }
+
+  isPaused(): boolean {
+    return this.paused;
+  }
+
   setActive(active: boolean) {
     this.container.classList.remove('split-visible', 'split-focused');
     this.container.classList.toggle('active', active);
     if (active) {
+      this.resume();
       // Sync canvas bitmap to container size immediately to prevent the browser
       // from stretching the stale bitmap (300×150 default) for one frame,
       // which causes a "zoomed in" flash on tab switch / reopen.
@@ -839,6 +897,8 @@ export class TerminalPane {
           this.focusInput();
         }
       }, 50);
+    } else {
+      this.pause();
     }
   }
 
@@ -847,6 +907,7 @@ export class TerminalPane {
     this.container.classList.toggle('split-visible', visible);
     this.container.classList.toggle('split-focused', focused);
     if (visible) {
+      this.resume();
       // Sync canvas bitmap to container size immediately to prevent zoom flash.
       this.renderer.updateSize();
       requestAnimationFrame(() => {
@@ -859,6 +920,8 @@ export class TerminalPane {
         }
         this.fetchAndRenderSnapshot();
       });
+    } else {
+      this.pause();
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `pause()`/`resume()` methods to `TerminalPane` that suspend all output processing for non-visible terminals
- `pause()` disconnects the output stream, cancels pending snapshot timers/RAFs, and makes event callbacks (grid diff, terminal-output, stream chunks) early-return
- `resume()` reconnects the stream, invalidates cached snapshot (forces full fetch, not diff), and immediately catches up with the daemon's current state
- Wired into `setActive()` and `setSplitVisible()` so tab switches and split view changes automatically pause/resume

This makes CPU proportional to 1 visible terminal instead of N total. The daemon's godly-vt parser always has current state, so a single snapshot fetch on resume gives instant catch-up — no ring buffer replay needed.

## Test plan

- [x] 22 new unit tests covering pause/resume lifecycle, event callback guards, tab switch cycles, split view, and full snapshot catch-up
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] Full frontend test suite passes (732 tests, 57 files)
- [ ] Manual: open 5+ terminals, run continuous output in background tabs — only active tab causes snapshot fetches
- [ ] Manual: switch to a background tab — shows up-to-date content immediately

refs #213