### PR TITLE
fix: security hardening for godly-remote mobile access

### DIFF
--- a/scripts/setup-phone.ps1
+++ b/scripts/setup-phone.ps1
@@ -51,7 +51,7 @@ if (-not (Test-Path $remoteBin)) {
 
 # --- Generate API key and password ---
 $ApiKey = -join ((65..90) + (97..122) + (48..57) | Get-Random -Count 24 | ForEach-Object { [char]$_ })
-$Password = -join ((48..57) + (97..122) | Get-Random -Count 6 | ForEach-Object { [char]$_ })
+$Password = -join ((48..57) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })
 
 # --- Kill any existing godly-remote so we start fresh with our API key + password ---
 $remoteProc = $null
@@ -110,9 +110,11 @@ if (-not $publicUrl) {
     exit 1
 }
 
-# --- Build phone URL with embedded API key ---
+# --- Build phone URL with API key in URL fragment (not query param) ---
+# URL fragments (#) are NOT sent to the server in HTTP requests, NOT logged
+# by proxies/ngrok, and NOT included in Referer headers.
 if ($ApiKey) {
-    $phoneUrl = "$publicUrl/phone?key=$ApiKey"
+    $phoneUrl = "$publicUrl/phone#key=$ApiKey"
 } else {
     $phoneUrl = "$publicUrl/phone"
 }
@@ -146,7 +148,7 @@ Write-Host "  Password: $Password" -ForegroundColor White
 Write-Host "  (enter this on your phone to connect)" -ForegroundColor DarkGray
 Write-Host ""
 if ($ApiKey) {
-    Write-Host "  API Key: $ApiKey" -ForegroundColor DarkGray
+    Write-Host "  API Key: (embedded in QR code)" -ForegroundColor DarkGray
 }
 Write-Host "  Tunnel:  $publicUrl" -ForegroundColor DarkGray
 Write-Host "  Local:   http://localhost:$Port/phone" -ForegroundColor DarkGray

--- a/src-tauri/remote/Cargo.toml
+++ b/src-tauri/remote/Cargo.toml
@@ -23,6 +23,7 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22"
+subtle = "2"
 futures = "0.3"
 tokio-stream = "0.1"
 async-stream = "0.3"

--- a/src-tauri/remote/src/auth.rs
+++ b/src-tauri/remote/src/auth.rs
@@ -6,8 +6,17 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use subtle::ConstantTimeEq;
 
 use crate::device_lock::DeviceLock;
+
+/// Constant-time string comparison to prevent timing attacks on API keys.
+fn secure_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
 
 /// Middleware that checks `X-API-Key` header or `api_key` query param against the configured key.
 /// If no key is configured (dev mode), all requests are allowed.
@@ -40,7 +49,6 @@ pub async fn api_key_auth(
                             let mut parts = pair.splitn(2, '=');
                             match (parts.next(), parts.next()) {
                                 (Some("api_key"), Some(v)) => {
-                                    // URL-decode the value
                                     urlencoding_decode(v)
                                 }
                                 _ => None,
@@ -51,8 +59,8 @@ pub async fn api_key_auth(
             let provided = from_header.or(from_query);
 
             match provided {
-                Some(ref key) if key == &expected => next.run(req).await,
-                _ => (StatusCode::UNAUTHORIZED, "Invalid or missing API key").into_response(),
+                Some(ref key) if secure_eq(key, &expected) => next.run(req).await,
+                _ => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
             }
         }
     }
@@ -104,27 +112,52 @@ pub async fn device_token_auth(
 
     match provided {
         Some(ref token) if device_lock.check(token) => next.run(req).await,
-        _ => (StatusCode::FORBIDDEN, "Device not authorized").into_response(),
+        _ => (StatusCode::FORBIDDEN, "Unauthorized").into_response(),
     }
 }
 
-/// Simple URL decode for query param values (handles %XX encoding).
+/// URL decode for query param values (handles %XX and + encoding).
 fn urlencoding_decode(input: &str) -> Option<String> {
-    let mut result = String::with_capacity(input.len());
-    let mut chars = input.bytes();
-    while let Some(b) = chars.next() {
-        match b {
+    let mut result = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
             b'%' => {
-                let hi = chars.next()?;
-                let lo = chars.next()?;
-                let hex = [hi, lo];
-                let s = std::str::from_utf8(&hex).ok()?;
-                let byte = u8::from_str_radix(s, 16).ok()?;
-                result.push(byte as char);
+                if i + 2 >= bytes.len() {
+                    return None; // truncated escape
+                }
+                let hi = bytes[i + 1];
+                let lo = bytes[i + 2];
+                let byte = hex_byte(hi, lo)?;
+                result.push(byte);
+                i += 3;
             }
-            b'+' => result.push(' '),
-            _ => result.push(b as char),
+            b'+' => {
+                result.push(b' ');
+                i += 1;
+            }
+            b => {
+                result.push(b);
+                i += 1;
+            }
         }
     }
-    Some(result)
+    String::from_utf8(result).ok()
+}
+
+/// Convert two hex ASCII chars to a byte.
+fn hex_byte(hi: u8, lo: u8) -> Option<u8> {
+    let h = hex_digit(hi)?;
+    let l = hex_digit(lo)?;
+    Some((h << 4) | l)
+}
+
+fn hex_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
 }

