### PR TITLE
feat: add skill autocomplete to Quick Claude dialog

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,10 +1,102 @@
 use std::path::PathBuf;
 
+#[derive(serde::Serialize, Clone)]
+pub struct SkillInfo {
+    pub name: String,
+    pub description: String,
+    pub usage: String,
+    pub source: String, // "project" or "global"
+}
+
+/// Scan a skills directory and return SkillInfo for each .md file found.
+fn scan_skills_dir(dir: &PathBuf, source: &str) -> Vec<SkillInfo> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut skills = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let name = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let lines: Vec<&str> = content.lines().take(20).collect();
+
+        let description = lines
+            .get(2)
+            .map(|l| l.trim().to_string())
+            .unwrap_or_default();
+
+        let mut usage = String::new();
+        let mut in_usage_section = false;
+        let mut in_code_block = false;
+        for line in &lines {
+            if line.starts_with("## Usage") {
+                in_usage_section = true;
+                continue;
+            }
+            if in_usage_section {
+                if line.starts_with("```") {
+                    if in_code_block {
+                        break;
+                    }
+                    in_code_block = true;
+                    continue;
+                }
+                if in_code_block {
+                    usage = line.trim().to_string();
+                }
+            }
+        }
+
+        skills.push(SkillInfo {
+            name,
+            description,
+            usage,
+            source: source.to_string(),
+        });
+    }
+    skills
+}
+
+#[tauri::command]
+pub fn list_skills(project_path: String) -> Vec<SkillInfo> {
+    let mut skills_map = std::collections::HashMap::new();
+
+    if let Ok(home) = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")) {
+        let global_dir = PathBuf::from(home).join(".claude").join("skills");
+        for skill in scan_skills_dir(&global_dir, "global") {
+            skills_map.insert(skill.name.clone(), skill);
+        }
+    }
+
+    let project_dir = PathBuf::from(&project_path)
+        .join(".claude")
+        .join("skills");
+    for skill in scan_skills_dir(&project_dir, "project") {
+        skills_map.insert(skill.name.clone(), skill);
+    }
+
+    let mut result: Vec<SkillInfo> = skills_map.into_values().collect();
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    result
+}
+
 #[tauri::command]
 pub fn read_file(path: String) -> Result<String, String> {
     let path = PathBuf::from(&path);
     if !path.exists() {
-        // Return empty string for non-existent files (editor will start empty)
         return Ok(String::new());
     }
     std::fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {e}"))
@@ -13,7 +105,6 @@ pub fn read_file(path: String) -> Result<String, String> {
 #[tauri::command]
 pub fn write_file(path: String, content: String) -> Result<(), String> {
     let path = PathBuf::from(&path);
-    // Create parent directories if they don't exist
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create directories: {e}"))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,6 +161,7 @@ pub fn run() {
             commands::list_worktrees,
             commands::remove_worktree,
             commands::cleanup_all_worktrees,
+            commands::list_skills,
             commands::read_file,
             commands::write_file,
             commands::get_user_claude_md_path,

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -478,7 +478,7 @@ export class App {
 
           const { showQuickClaudeDialog } = await import('./dialogs');
           const input = await showQuickClaudeDialog({
-            workspaces: state.workspaces.map(w => ({ id: w.id, name: w.name })),
+            workspaces: state.workspaces.map(w => ({ id: w.id, name: w.name, folderPath: w.folderPath })),
             activeWorkspaceId: state.activeWorkspaceId,
           });
           if (!input) break;

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -231,7 +231,7 @@ export interface QuickClaudeInput {
 }
 
 export interface QuickClaudeOptions {
-  workspaces: { id: string; name: string }[];
+  workspaces: { id: string; name: string; folderPath: string }[];
   activeWorkspaceId: string;
 }
 
@@ -269,12 +269,124 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
     workspaceSelect.value = validSaved ? savedId : options.activeWorkspaceId;
     dialog.appendChild(workspaceSelect);
 
+    // -- Prompt textarea with skill dropdown wrapper --
+    const promptWrapper = document.createElement('div');
+    promptWrapper.style.position = 'relative';
+
     const promptArea = document.createElement('textarea');
     promptArea.className = 'dialog-input';
-    promptArea.placeholder = 'Describe your idea...';
+    promptArea.placeholder = 'Describe your idea... (type / for skills)';
     promptArea.rows = 4;
     promptArea.style.cssText = 'resize: vertical; min-height: 80px; font-family: inherit; font-size: 13px;';
-    dialog.appendChild(promptArea);
+    promptWrapper.appendChild(promptArea);
+
+    const skillDropdown = document.createElement('div');
+    skillDropdown.className = 'skill-dropdown';
+    skillDropdown.style.display = 'none';
+    promptWrapper.appendChild(skillDropdown);
+
+    dialog.appendChild(promptWrapper);
+
+    // -- Skill autocomplete state --
+    interface SkillInfo { name: string; description: string; usage: string; source: string }
+    const skillCache = new Map<string, SkillInfo[]>();
+    let activeSkills: SkillInfo[] = [];
+    let activeIndex = -1;
+    let dropdownVisible = false;
+
+    async function fetchSkills(workspaceId: string): Promise<SkillInfo[]> {
+      if (skillCache.has(workspaceId)) return skillCache.get(workspaceId)!;
+      const ws = options.workspaces.find(w => w.id === workspaceId);
+      if (!ws) return [];
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const skills = await invoke<SkillInfo[]>('list_skills', { projectPath: ws.folderPath });
+        skillCache.set(workspaceId, skills);
+        return skills;
+      } catch {
+        return [];
+      }
+    }
+
+    function renderDropdown(skills: SkillInfo[], highlightIndex: number) {
+      skillDropdown.innerHTML = '';
+      if (skills.length === 0) {
+        hideDropdown();
+        return;
+      }
+      skills.forEach((skill, i) => {
+        const item = document.createElement('div');
+        item.className = 'skill-item' + (i === highlightIndex ? ' skill-item-active' : '');
+        const nameEl = document.createElement('div');
+        nameEl.className = 'skill-item-name';
+        nameEl.textContent = '/' + skill.name;
+        const descEl = document.createElement('div');
+        descEl.className = 'skill-item-desc';
+        descEl.textContent = skill.description;
+        item.appendChild(nameEl);
+        item.appendChild(descEl);
+        item.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+          selectSkill(skill);
+        });
+        item.addEventListener('mouseenter', () => {
+          activeIndex = i;
+          updateHighlight();
+        });
+        skillDropdown.appendChild(item);
+      });
+      skillDropdown.style.display = '';
+      dropdownVisible = true;
+    }
+
+    function updateHighlight() {
+      const items = skillDropdown.querySelectorAll('.skill-item');
+      items.forEach((el, i) => {
+        el.classList.toggle('skill-item-active', i === activeIndex);
+        if (i === activeIndex) el.scrollIntoView({ block: 'nearest' });
+      });
+    }
+
+    function hideDropdown() {
+      skillDropdown.style.display = 'none';
+      dropdownVisible = false;
+      activeIndex = -1;
+      activeSkills = [];
+    }
+
+    function selectSkill(skill: SkillInfo) {
+      const val = promptArea.value;
+      const cursor = promptArea.selectionStart;
+      const before = val.slice(0, cursor);
+      const slashIdx = before.lastIndexOf('/');
+      if (slashIdx >= 0) {
+        const replacement = skill.usage || ('/' + skill.name);
+        promptArea.value = val.slice(0, slashIdx) + replacement + ' ' + val.slice(cursor);
+        const newPos = slashIdx + replacement.length + 1;
+        promptArea.setSelectionRange(newPos, newPos);
+      }
+      hideDropdown();
+      promptArea.focus();
+    }
+
+    promptArea.addEventListener('input', async () => {
+      const val = promptArea.value;
+      const cursor = promptArea.selectionStart;
+      const before = val.slice(0, cursor);
+      const match = before.match(/(^|[\s\n])\/([\w-]*)$/);
+      if (!match) {
+        hideDropdown();
+        return;
+      }
+      const query = match[2].toLowerCase();
+      const skills = await fetchSkills(workspaceSelect.value);
+      const filtered = query
+        ? skills.filter(s => s.name.toLowerCase().includes(query))
+        : skills;
+      activeSkills = filtered;
+      activeIndex = filtered.length > 0 ? 0 : -1;
+      renderDropdown(filtered, activeIndex);
+    });
 
     const branchRow = document.createElement('div');
     branchRow.style.cssText = 'display: flex; gap: 8px; align-items: center; margin-top: 8px;';
@@ -353,6 +465,39 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
     okBtn.onclick = submit;
 
     promptArea.onkeydown = (e) => {
+      if (dropdownVisible) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          activeIndex = Math.min(activeIndex + 1, activeSkills.length - 1);
+          updateHighlight();
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          activeIndex = Math.max(activeIndex - 1, 0);
+          updateHighlight();
+          return;
+        }
+        if (e.key === 'Enter' && !e.ctrlKey) {
+          if (activeIndex >= 0 && activeIndex < activeSkills.length) {
+            e.preventDefault();
+            selectSkill(activeSkills[activeIndex]);
+            return;
+          }
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          hideDropdown();
+          return;
+        }
+        if (e.key === 'Tab') {
+          if (activeIndex >= 0 && activeIndex < activeSkills.length) {
+            e.preventDefault();
+            selectSkill(activeSkills[activeIndex]);
+            return;
+          }
+        }
+      }
       if (e.key === 'Enter' && e.ctrlKey) { e.preventDefault(); submit(); }
       if (e.key === 'Escape') { close(); resolve(null); }
     };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -514,6 +514,47 @@ body.dragging-active * {
   background: var(--bg-active);
 }
 
