### PR TITLE
fix: plugin card settings overlapping body content

### DIFF
--- a/src/components/PluginCard.test.ts
+++ b/src/components/PluginCard.test.ts
@@ -164,6 +164,26 @@ describe('createPluginCard', () => {
     expect(settingsSection?.textContent).toContain('Settings content');
   });
 
+  // Bug: settings section was a sibling of body in the flex row, causing
+  // text overlap when the settings content crushed the body width
+  it('renders settings section inside body, not as a card sibling', () => {
+    const settingsEl = document.createElement('div');
+    settingsEl.textContent = 'Settings content';
+    const plugin = makePlugin({ renderSettings: () => settingsEl });
+
+    const card = createPluginCard({
+      plugin,
+      isBuiltin: true,
+      isEnabled: true,
+      isInstalled: true,
+    });
+
+    const body = card.querySelector('.plugin-card-body');
+    const settingsSection = body?.querySelector('.plugin-card-settings');
+    expect(settingsSection).not.toBeNull();
+    expect(settingsSection?.textContent).toContain('Settings content');
+  });
+
   it('does not render settings section when disabled', () => {
     const plugin = makePlugin({ renderSettings: () => document.createElement('div') });
 

--- a/src/components/PluginCard.ts
+++ b/src/components/PluginCard.ts
@@ -150,7 +150,6 @@ export function createPluginCard(opts: PluginCardOptions): HTMLElement {
   }
 
   body.appendChild(actions);
-  card.appendChild(body);
 
   // Expandable settings (only when installed + enabled + has renderSettings)
   if (opts.isInstalled && opts.isEnabled && opts.plugin?.renderSettings) {
@@ -165,8 +164,10 @@ export function createPluginCard(opts: PluginCardOptions): HTMLElement {
       errEl.textContent = 'Failed to load plugin settings.';
       settingsSection.appendChild(errEl);
     }
-    card.appendChild(settingsSection);
+    body.appendChild(settingsSection);
   }
+
+  card.appendChild(body);
 
   return card;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1916,6 +1916,4 @@ body.dragging-active * {
   margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--border-color);
-  grid-column: 1 / -1;
-  width: 100%;
 }


### PR DESCRIPTION
## Summary
- Settings section was a direct child of the flex-row card, rendering horizontally next to the body and crushing text into an unreadable overlapping mess
- Moved settings inside `.plugin-card-body` so it flows vertically below header/description/actions
- Removed stale `grid-column` and `width: 100%` CSS from `.plugin-card-settings`
- Added regression test verifying settings is a child of body, not a card sibling

## Test plan
- [x] `vitest run src/components/PluginCard.test.ts` — 16/16 pass
- [x] `npm run build` — clean build
- [ ] Open Settings > Plugins and verify Peon Ping card renders correctly with settings below the description/toggle