### PR TITLE
feat: add Remote settings tab for phone access

### DIFF
--- a/scripts/setup-phone.ps1
+++ b/scripts/setup-phone.ps1
@@ -49,9 +49,37 @@ if (-not (Test-Path $remoteBin)) {
     }
 }
 
-# --- Generate API key and password ---
-$ApiKey = -join ((65..90) + (97..122) + (48..57) | Get-Random -Count 24 | ForEach-Object { [char]$_ })
-$Password = -join ((48..57) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })
+# --- Read persisted settings (if any) ---
+$configPath = Join-Path $env:APPDATA "com.godly.terminal\remote-config.json"
+$savedConfig = $null
+if (Test-Path $configPath) {
+    try {
+        $savedConfig = Get-Content $configPath -Raw | ConvertFrom-Json
+        Write-Host "Using saved settings from $configPath" -ForegroundColor Green
+    } catch {
+        Write-Host "Could not parse saved config, using defaults" -ForegroundColor Yellow
+    }
+}
+
+# --- Use saved or generate API key and password ---
+if ($savedConfig -and $savedConfig.api_key) {
+    $ApiKey = $savedConfig.api_key
+    Write-Host "  API Key: (from saved settings)" -ForegroundColor DarkGray
+} else {
+    $ApiKey = -join ((65..90) + (97..122) + (48..57) | Get-Random -Count 24 | ForEach-Object { [char]$_ })
+}
+
+if ($savedConfig -and $savedConfig.password) {
+    $Password = $savedConfig.password
+    Write-Host "  Password: (from saved settings)" -ForegroundColor DarkGray
+} else {
+    $Password = -join ((48..57) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })
+}
+
+# Override port from saved settings if not explicitly provided via CLI
+if ($savedConfig -and $savedConfig.port -and $Port -eq 3377) {
+    $Port = $savedConfig.port
+}
 
 # --- Kill any existing godly-remote so we start fresh with our API key + password ---
 $remoteProc = $null

--- a/src-tauri/remote/static/phone.html
+++ b/src-tauri/remote/static/phone.html
@@ -226,12 +226,15 @@
     <div class="login-icon">&#128274;</div>
     <div class="login-title">Godly Remote</div>
     <div class="login-subtitle">Enter the password shown in your terminal</div>
-    <div class="login-form">
+    <form class="login-form" id="godly-login" action="/api/register-device" method="POST" autocomplete="on"
+          onsubmit="event.preventDefault(); submitLogin();">
+      <input type="text" name="username" value="Godly Terminal" autocomplete="username" style="display:none">
       <div class="login-error" id="loginError"></div>