--- a/src-tauri/remote/src/device_lock.rs
+++ b/src-tauri/remote/src/device_lock.rs
@@ -1,6 +1,8 @@
 use std::sync::Mutex;
 use std::time::Instant;
 
+use subtle::ConstantTimeEq;
+
 const MAX_FAILED_ATTEMPTS: u32 = 5;
 const LOCKOUT_SECS: u64 = 300; // 5 minutes
 
@@ -12,6 +14,16 @@ pub struct DeviceLock {
     password: Option<String>,
     failed_attempts: Mutex<u32>,
     lockout_until: Mutex<Option<Instant>>,
+}
+
+/// Constant-time string comparison to prevent timing attacks.
+fn secure_eq(a: &str, b: &str) -> bool {
+    // Length comparison leaks length info, but that's acceptable —
+    // passwords are fixed-length and tokens are always 64 hex chars.
+    if a.len() != b.len() {
+        return false;
+    }
+    a.as_bytes().ct_eq(b.as_bytes()).into()
 }
 
 impl DeviceLock {
@@ -38,7 +50,7 @@ impl DeviceLock {
 
         match &self.password {
             None => Ok(()), // no password configured
-            Some(expected) if expected == provided => {
+            Some(expected) if secure_eq(expected, provided) => {
                 // Reset failed attempts on success
                 *self.failed_attempts.lock().unwrap() = 0;
                 *self.lockout_until.lock().unwrap() = None;
@@ -51,7 +63,11 @@ impl DeviceLock {
                 if *attempts >= MAX_FAILED_ATTEMPTS {
                     let mut lockout = self.lockout_until.lock().unwrap();
                     *lockout = Some(Instant::now() + std::time::Duration::from_secs(LOCKOUT_SECS));
-                    tracing::warn!("Device registration locked out for {}s after {} failed attempts", LOCKOUT_SECS, attempts);
+                    tracing::warn!(
+                        "Device registration locked out for {}s after {} failed attempts",
+                        LOCKOUT_SECS,
+                        attempts
+                    );
                 }
                 Err("Invalid password")
             }
@@ -67,7 +83,7 @@ impl DeviceLock {
             return Err("Device already registered");
         }
         *token = Some(candidate_token.to_string());
-        tracing::info!("Device locked to token: {}...", &candidate_token[..8.min(candidate_token.len())]);
+        tracing::info!("Device registered successfully");
         Ok(())
     }
 
@@ -76,7 +92,7 @@ impl DeviceLock {
         let token = self.token.lock().unwrap();
         match token.as_deref() {
             None => false,
-            Some(expected) => expected == provided,
+            Some(expected) => secure_eq(expected, provided),
         }
     }
 
@@ -180,5 +196,15 @@ mod tests {
         // Can fail again without immediate lockout
         assert!(lock.verify_password("wrong").is_err());
         assert!(lock.verify_password("secret").is_ok());
+    }
+
+    #[test]
+    fn timing_safe_comparison() {
+        // Verify secure_eq works correctly
+        assert!(secure_eq("hello", "hello"));
+        assert!(!secure_eq("hello", "world"));
+        assert!(!secure_eq("hello", "hell"));
+        assert!(!secure_eq("", "a"));
+        assert!(secure_eq("", ""));
     }
 }

--- a/src-tauri/remote/src/main.rs
+++ b/src-tauri/remote/src/main.rs
@@ -17,8 +17,9 @@ use device_lock::DeviceLock;
 use event_pump::EventPump;
 use layout_reader::LayoutReader;
 use monitor::MonitorRegistry;
+use tower_http::cors::{AllowHeaders, AllowMethods, CorsLayer};
 
-const BUILD: u32 = 3;
+const BUILD: u32 = 4;
 
 /// Shared application state, cloneable via Arc internals.
 #[derive(Clone)]
@@ -46,6 +47,13 @@ async fn main() {
 
     if config.auth.api_key.is_none() {
         tracing::warn!("No API key configured — running in dev mode (all requests allowed)");
+    }
+
+    // Warn if binding to all interfaces without auth
+    if config.server.host == "0.0.0.0" && config.auth.api_key.is_none() {
+        tracing::warn!(
+            "WARNING: Binding to 0.0.0.0 without API key — server is accessible to anyone on the network!"
+        );
     }
 
     // Connect to daemon
@@ -86,7 +94,15 @@ async fn main() {
         device_lock: Arc::clone(&device_lock),
     };
 
+    // CORS: only allow the same origin (ngrok tunnel or localhost).
+    // No wildcard — credentials must come from the served phone.html page.
+    let cors = CorsLayer::new()
+        .allow_methods(AllowMethods::mirror_request())
+        .allow_headers(AllowHeaders::mirror_request())
+        .allow_credentials(true);
+
     let app = routes::build_router(state)
+        .layer(cors)
         .layer(axum::Extension(device_lock))
         .layer(axum::Extension(api_key));
 

--- a/src-tauri/remote/src/routes/input.rs
+++ b/src-tauri/remote/src/routes/input.rs
@@ -9,6 +9,9 @@ use godly_protocol::Response;
 use crate::daemon_client::async_request;
 use crate::AppState;
 
+/// Maximum write payload size (64 KB). Prevents memory exhaustion from oversized requests.
+const MAX_WRITE_BYTES: usize = 64 * 1024;
+
 #[derive(Deserialize)]
 pub struct WriteRequest {
     pub data: String,
@@ -19,6 +22,13 @@ pub async fn write_to_session(
     Path(id): Path<String>,
     Json(body): Json<WriteRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    if body.data.len() > MAX_WRITE_BYTES {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("Write payload exceeds {} byte limit", MAX_WRITE_BYTES),
+        ));
+    }
+
     // Convert \n → \r for PTY (same as MCP handler)
     let converted = body.data.replace("\r\n", "\r").replace('\n', "\r");
 

--- a/src-tauri/remote/src/routes/sessions.rs
+++ b/src-tauri/remote/src/routes/sessions.rs
@@ -74,11 +74,39 @@ pub async fn create_session(
     State(state): State<AppState>,
     Json(body): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<CreateSessionResponse>), (StatusCode, String)> {
-    let session_id = uuid::Uuid::new_v4().to_string();
+    // Validate rows/cols to prevent resource exhaustion
+    let rows = body.rows.clamp(1, 500);
+    let cols = body.cols.clamp(1, 500);
+
+    // Validate cwd if provided — must be an existing directory, no path traversal
+    let cwd = match &body.cwd {
+        Some(path) => {
+            let p = std::path::Path::new(path);
+            // Reject relative paths and path traversal
+            if !p.is_absolute() {
+                return Err((StatusCode::BAD_REQUEST, "cwd must be an absolute path".into()));
+            }
+            if path.contains("..") {
+                return Err((StatusCode::BAD_REQUEST, "cwd must not contain path traversal".into()));
+            }
+            if !p.is_dir() {
+                return Err((StatusCode::BAD_REQUEST, "cwd directory does not exist".into()));
+            }
+            Some(path.clone())
+        }
+        None => None,
+    };
+
+    // Validate shell_type
     let shell = match body.shell_type.as_deref() {
         Some("wsl") => ShellType::Wsl { distribution: None },
-        _ => ShellType::Windows,
+        Some("windows") | None => ShellType::Windows,
+        Some(other) => {
+            return Err((StatusCode::BAD_REQUEST, format!("Unknown shell_type: {}", other)));
+        }
     };
+
+    let session_id = uuid::Uuid::new_v4().to_string();
 
     let mut env_vars = HashMap::new();
     env_vars.insert("GODLY_SESSION_ID".to_string(), session_id.clone());
@@ -86,9 +114,9 @@ pub async fn create_session(
     let create_req = Request::CreateSession {
         id: session_id.clone(),
         shell_type: shell,
-        cwd: body.cwd,
-        rows: body.rows,
-        cols: body.cols,
+        cwd,
+        rows,
+        cols,
         env: Some(env_vars),
     };
 
@@ -254,12 +282,15 @@ pub async fn resize_session(
     Path(id): Path<String>,
     Json(body): Json<ResizeRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let rows = body.rows.clamp(1, 500);
+    let cols = body.cols.clamp(1, 500);
+
     let resp = async_request(
         &state.daemon,
         Request::Resize {
             session_id: id,
-            rows: body.rows,
-            cols: body.cols,
+            rows,
+            cols,
         },
     )
     .await
@@ -317,8 +348,8 @@ pub async fn get_text(
                 rows.pop();
             }
 
-            // Take last N lines
-            let n = query.lines.min(rows.len());
+            // Take last N lines (capped at 200 to limit data exposure)
+            let n = query.lines.min(200).min(rows.len());
             let lines: Vec<String> = rows[rows.len().saturating_sub(n)..].to_vec();
 
             Ok(Json(TextResponse { lines, total_rows }))

--- a/src-tauri/remote/src/ws.rs
+++ b/src-tauri/remote/src/ws.rs
@@ -123,6 +123,10 @@ async fn handle_ws(state: AppState, session_id: String, socket: WebSocket) {
 
         match client_msg {
             WsClientMessage::Write { data } => {
+                // Limit write payload size to prevent memory exhaustion
+                if data.len() > 64 * 1024 {
+                    continue;
+                }
                 let converted = data.replace("\r\n", "\r").replace('\n', "\r");
                 let _ = async_request(
                     &daemon2,

--- a/src-tauri/remote/static/phone.html
+++ b/src-tauri/remote/static/phone.html
@@ -208,13 +208,6 @@
   .login-form { width: 100%; max-width: 320px; }
   .login-form .settings-input { margin-bottom: 12px; text-align: center; font-size: 20px; letter-spacing: 4px; }
   .login-error { color: var(--danger); font-size: 13px; text-align: center; margin-bottom: 12px; min-height: 20px; }
-  .biometric-btn {
-    width: 100%; min-height: var(--touch-min); margin-top: 12px;
-    background: var(--bg-input); border: 1px solid var(--border);
-    border-radius: 8px; color: var(--text); font-size: 15px;
-    cursor: pointer; display: none;
-  }
-  .biometric-btn:active { background: var(--border); }
 </style>
 </head>
 <body>
@@ -238,7 +231,6 @@
       <input class="settings-input" id="loginPassword" type="password" placeholder="Password"
              autocomplete="off" inputmode="text">
       <button class="settings-save" id="loginBtn" onclick="submitLogin()">Connect</button>
-      <button class="biometric-btn" id="biometricBtn" onclick="biometricLogin()">Use Fingerprint</button>
     </div>
   </div>
 </div>
@@ -650,8 +642,6 @@ async function submitLogin() {
 
   try {
     await registerDevice(pw);
-    // Offer biometric setup if supported
-    await offerBiometricSetup();
     startApp();
   } catch (e) {
     deviceToken = '';
@@ -679,86 +669,32 @@ function startApp() {
   connectSSE();
 }
 
-// --- WebAuthn Biometric ---
-const WEBAUTHN_CRED_KEY = 'godly_webauthn_cred';
-
-function webAuthnSupported() {
-  return window.PublicKeyCredential &&
-    typeof window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === 'function';
-}
-
-async function hasPlatformAuthenticator() {
-  if (!webAuthnSupported()) return false;
-  try {
-    return await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
-  } catch { return false; }
-}
-
-async function offerBiometricSetup() {
-  if (!await hasPlatformAuthenticator()) return;
-  if (localStorage.getItem(WEBAUTHN_CRED_KEY)) return; // already set up
-
-  try {
-    const challenge = crypto.getRandomValues(new Uint8Array(32));
-    const userId = new TextEncoder().encode('godly-remote-user');
-
-    const credential = await navigator.credentials.create({
-      publicKey: {
-        challenge,
-        rp: { name: 'Godly Remote' },
-        user: { id: userId, name: 'godly-user', displayName: 'Godly Remote' },
-        pubKeyCredParams: [{ alg: -7, type: 'public-key' }, { alg: -257, type: 'public-key' }],
-        authenticatorSelection: {
-          authenticatorAttachment: 'platform',
-          userVerification: 'required',
-          residentKey: 'discouraged'
-        },
-        timeout: 60000
-      }
-    });
-
-    if (credential) {
-      // Store credential ID for future verification
-      const credId = btoa(String.fromCharCode(...new Uint8Array(credential.rawId)));
-      localStorage.setItem(WEBAUTHN_CRED_KEY, credId);
-    }
-  } catch {
-    // User declined or error — no biometric, that's fine
-  }
-}
-
-async function biometricLogin() {
-  const credIdB64 = localStorage.getItem(WEBAUTHN_CRED_KEY);
-  if (!credIdB64) return false;
-
-  try {
-    const credId = Uint8Array.from(atob(credIdB64), c => c.charCodeAt(0));
-    const challenge = crypto.getRandomValues(new Uint8Array(32));
-
-    await navigator.credentials.get({
-      publicKey: {
-        challenge,
-        allowCredentials: [{ id: credId, type: 'public-key', transports: ['internal'] }],
-        userVerification: 'required',
-        timeout: 60000
-      }
-    });
-    // Biometric verified — proceed to app
-    startApp();
-    return true;
-  } catch {
-    showLoginError('Biometric verification failed');
-    return false;
-  }
-}
+// --- WebAuthn removed ---
+// Biometric auth was client-only (no server-side challenge verification),
+// providing false security. Removed in security hardening pass.
+// TODO: Implement proper server-side WebAuthn with challenge/response verification.
 
 // --- Init ---
 (async function init() {
-  // Auto-configure API key from URL param (e.g. /phone?key=abc123)
+  // Auto-configure API key from URL fragment (e.g. /phone#key=abc123)
+  // URL fragments are NOT sent to the server, NOT logged by proxies/ngrok,
+  // and NOT included in Referer headers — much safer than query params.
+  const hash = window.location.hash.slice(1); // remove #
+  if (hash) {
+    const fragParams = new URLSearchParams(hash);
+    const urlKey = fragParams.get('key');
+    if (urlKey) {
+      apiKey = urlKey;
+      localStorage.setItem('godly_api_key', apiKey);
+      // Clean the URL fragment to prevent leaking in browser history
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+  }
+  // Also support legacy query param for backwards compatibility
   const params = new URLSearchParams(window.location.search);
-  const urlKey = params.get('key');
-  if (urlKey) {
-    apiKey = urlKey;
+  const queryKey = params.get('key');
+  if (queryKey && !apiKey) {
+    apiKey = queryKey;
     localStorage.setItem('godly_api_key', apiKey);
     params.delete('key');
     const clean = window.location.pathname + (params.toString() ? '?' + params : '');
@@ -767,21 +703,7 @@ async function biometricLogin() {
 
   // Check if we already have a valid device token
   if (await tryExistingToken()) {
-    // Already registered — check for biometric re-auth
-    const hasBiometric = localStorage.getItem(WEBAUTHN_CRED_KEY);
-    if (hasBiometric && await hasPlatformAuthenticator()) {
-      // Show login view with biometric button
-      document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
-      document.getElementById('view-login').classList.add('active');
-      document.getElementById('loginPassword').style.display = 'none';
-      document.getElementById('loginBtn').style.display = 'none';
-      document.getElementById('biometricBtn').style.display = 'block';
-      document.querySelector('.login-subtitle').textContent = 'Verify your identity to continue';
-      // Auto-trigger biometric
-      biometricLogin();
-    } else {
-      startApp();
-    }
+    startApp();
     return;
   }
 


### PR DESCRIPTION
## Summary

Security audit of `godly-remote` found 21 vulnerabilities across the remote terminal access system. This PR fixes all **critical** (5) and **high** (5) severity issues.

### Critical Fixes
- **Timing-safe comparisons** — All password, API key, and device token comparisons now use `subtle::ConstantTimeEq` to prevent timing attacks
- **Password entropy** — Increased from 6 chars (~35 bits) to 16 chars (~82 bits)
- **API key moved to URL fragment** — Changed from `?key=` (logged by proxies/servers) to `#key=` (never sent in HTTP requests)
- **Removed fake WebAuthn** — Client-only biometric auth had no server-side verification, providing false security
- **No sensitive data in logs** — Removed token prefix from log messages

### High Fixes
- **CORS middleware** added via `tower-http`
- **Input validation** — `cwd` requires absolute path without `..` traversal; `rows`/`cols` clamped to 1-500
- **Write payload limit** — 64KB max on HTTP and WebSocket write requests
- **Text lines capped** at 200 to limit data exposure
- **Generic error messages** to prevent information leakage
- **URL decoder rewritten** with proper hex parsing

## Test plan
- [x] `cargo check -p godly-remote` — clean compile
- [x] `cargo test -p godly-remote` — 28/28 tests pass (includes new `timing_safe_comparison` test)
- [ ] Manual: verify QR code URL uses `#key=` fragment
- [ ] Manual: verify 16-char password in setup output
- [ ] Manual: verify biometric button removed from phone UI

Fixes #273