### PR TITLE
feat: automated phone setup with QR code sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test:e2e:no-build": "cross-env SKIP_BUILD=1 wdio run e2e/wdio.conf.ts",
     "test:all": "npm run test && npm run test:rust && npm run test:e2e",
     "check:persistence": "npx ts-node e2e/check-persistence.ts",
-    "version:bump": "node scripts/bump-version.mjs"
+    "version:bump": "node scripts/bump-version.mjs",
+    "phone": "pwsh scripts/setup-phone.ps1"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
@@ -53,6 +54,7 @@
     "cross-env": "^10.1.0",
     "edgedriver": "^6.3.0",
     "jsdom": "^28.0.0",
+    "qrcode-terminal": "^0.12.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",

--- a/scripts/setup-phone.ps1
+++ b/scripts/setup-phone.ps1
@@ -1,0 +1,141 @@
+# Automated phone setup: starts godly-remote + ngrok tunnel + displays QR code
+# Usage: pwsh scripts/setup-phone.ps1 [-Port <port>]
+
+param(
+    [int]$Port = 3377
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Check ngrok ---
+if (-not (Get-Command ngrok -ErrorAction SilentlyContinue)) {
+    Write-Host "ngrok not found." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Install it with:" -ForegroundColor Yellow
+    Write-Host "  winget install ngrok.ngrok" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Then authenticate:" -ForegroundColor Yellow
+    Write-Host "  ngrok config add-authtoken <your-token>" -ForegroundColor Cyan
+    Write-Host "  (Get a free token at https://dashboard.ngrok.com/get-started/your-authtoken)" -ForegroundColor DarkGray
+    exit 1
+}
+
+# --- Check godly-remote binary ---
+$scriptDir = $PSScriptRoot
+$repoRoot = (Resolve-Path "$scriptDir\..").Path
+$remoteBin = "$repoRoot\src-tauri\target\release\godly-remote.exe"
+if (-not (Test-Path $remoteBin)) {
+    $remoteBin = "$repoRoot\src-tauri\target\debug\godly-remote.exe"
+}
+if (-not (Test-Path $remoteBin)) {
+    Write-Host "godly-remote.exe not found. Building..." -ForegroundColor Yellow
+    Push-Location "$repoRoot\src-tauri"
+    cargo build -p godly-remote --release
+    Pop-Location
+    $remoteBin = "$repoRoot\src-tauri\target\release\godly-remote.exe"
+    if (-not (Test-Path $remoteBin)) {
+        Write-Host "Build failed. Cannot find godly-remote.exe" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# --- Generate API key ---
+$ApiKey = -join ((65..90) + (97..122) + (48..57) | Get-Random -Count 24 | ForEach-Object { [char]$_ })
+
+# --- Start godly-remote ---
+Write-Host ""
+Write-Host "Starting godly-remote on port $Port..." -ForegroundColor Green
+$env:GODLY_REMOTE_PORT = $Port
+$env:GODLY_REMOTE_API_KEY = $ApiKey
+$remoteProc = Start-Process -FilePath $remoteBin -PassThru -NoNewWindow
+Start-Sleep -Seconds 1
+
+if ($remoteProc.HasExited) {
+    Write-Host "godly-remote failed to start. Is the daemon running?" -ForegroundColor Red
+    Write-Host "Start Godly Terminal first, or run: src-tauri\target\release\godly-daemon.exe" -ForegroundColor Yellow
+    exit 1
+}
+
+# --- Start ngrok ---
+Write-Host "Starting ngrok tunnel..." -ForegroundColor Green
+$ngrokProc = Start-Process -FilePath "ngrok" -ArgumentList "http", "$Port", "--log=stderr" -PassThru -NoNewWindow -RedirectStandardError "$env:TEMP\ngrok-stderr.log"
+
+# --- Get public URL from ngrok API ---
+$publicUrl = $null
+$attempts = 0
+$maxAttempts = 15
+while (-not $publicUrl -and $attempts -lt $maxAttempts) {
+    $attempts++
+    Start-Sleep -Seconds 1
+    try {
+        $tunnels = Invoke-RestMethod -Uri "http://localhost:4040/api/tunnels" -ErrorAction SilentlyContinue
+        $tunnel = $tunnels.tunnels | Where-Object { $_.proto -eq "https" } | Select-Object -First 1
+        if ($tunnel) {
+            $publicUrl = $tunnel.public_url
+        }
+    } catch {
+        # ngrok not ready yet
+    }
+}
+
+if (-not $publicUrl) {
+    Write-Host "Failed to get ngrok tunnel URL after ${maxAttempts}s." -ForegroundColor Red
+    Write-Host "Check ngrok auth: ngrok config add-authtoken <token>" -ForegroundColor Yellow
+    Stop-Process -Id $remoteProc.Id -Force -ErrorAction SilentlyContinue
+    Stop-Process -Id $ngrokProc.Id -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# --- Build phone URL with embedded API key ---
+$phoneUrl = "$publicUrl/phone?key=$ApiKey"
+
+# --- Display QR code ---
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "  Scan this QR code with your phone:" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Use npx qrcode-terminal to render QR in terminal
+$npxPath = (Get-Command npx -ErrorAction SilentlyContinue).Source
+if ($npxPath) {
+    & npx --yes qrcode-terminal "$phoneUrl" --small
+} else {
+    Write-Host "(QR code unavailable - npx not found)" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "  Or open this URL manually:" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  $phoneUrl" -ForegroundColor White
+Write-Host ""
+Write-Host "  API Key: $ApiKey" -ForegroundColor DarkGray
+Write-Host "  Tunnel:  $publicUrl" -ForegroundColor DarkGray
+Write-Host "  Local:   http://localhost:$Port/phone" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "Press Ctrl+C to stop." -ForegroundColor Yellow
+Write-Host ""
+
+# --- Wait for Ctrl+C, then cleanup ---
+try {
+    while ($true) {
+        Start-Sleep -Seconds 1
+        # Check if processes are still alive
+        if ($remoteProc.HasExited) {
+            Write-Host "godly-remote exited unexpectedly." -ForegroundColor Red
+            break
+        }
+        if ($ngrokProc.HasExited) {
+            Write-Host "ngrok exited unexpectedly." -ForegroundColor Red
+            break
+        }
+    }
+} finally {
+    Write-Host ""
+    Write-Host "Shutting down..." -ForegroundColor Yellow
+    Stop-Process -Id $ngrokProc.Id -Force -ErrorAction SilentlyContinue
+    Stop-Process -Id $remoteProc.Id -Force -ErrorAction SilentlyContinue
+    Write-Host "Done." -ForegroundColor Green
+}

--- a/src-tauri/remote/static/phone.html
+++ b/src-tauri/remote/static/phone.html
@@ -560,6 +560,17 @@ document.getElementById('inputField').addEventListener('keydown', (e) => {
 
 // --- Init ---
 (async function init() {
+  // Auto-configure API key from URL param (e.g. /phone?key=abc123)
+  const params = new URLSearchParams(window.location.search);
+  const urlKey = params.get('key');
+  if (urlKey) {
+    apiKey = urlKey;
+    localStorage.setItem('godly_api_key', apiKey);
+    params.delete('key');
+    const clean = window.location.pathname + (params.toString() ? '?' + params : '');
+    history.replaceState(null, '', clean);
+  }
+
   refreshDashboard();
   refreshTimer = setInterval(() => {
     if (currentView === 'dashboard') refreshDashboard();


### PR DESCRIPTION
## Summary
- Add `scripts/setup-phone.ps1` — one-command setup for phone remote access
- Add `?key=` URL param support to `phone.html` for zero-config phone setup
- Add `qrcode-terminal` devDependency + `npm run phone` script

## How it works
```
npm run phone
```
1. Checks ngrok is installed (shows install instructions if not)
2. Finds or builds `godly-remote` binary
3. Generates random 24-char API key
4. Starts `godly-remote` on port 3377
5. Starts ngrok tunnel, gets public HTTPS URL
6. Displays QR code in terminal (via `qrcode-terminal`)
7. User scans QR → phone opens URL → API key auto-configured → dashboard loads

## Test plan
- [ ] Verify `npm run phone` starts both godly-remote and ngrok
- [ ] Verify QR code renders in terminal
- [ ] Scan QR with phone camera → confirm auto-login works
- [ ] Verify Ctrl+C cleanly stops both processes
- [ ] Verify `npm test` passes (753 tests pass)

Fixes #269