-      <input class="settings-input" id="loginPassword" type="password" placeholder="Password"
-             autocomplete="off" inputmode="text">
-      <button class="settings-save" id="loginBtn" onclick="submitLogin()">Connect</button>
-    </div>
+      <input class="settings-input" id="loginPassword" name="password" type="password" placeholder="Password"
+             autocomplete="current-password" inputmode="text"
+             passwordrules="minlength: 16; maxlength: 128; required: upper, lower, digit, special;">
+      <button class="settings-save" id="loginBtn" type="submit">Connect</button>
+    </form>
   </div>
 </div>
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -113,6 +113,20 @@ pub fn write_file(path: String, content: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub fn write_remote_config(config: serde_json::Value) -> Result<(), String> {
+    let appdata = std::env::var("APPDATA")
+        .map_err(|_| "APPDATA not set".to_string())?;
+    let dir = PathBuf::from(appdata).join("com.godly.terminal");
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create config directory: {e}"))?;
+    let path = dir.join("remote-config.json");
+    let json = serde_json::to_string_pretty(&config)
+        .map_err(|e| format!("Failed to serialize config: {e}"))?;
+    std::fs::write(&path, json)
+        .map_err(|e| format!("Failed to write remote config: {e}"))
+}
+
+#[tauri::command]
 pub fn get_user_claude_md_path() -> Result<String, String> {
     let home = std::env::var("USERPROFILE")
         .or_else(|_| std::env::var("HOME"))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -394,6 +394,7 @@ pub fn run() {
             persistence::save_scrollback,
             persistence::load_scrollback,
             persistence::delete_scrollback,
+            commands::write_remote_config,
             scrollback_save_complete,
         ])
         .setup(move |app| {

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -14,6 +14,7 @@ import { settingsTabStore } from '../state/settings-tab-store';
 import { workspaceService } from '../services/workspace-service';
 import { playNotificationSound, type SoundPreset } from '../services/notification-sound';
 import { getRendererBackend } from './TerminalRenderer';
+import { remoteSettingsStore, generatePassword, generateApiKey } from '../state/remote-settings-store';
 import { themeStore } from '../state/theme-store';
 import type { ThemeDefinition } from '../themes/types';
 import { createThemePreview } from './ThemePreview';
@@ -66,6 +67,7 @@ export function showSettingsDialog(): Promise<void> {
       notifications: 'Notifications',
       plugins: 'Plugins',
       shortcuts: 'Shortcuts',
+      remote: 'Remote',
     };
 
     let tabOrder = settingsTabStore.getTabOrder();
@@ -1185,6 +1187,231 @@ export function showSettingsDialog(): Promise<void> {
     }
 
     renderShortcuts();
+
+    // ── Remote tab content ────────────────────────────────────────
+    const remoteContent = document.createElement('div');
+    remoteContent.className = 'settings-tab-content';
+    tabContents['remote'] = remoteContent;
+
+    // Password section
+    const pwSection = document.createElement('div');
+    pwSection.className = 'settings-section';
+
+    const pwTitle = document.createElement('div');
+    pwTitle.className = 'settings-section-title';
+    pwTitle.textContent = 'Password';
+    pwSection.appendChild(pwTitle);
+
+    const pwDesc = document.createElement('div');
+    pwDesc.className = 'settings-description';
+    pwDesc.textContent = 'Set a fixed password for phone access. We recommend saving this in a password manager like 1Password.';
+    pwSection.appendChild(pwDesc);
+
+    const pwForm = document.createElement('form');
+    pwForm.action = '/remote-setup';
+    pwForm.method = 'POST';
+    pwForm.autocomplete = 'on';
+    pwForm.onsubmit = (e) => e.preventDefault();
+
+    // Hidden username field for password manager association
+    const pwUsername = document.createElement('input');
+    pwUsername.type = 'text';
+    pwUsername.name = 'username';
+    pwUsername.autocomplete = 'username';
+    pwUsername.value = 'godly-terminal';
+    pwUsername.style.display = 'none';
+    pwForm.appendChild(pwUsername);
+
+    const pwInputRow = document.createElement('div');
+    pwInputRow.className = 'shortcut-row';
+    pwInputRow.style.gap = '8px';
+
+    const pwInput = document.createElement('input');
+    pwInput.type = 'password';
+    pwInput.name = 'password';
+    pwInput.id = 'godly-remote-password';
+    pwInput.autocomplete = 'new-password';
+    pwInput.className = 'notification-preset';
+    pwInput.style.flex = '1';
+    pwInput.style.fontFamily = "'Cascadia Code', Consolas, monospace";
+    pwInput.placeholder = 'Enter or generate a password';
+    pwInput.setAttribute('passwordrules', 'minlength: 16; maxlength: 128; required: upper, lower, digit, special;');
+    pwInput.value = remoteSettingsStore.getPassword();
+    pwInputRow.appendChild(pwInput);
+
+    const pwShowBtn = document.createElement('button');
+    pwShowBtn.className = 'dialog-btn dialog-btn-secondary';
+    pwShowBtn.textContent = 'Show';
+    pwShowBtn.style.fontSize = '11px';
+    pwShowBtn.style.padding = '2px 10px';
+    pwShowBtn.style.minWidth = '50px';
+    pwShowBtn.onclick = () => {
+      if (pwInput.type === 'password') {
+        pwInput.type = 'text';
+        pwShowBtn.textContent = 'Hide';
+      } else {
+        pwInput.type = 'password';
+        pwShowBtn.textContent = 'Show';
+      }
+    };
+    pwInputRow.appendChild(pwShowBtn);
+    pwForm.appendChild(pwInputRow);
+
+    const pwButtonRow = document.createElement('div');
+    pwButtonRow.className = 'shortcut-row';
+    pwButtonRow.style.marginTop = '8px';
+    pwButtonRow.style.gap = '8px';
+
+    const generateBtn = document.createElement('button');
+    generateBtn.className = 'dialog-btn dialog-btn-secondary';
+    generateBtn.textContent = 'Generate Strong Password';
+    generateBtn.onclick = () => {
+      pwInput.value = generatePassword(100);
+      pwInput.type = 'text';
+      pwShowBtn.textContent = 'Hide';
+    };
+    pwButtonRow.appendChild(generateBtn);
+
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'dialog-btn dialog-btn-secondary';
+    copyBtn.textContent = 'Copy';
+    copyBtn.onclick = async () => {
+      if (!pwInput.value) return;
+      try {
+        await navigator.clipboard.writeText(pwInput.value);
+        const original = copyBtn.textContent;
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = original; }, 1500);
+      } catch {
+        // Clipboard API may not be available
+      }
+    };
+    pwButtonRow.appendChild(copyBtn);
+
+    const pwSaveBtn = document.createElement('button');
+    pwSaveBtn.className = 'dialog-btn dialog-btn-primary';
+    pwSaveBtn.textContent = 'Save Password';
+    pwSaveBtn.onclick = () => {
+      remoteSettingsStore.setPassword(pwInput.value);
+      const original = pwSaveBtn.textContent;
+      pwSaveBtn.textContent = 'Saved!';
+      setTimeout(() => { pwSaveBtn.textContent = original; }, 1500);
+    };
+    pwButtonRow.appendChild(pwSaveBtn);
+    pwForm.appendChild(pwButtonRow);
+
+    pwSection.appendChild(pwForm);
+    remoteContent.appendChild(pwSection);
+
+    // Server section
+    const serverSection = document.createElement('div');
+    serverSection.className = 'settings-section';
+
+    const serverTitle = document.createElement('div');
+    serverTitle.className = 'settings-section-title';
+    serverTitle.textContent = 'Server';
+    serverSection.appendChild(serverTitle);
+
+    const portRow = document.createElement('div');
+    portRow.className = 'shortcut-row';
+
+    const portLabel = document.createElement('span');
+    portLabel.className = 'shortcut-label';
+    portLabel.textContent = 'Port';
+    portRow.appendChild(portLabel);
+
+    const portInput = document.createElement('input');
+    portInput.type = 'number';
+    portInput.className = 'notification-preset';
+    portInput.style.width = '100px';
+    portInput.min = '1024';
+    portInput.max = '65535';
+    portInput.value = String(remoteSettingsStore.getPort());
+    portInput.onchange = () => {
+      const port = parseInt(portInput.value);
+      if (port >= 1024 && port <= 65535) {
+        remoteSettingsStore.setPort(port);
+      }
+    };
+    portRow.appendChild(portInput);
+    serverSection.appendChild(portRow);
+
+    const autoStartRow = document.createElement('div');
+    autoStartRow.className = 'shortcut-row';
+
+    const autoStartLabel = document.createElement('span');
+    autoStartLabel.className = 'shortcut-label';
+    autoStartLabel.textContent = 'Start remote server on launch';
+    autoStartRow.appendChild(autoStartLabel);
+
+    const autoStartCheckbox = document.createElement('input');
+    autoStartCheckbox.type = 'checkbox';
+    autoStartCheckbox.className = 'notification-checkbox';
+    autoStartCheckbox.checked = remoteSettingsStore.getAutoStart();
+    autoStartCheckbox.onchange = () => {
+      remoteSettingsStore.setAutoStart(autoStartCheckbox.checked);
+    };
+    autoStartRow.appendChild(autoStartCheckbox);
+    serverSection.appendChild(autoStartRow);
+
+    // API Key row
+    const apiKeyRow = document.createElement('div');
+    apiKeyRow.className = 'shortcut-row';
+
+    const apiKeyLabel = document.createElement('span');
+    apiKeyLabel.className = 'shortcut-label';
+    apiKeyLabel.textContent = 'API Key';
+    apiKeyRow.appendChild(apiKeyLabel);
+
+    const apiKeyDisplay = document.createElement('span');
+    apiKeyDisplay.className = 'shortcut-binding';
+    apiKeyDisplay.style.fontFamily = "'Cascadia Code', Consolas, monospace";
+    apiKeyDisplay.style.fontSize = '11px';
+    const storedApiKey = remoteSettingsStore.getApiKey();
+    apiKeyDisplay.textContent = storedApiKey ? storedApiKey.slice(0, 8) + '...' : '(not set)';
+    apiKeyRow.appendChild(apiKeyDisplay);
+
+    const apiKeyGenBtn = document.createElement('button');
+    apiKeyGenBtn.className = 'dialog-btn dialog-btn-secondary';
+    apiKeyGenBtn.textContent = storedApiKey ? 'Regenerate' : 'Generate';
+    apiKeyGenBtn.style.fontSize = '11px';
+    apiKeyGenBtn.style.padding = '2px 10px';
+    apiKeyGenBtn.onclick = () => {
+      const newKey = generateApiKey();
+      remoteSettingsStore.setApiKey(newKey);
+      apiKeyDisplay.textContent = newKey.slice(0, 8) + '...';
+      apiKeyGenBtn.textContent = 'Regenerate';
+    };
+    apiKeyRow.appendChild(apiKeyGenBtn);
+    serverSection.appendChild(apiKeyRow);
+
+    remoteContent.appendChild(serverSection);
+
+    // Connection section
+    const connSection = document.createElement('div');
+    connSection.className = 'settings-section';
+
+    const connTitle = document.createElement('div');
+    connTitle.className = 'settings-section-title';
+    connTitle.textContent = 'Connection';
+    connSection.appendChild(connTitle);
+
+    const connDesc = document.createElement('div');
+    connDesc.className = 'settings-description';
+    connDesc.textContent = 'Run setup-phone.ps1 to start the remote server with an ngrok tunnel. The script will use your saved password, port, and API key.';
+    connSection.appendChild(connDesc);
+
+    const connInstructions = document.createElement('div');
+    connInstructions.className = 'settings-description';
+    connInstructions.style.fontFamily = "'Cascadia Code', Consolas, monospace";
+    connInstructions.style.fontSize = '12px';
+    connInstructions.style.marginTop = '8px';
+    connInstructions.textContent = 'pwsh scripts/setup-phone.ps1';
+    connSection.appendChild(connInstructions);
+
+    remoteContent.appendChild(connSection);
+
+    dialog.appendChild(remoteContent);
 
     // ── Info footer ──────────────────────────────────────────────
     const footer = document.createElement('div');

--- a/src/state/remote-settings-store.ts
+++ b/src/state/remote-settings-store.ts
@@ -1,0 +1,148 @@
+import { invoke } from '@tauri-apps/api/core';
+
+const STORAGE_KEY = 'godly-remote-settings';
+
+export interface RemoteSettings {
+  password: string;
+  port: number;
+  autoStart: boolean;
+  apiKey: string;
+}
+
+type Subscriber = () => void;
+
+function generateRandomString(length: number, charset: string): string {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += charset[array[i] % charset.length];
+  }
+  return result;
+}
+
+export function generatePassword(length: number = 100): string {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=+[]{}|;:,.<>?';
+  return generateRandomString(length, charset);
+}
+
+export function generateApiKey(): string {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  return generateRandomString(24, charset);
+}
+
+class RemoteSettingsStore {
+  private settings: RemoteSettings = {
+    password: '',
+    port: 3377,
+    autoStart: false,
+    apiKey: '',
+  };
+
+  private subscribers: Subscriber[] = [];
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  getSettings(): RemoteSettings {
+    return { ...this.settings };
+  }
+
+  getPassword(): string {
+    return this.settings.password;
+  }
+
+  setPassword(password: string): void {
+    this.settings.password = password;
+    this.saveToStorage();
+    this.writeSidecarConfig();
+    this.notify();
+  }
+
+  getPort(): number {
+    return this.settings.port;
+  }
+
+  setPort(port: number): void {
+    this.settings.port = Math.max(1024, Math.min(65535, port));
+    this.saveToStorage();
+    this.writeSidecarConfig();
+    this.notify();
+  }
+
+  getAutoStart(): boolean {
+    return this.settings.autoStart;
+  }
+
+  setAutoStart(autoStart: boolean): void {
+    this.settings.autoStart = autoStart;
+    this.saveToStorage();
+    this.writeSidecarConfig();
+    this.notify();
+  }
+
+  getApiKey(): string {
+    return this.settings.apiKey;
+  }
+
+  setApiKey(apiKey: string): void {
+    this.settings.apiKey = apiKey;
+    this.saveToStorage();
+    this.writeSidecarConfig();
+    this.notify();
+  }
+
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.push(fn);
+    return () => {
+      this.subscribers = this.subscribers.filter(s => s !== fn);
+    };
+  }
+
+  private notify(): void {
+    for (const fn of this.subscribers) fn();
+  }
+
+  private loadFromStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw) as Partial<RemoteSettings>;
+      if (typeof data.password === 'string') this.settings.password = data.password;
+      if (typeof data.port === 'number' && data.port >= 1024 && data.port <= 65535) {
+        this.settings.port = data.port;
+      }
+      if (typeof data.autoStart === 'boolean') this.settings.autoStart = data.autoStart;
+      if (typeof data.apiKey === 'string') this.settings.apiKey = data.apiKey;
+    } catch {
+      // Corrupt data — use defaults
+    }
+  }
+
+  private saveToStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.settings));
+    } catch {
+      // No localStorage available
+    }
+  }
+
+  /** Write a JSON sidecar file that setup-phone.ps1 can read */
+  private writeSidecarConfig(): void {
+    invoke('write_remote_config', {
+      config: {
+        password: this.settings.password,
+        port: this.settings.port,
+        auto_start: this.settings.autoStart,
+        api_key: this.settings.apiKey,
+      },
+    }).catch(() => {
+      // Tauri command may not be available yet
+    });
+  }
+}
+
+export const remoteSettingsStore = new RemoteSettingsStore();

