### PR TITLE
feat(mcp): add SSE transport mode

### DIFF
--- a/src-tauri/mcp/Cargo.toml
+++ b/src-tauri/mcp/Cargo.toml
@@ -13,6 +13,10 @@ godly-protocol.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+async-stream = "0.3"
+futures-core = "0.3"
+axum = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 winapi.workspace = true

--- a/src-tauri/mcp/src/backend.rs
+++ b/src-tauri/mcp/src/backend.rs
@@ -4,7 +4,7 @@ use godly_protocol::{McpRequest, McpResponse};
 /// Two implementations:
 /// - `AppBackend`: talks to the Tauri app via MCP pipe (full functionality)
 /// - `DaemonDirectBackend`: talks directly to the daemon (subset of tools)
-pub trait Backend {
+pub trait Backend: Send {
     fn send_request(&mut self, request: &McpRequest) -> Result<McpResponse, String>;
 
     /// Human-readable label for logging (e.g. "app" or "daemon-direct").

--- a/src-tauri/mcp/src/handler.rs
+++ b/src-tauri/mcp/src/handler.rs
@@ -1,0 +1,200 @@
+use serde_json::json;
+
+use crate::app_backend::AppBackend;
+use crate::backend::Backend;
+use crate::daemon_direct::DaemonDirectBackend;
+use crate::jsonrpc::{JsonRpcRequest, JsonRpcResponse};
+use crate::log::mcp_log;
+use crate::pipe_client::McpPipeClient;
+use crate::tools;
+
+/// Try to connect a backend: MCP pipe (app) first, then daemon direct.
+pub fn connect_backend() -> Result<Box<dyn Backend>, String> {
+    // Try MCP pipe first (Tauri app)
+    match McpPipeClient::connect() {
+        Ok(client) => {
+            mcp_log!("Connected via MCP pipe (app backend)");
+            return Ok(Box::new(AppBackend::new(client)));
+        }
+        Err(e) => {
+            mcp_log!("MCP pipe unavailable: {} — trying daemon direct...", e);
+        }
+    }
+
+    // Fall back to daemon direct
+    match DaemonDirectBackend::connect() {
+        Ok(backend) => {
+            mcp_log!("Connected via daemon pipe (daemon-direct fallback)");
+            Ok(Box::new(backend))
+        }
+        Err(e) => Err(format!(
+            "Cannot connect to Godly Terminal. App pipe and daemon pipe both unavailable. Last error: {}",
+            e
+        )),
+    }
+}
+
+/// Try to reconnect: MCP pipe first, then daemon direct.
+/// Returns new backend on success, None on failure.
+pub fn try_reconnect() -> Option<Box<dyn Backend>> {
+    if let Ok(client) = McpPipeClient::connect() {
+        mcp_log!("Reconnected via MCP pipe (app backend)");
+        return Some(Box::new(AppBackend::new(client)));
+    }
+    if let Ok(backend) = DaemonDirectBackend::connect() {
+        mcp_log!("Reconnected via daemon pipe (daemon-direct fallback)");
+        return Some(Box::new(backend));
+    }
+    None
+}
+
+/// If currently in daemon-direct mode, cheaply probe the MCP pipe
+/// and upgrade to app backend if the Tauri app is back.
+pub fn maybe_upgrade_backend(backend: &mut Box<dyn Backend>) {
+    if backend.label() != "daemon-direct" {
+        return;
+    }
+
+    // Cheap probe: try opening the MCP pipe
+    if let Ok(client) = McpPipeClient::connect() {
+        mcp_log!("App pipe is back — upgrading from daemon-direct to app backend");
+        *backend = Box::new(AppBackend::new(client));
+    }
+}
+
+pub fn handle_request(
+    request: &JsonRpcRequest,
+    backend: &mut Box<dyn Backend>,
+    session_id: &Option<String>,
+) -> JsonRpcResponse {
+    match request.method.as_str() {
+        "initialize" => {
+            mcp_log!("Handling initialize");
+            JsonRpcResponse::success(
+                request.id.clone(),
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {
+                        "tools": {}
+                    },
+                    "serverInfo": {
+                        "name": "godly-terminal",
+                        "version": "0.1.0"
+                    }
+                }),
+            )
+        }
+
+        "tools/list" => {
+            mcp_log!("Handling tools/list");
+            JsonRpcResponse::success(request.id.clone(), tools::list_tools())
+        }
+
+        "tools/call" => {
+            let params = request.params.as_ref();
+            let tool_name = params
+                .and_then(|p| p.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let args = params
+                .and_then(|p| p.get("arguments"))
+                .cloned()
+                .unwrap_or(json!({}));
+
+            mcp_log!(
+                "Handling tools/call: tool={}, args={}, backend={}",
+                tool_name,
+                args,
+                backend.label()
+            );
+
+            match tools::call_tool(backend.as_mut(), tool_name, &args, session_id) {
+                Ok(result) => {
+                    mcp_log!("Tool call succeeded: {}", tool_name);
+                    JsonRpcResponse::success(
+                        request.id.clone(),
+                        json!({
+                            "content": [{
+                                "type": "text",
+                                "text": serde_json::to_string_pretty(&result)
+                                    .unwrap_or_else(|_| result.to_string())
+                            }]
+                        }),
+                    )
+                }
+                Err(e) => {
+                    mcp_log!("Tool call failed: {} — {}", tool_name, e);
+
+                    // If it looks like a pipe error, try to reconnect
+                    if e.contains("Pipe error")
+                        || e.contains("write error")
+                        || e.contains("read error")
+                        || e.contains("Pipe closed")
+                        || e.contains("Daemon pipe closed")
+                    {
+                        mcp_log!("Pipe error detected — attempting reconnect...");
+                        if let Some(new_backend) = try_reconnect() {
+                            mcp_log!("Reconnected via {}", new_backend.label());
+                            *backend = new_backend;
+
+                            // Retry the tool call once
+                            match tools::call_tool(
+                                backend.as_mut(),
+                                tool_name,
+                                &args,
+                                session_id,
+                            ) {
+                                Ok(result) => {
+                                    mcp_log!("Retry succeeded: {}", tool_name);
+                                    return JsonRpcResponse::success(
+                                        request.id.clone(),
+                                        json!({
+                                            "content": [{
+                                                "type": "text",
+                                                "text": serde_json::to_string_pretty(&result)
+                                                    .unwrap_or_else(|_| result.to_string())
+                                            }]
+                                        }),
+                                    );
+                                }
+                                Err(retry_err) => {
+                                    mcp_log!("Retry also failed: {}", retry_err);
+                                    return JsonRpcResponse::success(
+                                        request.id.clone(),
+                                        json!({
+                                            "content": [{
+                                                "type": "text",
+                                                "text": format!("Error: {}", retry_err)
+                                            }],
+                                            "isError": true
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    JsonRpcResponse::success(
+                        request.id.clone(),
+                        json!({
+                            "content": [{
+                                "type": "text",
+                                "text": format!("Error: {}", e)
+                            }],
+                            "isError": true
+                        }),
+                    )
+                }
+            }
+        }
+
+        _ => {
+            mcp_log!("Unknown method: {}", request.method);
+            JsonRpcResponse::error(
+                request.id.clone(),
+                -32601,
+                format!("Method not found: {}", request.method),
+            )
+        }
+    }
+}

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -1,24 +1,20 @@
 mod app_backend;
 mod backend;
 mod daemon_direct;
+mod handler;
 mod jsonrpc;
 mod log;
 mod pipe_client;
+mod sse;
 mod tools;
 
 use std::io::{self, BufReader};
 
-use serde_json::json;
-
-use app_backend::AppBackend;
-use backend::Backend;
-use daemon_direct::DaemonDirectBackend;
-use jsonrpc::{JsonRpcResponse, read_message, write_message};
+use jsonrpc::{read_message, write_message};
 use log::mcp_log;
-use pipe_client::McpPipeClient;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 14;
+const BUILD: u32 = 15;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -33,64 +29,6 @@ fn main() {
 }
 
 // ---------------------------------------------------------------------------
-// Backend connection
-// ---------------------------------------------------------------------------
-
-/// Try to connect a backend: MCP pipe (app) first, then daemon direct.
-fn connect_backend() -> Result<Box<dyn Backend>, String> {
-    // Try MCP pipe first (Tauri app)
-    match McpPipeClient::connect() {
-        Ok(client) => {
-            mcp_log!("Connected via MCP pipe (app backend)");
-            return Ok(Box::new(AppBackend::new(client)));
-        }
-        Err(e) => {
-            mcp_log!("MCP pipe unavailable: {} — trying daemon direct...", e);
-        }
-    }
-
-    // Fall back to daemon direct
-    match DaemonDirectBackend::connect() {
-        Ok(backend) => {
-            mcp_log!("Connected via daemon pipe (daemon-direct fallback)");
-            Ok(Box::new(backend))
-        }
-        Err(e) => Err(format!(
-            "Cannot connect to Godly Terminal. App pipe and daemon pipe both unavailable. Last error: {}",
-            e
-        )),
-    }
-}
-
-/// Try to reconnect: MCP pipe first, then daemon direct.
-/// Returns new backend on success, None on failure.
-fn try_reconnect() -> Option<Box<dyn Backend>> {
-    if let Ok(client) = McpPipeClient::connect() {
-        mcp_log!("Reconnected via MCP pipe (app backend)");
-        return Some(Box::new(AppBackend::new(client)));
-    }
-    if let Ok(backend) = DaemonDirectBackend::connect() {
-        mcp_log!("Reconnected via daemon pipe (daemon-direct fallback)");
-        return Some(Box::new(backend));
-    }
-    None
-}
-
-/// If currently in daemon-direct mode, cheaply probe the MCP pipe
-/// and upgrade to app backend if the Tauri app is back.
-fn maybe_upgrade_backend(backend: &mut Box<dyn Backend>) {
-    if backend.label() != "daemon-direct" {
-        return;
-    }
-
-    // Cheap probe: try opening the MCP pipe
-    if let Ok(client) = McpPipeClient::connect() {
-        mcp_log!("App pipe is back — upgrading from daemon-direct to app backend");
-        *backend = Box::new(AppBackend::new(client));
-    }
-}
-
-// ---------------------------------------------------------------------------
 // CLI mode
 // ---------------------------------------------------------------------------
 
@@ -101,13 +39,15 @@ godly-mcp — Godly Terminal MCP server & CLI
 
 USAGE:
     godly-mcp                          Start MCP server (stdin/stdout JSON-RPC)
+    godly-mcp sse [OPTIONS]            Start MCP server (SSE/HTTP transport)
     godly-mcp notify [OPTIONS]         Send a notification to Godly Terminal
     godly-mcp --help                   Show this help
 
 COMMANDS:
+    sse       Start SSE transport server (HTTP, serves multiple sessions)
     notify    Send a sound notification and badge alert
 
-Run 'godly-mcp notify --help' for subcommand details."
+Run 'godly-mcp sse --help' or 'godly-mcp notify --help' for subcommand details."
     );
 }
 
@@ -136,6 +76,33 @@ EXAMPLES:
     );
 }
 
+fn print_sse_help() {
+    eprintln!(
+        "\
+Start the SSE transport server.
+
+Runs a persistent HTTP server that serves multiple Claude Code sessions
+over Server-Sent Events (SSE). One process, many clients.
+
+USAGE:
+    godly-mcp sse [OPTIONS]
+
+OPTIONS:
+    -p, --port <PORT>          Port to listen on (default: 8089)
+    -h, --help                 Show this help
+
+PROTOCOL:
+    1. Client opens GET /sse → receives SSE stream
+    2. Server sends event: endpoint with POST URL
+    3. Client sends JSON-RPC via POST /messages?sessionId=XXX
+    4. Server pushes response as event: message on the SSE stream
+
+EXAMPLES:
+    godly-mcp sse
+    godly-mcp sse --port 9090"
+    );
+}
+
 /// Run in CLI mode. Returns the process exit code.
 fn run_cli(args: &[String]) -> i32 {
     match args[0].as_str() {
@@ -144,6 +111,7 @@ fn run_cli(args: &[String]) -> i32 {
             0
         }
         "notify" => run_cli_notify(&args[1..]),
+        "sse" => run_cli_sse(&args[1..]),
         other => {
             eprintln!("Error: unknown command '{}'\n", other);
             print_help();
@@ -199,7 +167,7 @@ fn run_cli_notify(args: &[String]) -> i32 {
     };
 
     // Connect to pipe and send the request (CLI notify only uses app backend)
-    let mut client = match McpPipeClient::connect() {
+    let mut client = match pipe_client::McpPipeClient::connect() {
         Ok(c) => c,
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -232,8 +200,51 @@ fn run_cli_notify(args: &[String]) -> i32 {
     }
 }
 
+/// Parse and execute `godly-mcp sse [OPTIONS]`.
+fn run_cli_sse(args: &[String]) -> i32 {
+    let mut port: u16 = 8089;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--help" | "-h" => {
+                print_sse_help();
+                return 0;
+            }
+            "-p" | "--port" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Error: --port requires a value");
+                    return 1;
+                }
+                port = match args[i].parse() {
+                    Ok(p) => p,
+                    Err(_) => {
+                        eprintln!("Error: invalid port number '{}'", args[i]);
+                        return 1;
+                    }
+                };
+            }
+            other => {
+                eprintln!("Error: unknown option '{}'\n", other);
+                print_sse_help();
+                return 1;
+            }
+        }
+        i += 1;
+    }
+
+    log::init();
+    mcp_log!("=== godly-mcp SSE starting === build={}", BUILD);
+    mcp_log!("PID: {}", std::process::id());
+
+    // run_sse_server blocks forever
+    sse::run_sse_server(port);
+    0
+}
+
 // ---------------------------------------------------------------------------
-// MCP server mode
+// MCP server mode (stdio)
 // ---------------------------------------------------------------------------
 
 fn run_mcp_server() {
@@ -255,7 +266,7 @@ fn run_mcp_server() {
     mcp_log!("GODLY_MCP_PIPE_NAME: {:?}", pipe_name);
 
     mcp_log!("Connecting backend...");
-    let mut backend = match connect_backend() {
+    let mut backend = match handler::connect_backend() {
         Ok(b) => {
             mcp_log!("Backend connected: {}", b.label());
             b
@@ -301,9 +312,9 @@ fn run_mcp_server() {
         }
 
         // If in fallback mode, try to upgrade to app backend
-        maybe_upgrade_backend(&mut backend);
+        handler::maybe_upgrade_backend(&mut backend);
 
-        let response = handle_request(&request, &mut backend, &session_id);
+        let response = handler::handle_request(&request, &mut backend, &session_id);
 
         let response_json = serde_json::to_string(&response).unwrap_or_default();
         mcp_log!("Sending response: {}", response_json);
@@ -318,141 +329,4 @@ fn run_mcp_server() {
     }
 
     mcp_log!("=== godly-mcp shutting down ===");
-}
-
-fn handle_request(
-    request: &jsonrpc::JsonRpcRequest,
-    backend: &mut Box<dyn Backend>,
-    session_id: &Option<String>,
-) -> JsonRpcResponse {
-    match request.method.as_str() {
-        "initialize" => {
-            mcp_log!("Handling initialize");
-            JsonRpcResponse::success(
-                request.id.clone(),
-                json!({
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {
-                        "tools": {}
-                    },
-                    "serverInfo": {
-                        "name": "godly-terminal",
-                        "version": "0.1.0"
-                    }
-                }),
-            )
-        }
-
-        "tools/list" => {
-            mcp_log!("Handling tools/list");
-            JsonRpcResponse::success(request.id.clone(), tools::list_tools())
-        }
-
-        "tools/call" => {
-            let params = request.params.as_ref();
-            let tool_name = params
-                .and_then(|p| p.get("name"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let args = params
-                .and_then(|p| p.get("arguments"))
-                .cloned()
-                .unwrap_or(json!({}));
-
-            mcp_log!(
-                "Handling tools/call: tool={}, args={}, backend={}",
-                tool_name,
-                args,
-                backend.label()
-            );
-
-            match tools::call_tool(backend.as_mut(), tool_name, &args, session_id) {
-                Ok(result) => {
-                    mcp_log!("Tool call succeeded: {}", tool_name);
-                    JsonRpcResponse::success(
-                        request.id.clone(),
-                        json!({
-                            "content": [{
-                                "type": "text",
-                                "text": serde_json::to_string_pretty(&result)
-                                    .unwrap_or_else(|_| result.to_string())
-                            }]
-                        }),
-                    )
-                }
-                Err(e) => {
-                    mcp_log!("Tool call failed: {} — {}", tool_name, e);
-
-                    // If it looks like a pipe error, try to reconnect
-                    if e.contains("Pipe error")
-                        || e.contains("write error")
-                        || e.contains("read error")
-                        || e.contains("Pipe closed")
-                        || e.contains("Daemon pipe closed")
-                    {
-                        mcp_log!("Pipe error detected — attempting reconnect...");
-                        if let Some(new_backend) = try_reconnect() {
-                            mcp_log!("Reconnected via {}", new_backend.label());
-                            *backend = new_backend;
-
-                            // Retry the tool call once
-                            match tools::call_tool(
-                                backend.as_mut(),
-                                tool_name,
-                                &args,
-                                session_id,
-                            ) {
-                                Ok(result) => {
-                                    mcp_log!("Retry succeeded: {}", tool_name);
-                                    return JsonRpcResponse::success(
-                                        request.id.clone(),
-                                        json!({
-                                            "content": [{
-                                                "type": "text",
-                                                "text": serde_json::to_string_pretty(&result)
-                                                    .unwrap_or_else(|_| result.to_string())
-                                            }]
-                                        }),
-                                    );
-                                }
-                                Err(retry_err) => {
-                                    mcp_log!("Retry also failed: {}", retry_err);
-                                    return JsonRpcResponse::success(
-                                        request.id.clone(),
-                                        json!({
-                                            "content": [{
-                                                "type": "text",
-                                                "text": format!("Error: {}", retry_err)
-                                            }],
-                                            "isError": true
-                                        }),
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    JsonRpcResponse::success(
-                        request.id.clone(),
-                        json!({
-                            "content": [{
-                                "type": "text",
-                                "text": format!("Error: {}", e)
-                            }],
-                            "isError": true
-                        }),
-                    )
-                }
-            }
-        }
-
-        _ => {
-            mcp_log!("Unknown method: {}", request.method);
-            JsonRpcResponse::error(
-                request.id.clone(),
-                -32601,
-                format!("Method not found: {}", request.method),
-            )
-        }
-    }
 }

--- a/src-tauri/mcp/src/sse.rs
+++ b/src-tauri/mcp/src/sse.rs
@@ -1,0 +1,201 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::Router;
+use tokio::sync::mpsc;
+
+use crate::backend::Backend;
+use crate::handler;
+use crate::jsonrpc::{JsonRpcRequest, JsonRpcResponse};
+use crate::log::mcp_log;
+
+/// Shared state for the SSE server.
+struct SseState {
+    /// The backend connection (sync — guarded by std::sync::Mutex since pipe I/O blocks).
+    backend: Mutex<Box<dyn Backend>>,
+    /// Map of session ID → channel sender for pushing SSE responses.
+    sessions: Mutex<HashMap<String, mpsc::Sender<JsonRpcResponse>>>,
+}
+
+type SharedState = Arc<SseState>;
+
+/// Start the SSE server on the given port. Blocks forever.
+pub fn run_sse_server(port: u16) {
+    mcp_log!("Starting SSE server on port {}", port);
+
+    let backend = match handler::connect_backend() {
+        Ok(b) => {
+            mcp_log!("SSE backend connected: {}", b.label());
+            b
+        }
+        Err(e) => {
+            mcp_log!("FATAL: No backend available: {}", e);
+            eprintln!("Failed to connect to Godly Terminal: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let state = Arc::new(SseState {
+        backend: Mutex::new(backend),
+        sessions: Mutex::new(HashMap::new()),
+    });
+
+    let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    rt.block_on(async move {
+        let app = Router::new()
+            .route("/sse", get(sse_handler))
+            .route("/messages", post(messages_handler))
+            .with_state(state);
+
+        let addr = format!("127.0.0.1:{}", port);
+        mcp_log!("SSE server listening on {}", addr);
+        eprintln!("godly-mcp SSE server listening on http://{}", addr);
+
+        let listener = tokio::net::TcpListener::bind(&addr)
+            .await
+            .unwrap_or_else(|e| {
+                mcp_log!("FATAL: Failed to bind to {}: {}", addr, e);
+                eprintln!("Failed to bind to {}: {}", addr, e);
+                std::process::exit(1);
+            });
+
+        axum::serve(listener, app).await.unwrap_or_else(|e| {
+            mcp_log!("FATAL: Server error: {}", e);
+            eprintln!("Server error: {}", e);
+        });
+    });
+}
+
+/// GET /sse — Create a new SSE session and return the event stream.
+async fn sse_handler(
+    State(state): State<SharedState>,
+) -> Sse<impl futures_core::Stream<Item = Result<Event, std::convert::Infallible>>> {
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let (tx, mut rx) = mpsc::channel::<JsonRpcResponse>(64);
+
+    // Register the session
+    {
+        let mut sessions = state.sessions.lock().unwrap();
+        sessions.insert(session_id.clone(), tx);
+    }
+    mcp_log!("SSE session connected: {}", session_id);
+
+    let endpoint_url = format!("/messages?sessionId={}", session_id);
+    let log_id = session_id.clone();
+    let cleanup_state = state.clone();
+    let cleanup_id = session_id.clone();
+
+    let stream = async_stream::stream! {
+        // First event: tell the client where to POST requests
+        yield Ok(Event::default().event("endpoint").data(endpoint_url));
+
+        // Then relay all responses for this session
+        loop {
+            match rx.recv().await {
+                Some(response) => {
+                    match serde_json::to_string(&response) {
+                        Ok(json) => {
+                            yield Ok(Event::default().event("message").data(json));
+                        }
+                        Err(e) => {
+                            mcp_log!("SSE serialize error for session {}: {}", log_id, e);
+                        }
+                    }
+                }
+                None => {
+                    // Channel closed — session ended
+                    break;
+                }
+            }
+        }
+
+        // Clean up session when stream drops
+        mcp_log!("SSE stream ended for session: {}", cleanup_id);
+        let mut sessions = cleanup_state.sessions.lock().unwrap();
+        sessions.remove(&cleanup_id);
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+#[derive(serde::Deserialize)]
+struct MessageQuery {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+}
+
+/// POST /messages?sessionId=X — Receive a JSON-RPC request, process it, push response via SSE.
+async fn messages_handler(
+    State(state): State<SharedState>,
+    Query(query): Query<MessageQuery>,
+    body: String,
+) -> impl IntoResponse {
+    let session_id = query.session_id;
+
+    // Find the sender for this session
+    let tx = {
+        let sessions = state.sessions.lock().unwrap();
+        match sessions.get(&session_id) {
+            Some(tx) => tx.clone(),
+            None => {
+                mcp_log!("POST /messages: unknown session {}", session_id);
+                return StatusCode::NOT_FOUND;
+            }
+        }
+    };
+
+    // Parse the JSON-RPC request
+    let request: JsonRpcRequest = match serde_json::from_str(&body) {
+        Ok(req) => req,
+        Err(e) => {
+            mcp_log!("POST /messages: JSON parse error: {}", e);
+            // Send error response via SSE
+            let error_response =
+                JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e));
+            let _ = tx.send(error_response).await;
+            return StatusCode::ACCEPTED;
+        }
+    };
+
+    mcp_log!(
+        "POST /messages: session={}, method={}, id={:?}",
+        session_id,
+        request.method,
+        request.id
+    );
+
+    // JSON-RPC notifications (no id) — don't respond
+    if request.id.is_none() {
+        mcp_log!("Skipping notification (no id): method={}", request.method);
+        return StatusCode::ACCEPTED;
+    }
+
+    // Process the request on a blocking thread (pipe I/O is synchronous)
+    let state_clone = state.clone();
+    tokio::task::spawn_blocking(move || {
+        let response = {
+            let mut backend = state_clone.backend.lock().unwrap();
+
+            // Try to upgrade backend if in fallback mode
+            handler::maybe_upgrade_backend(&mut backend);
+
+            // No per-session GODLY_SESSION_ID in SSE mode — each request must supply it via tool args
+            let session_id_env = std::env::var("GODLY_SESSION_ID").ok();
+
+            handler::handle_request(&request, &mut backend, &session_id_env)
+        };
+
+        let response_json = serde_json::to_string(&response).unwrap_or_default();
+        mcp_log!("SSE response: {}", response_json);
+
+        // Push through SSE channel
+        let _ = tx.blocking_send(response);
+    });
+
+    StatusCode::ACCEPTED
+}


### PR DESCRIPTION
## Summary

- Add `godly-mcp sse [--port PORT]` subcommand that starts a persistent HTTP server (axum) serving multiple Claude Code sessions over SSE
- Extract shared handler logic (`connect_backend`, `handle_request`, `try_reconnect`, `maybe_upgrade_backend`) into `handler.rs` so both stdio and SSE transports reuse it
- Add `sse.rs` implementing the MCP SSE protocol: `GET /sse` returns an SSE stream, `POST /messages?sessionId=X` accepts JSON-RPC requests and pushes responses via the stream

## Test plan

- [x] `cargo check -p godly-mcp` passes
- [ ] Start SSE server: `cargo run -p godly-mcp -- sse --port 8089`
- [ ] Test SSE connection: `curl -N http://localhost:8089/sse` — should receive `event: endpoint`
- [ ] Test tool call: `curl -X POST http://localhost:8089/messages?sessionId=XXX -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'`
- [ ] Verify existing stdio mode still works unchanged

Fixes #249