+/* Skill autocomplete dropdown */
+.skill-dropdown {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  max-height: 192px;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  z-index: 100;
+  margin-top: 4px;
+}
+
+.skill-item {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.skill-item:hover,
+.skill-item-active {
+  background: var(--bg-active);
+}
+
+.skill-item-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.skill-item-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Shell type selection */
 .shell-type-options {
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary

- Type `/` in the Quick Claude prompt textarea to trigger a skill autocomplete dropdown
- Skills are discovered from `.claude/skills/` directories (project-level and `~/.claude/skills/` global)
- Arrow keys navigate, Enter/Tab selects, Escape dismisses the dropdown
- New `list_skills` Tauri backend command scans `.md` skill files, returning name, description, and usage pattern
- Project-level skills override global ones with the same name

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/commands/files.rs` | New `SkillInfo` struct + `list_skills` command |
| `src-tauri/src/lib.rs` | Register `list_skills` in invoke_handler |
| `src/components/dialogs.ts` | Skill dropdown UI + autocomplete logic in Quick Claude dialog |
| `src/components/App.ts` | Pass `folderPath` in workspace data to dialog |
| `src/styles/main.css` | Styles for `.skill-dropdown` and `.skill-item` |

## Test plan

- [ ] Open Quick Claude (`Ctrl+Shift+Q`), type `/` — dropdown shows all skills
- [ ] Type `/fe` — filters to skills matching "fe" (e.g. `/feature`)
- [ ] Press ArrowDown/ArrowUp to navigate, Enter or Tab to select
- [ ] Selected skill inserts its usage pattern (e.g. `/feature <name> [description]`)
- [ ] Press Escape to dismiss dropdown without selecting
- [ ] Switch workspace in dialog — skills refresh for new workspace
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (718 tests)

Fixes #250