--- a/src/state/settings-tab-store.ts
+++ b/src/state/settings-tab-store.ts
@@ -1,6 +1,6 @@
 const STORAGE_KEY = 'godly-settings-tab-order';
 
-const DEFAULT_ORDER: string[] = ['themes', 'terminal', 'notifications', 'plugins', 'shortcuts'];
+const DEFAULT_ORDER: string[] = ['themes', 'terminal', 'notifications', 'plugins', 'shortcuts', 'remote'];
 
 type Subscriber = () => void;
 


### PR DESCRIPTION
## Summary

- Adds a **Remote** tab to the Settings dialog for configuring phone access (password, port, auto-start, API key)
- Password management with generate, show/hide, copy to clipboard — wrapped in a 1Password-friendly `<form>` with `autocomplete`, `passwordrules`, and hidden username
- Settings persist via localStorage and are also written as a **sidecar JSON file** (`remote-config.json`) that `setup-phone.ps1` reads
- `setup-phone.ps1` now checks for saved settings before falling back to random generation
- `phone.html` login form updated with proper `autocomplete="current-password"`, form action, and `passwordrules` for 1Password detection

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 757 tests pass
- [x] `cargo check -p godly-terminal` — no compilation errors
- [ ] Open Settings → Remote tab appears with Password, Server, Connection sections
- [ ] Generate password → 100-char password fills the field
- [ ] Copy → clipboard has password
- [ ] Save → refresh → password persists
- [ ] Check `%APPDATA%/com.godly.terminal/remote-config.json` has saved values
- [ ] Run `setup-phone.ps1` → uses saved password/port
- [ ] Open phone.html on mobile → 1Password detects login form

Fixes #281