### PR TITLE
feat: user-selectable models for SmolLM2 plugin

### DIFF
--- a/src-tauri/llm/src/download.rs
+++ b/src-tauri/llm/src/download.rs
@@ -31,6 +31,31 @@ impl ModelPaths {
         }
     }
 
+    /// Create paths for a custom model subdirectory.
+    pub fn custom(app_data_dir: &Path, subdir: &str, gguf_filename: &str) -> Self {
+        let model_dir = app_data_dir.join("models").join(subdir);
+        let gguf_path = model_dir.join(gguf_filename);
+        let tokenizer_path = model_dir.join(FILENAME_TOKENIZER);
+        Self {
+            model_dir,
+            gguf_path,
+            tokenizer_path,
+        }
+    }
+
+    /// Create paths from explicit file paths (for custom GGUF files).
+    pub fn from_paths(gguf_path: PathBuf, tokenizer_path: PathBuf) -> Self {
+        let model_dir = gguf_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .to_path_buf();
+        Self {
+            model_dir,
+            gguf_path,
+            tokenizer_path,
+        }
+    }
+
     /// Check if both model files exist.
     pub fn is_downloaded(&self) -> bool {
         self.gguf_path.exists() && self.tokenizer_path.exists()
@@ -83,6 +108,58 @@ where
     Ok(paths)
 }
 
+/// Download a model from HuggingFace with custom repo/filename parameters.
+pub fn download_model_custom<F>(
+    app_data_dir: &Path,
+    hf_repo: &str,
+    hf_filename: &str,
+    tokenizer_repo: &str,
+    subdir: &str,
+    on_progress: F,
+) -> Result<ModelPaths>
+where
+    F: Fn(u64, u64),
+{
+    let paths = ModelPaths::custom(app_data_dir, subdir, hf_filename);
+    std::fs::create_dir_all(&paths.model_dir)
+        .with_context(|| format!("Failed to create model directory: {:?}", paths.model_dir))?;
+
+    let api =
+        hf_hub::api::sync::Api::new().context("Failed to initialize HuggingFace Hub API")?;
+
+    // Download GGUF model file
+    if !paths.gguf_path.exists() {
+        eprintln!(
+            "[llm] Downloading GGUF model from {}/{}",
+            hf_repo, hf_filename
+        );
+        let repo = api.model(hf_repo.to_string());
+        let downloaded = repo.get(hf_filename).context("Failed to download GGUF model")?;
+        std::fs::copy(&downloaded, &paths.gguf_path)
+            .context("Failed to copy GGUF to model directory")?;
+        if let Ok(meta) = std::fs::metadata(&paths.gguf_path) {
+            on_progress(meta.len(), meta.len());
+        }
+    }
+
+    // Download tokenizer
+    if !paths.tokenizer_path.exists() {
+        eprintln!(
+            "[llm] Downloading tokenizer from {}/{}",
+            tokenizer_repo, FILENAME_TOKENIZER
+        );
+        let repo = api.model(tokenizer_repo.to_string());
+        let downloaded = repo
+            .get(FILENAME_TOKENIZER)
+            .context("Failed to download tokenizer")?;
+        std::fs::copy(&downloaded, &paths.tokenizer_path)
+            .context("Failed to copy tokenizer to model directory")?;
+    }
+
+    eprintln!("[llm] Custom model download complete");
+    Ok(paths)
+}
+
 /// Paths to the tiny branch name generator model files.
 #[derive(Debug, Clone)]
 pub struct BranchNameModelPaths {
@@ -131,6 +208,25 @@ mod tests {
     fn test_not_downloaded_when_missing() {
         let paths = ModelPaths::new(Path::new("/nonexistent/path"));
         assert!(!paths.is_downloaded());
+    }
+
+    #[test]
+    fn test_custom_model_paths() {
+        let paths = ModelPaths::custom(Path::new("/tmp/testapp"), "tinyllama-1.1b", "model.gguf");
+        assert!(paths.model_dir.ends_with("models/tinyllama-1.1b"));
+        assert!(paths.gguf_path.to_string_lossy().contains("model.gguf"));
+        assert!(paths.tokenizer_path.to_string_lossy().contains("tokenizer.json"));
+    }
+
+    #[test]
+    fn test_from_paths() {
+        let paths = ModelPaths::from_paths(
+            PathBuf::from("/custom/dir/model.gguf"),
+            PathBuf::from("/custom/dir/tokenizer.json"),
+        );
+        assert_eq!(paths.gguf_path, PathBuf::from("/custom/dir/model.gguf"));
+        assert_eq!(paths.tokenizer_path, PathBuf::from("/custom/dir/tokenizer.json"));
+        assert_eq!(paths.model_dir, PathBuf::from("/custom/dir"));
     }
 
     #[test]

--- a/src-tauri/llm/src/lib.rs
+++ b/src-tauri/llm/src/lib.rs
@@ -6,6 +6,6 @@ mod prompt;
 
 pub use branch_name::{generate_branch_name, sanitize_branch_name};
 pub use branch_name_engine::{try_generate_branch_name, BranchNameEngine};
-pub use download::{download_model, BranchNameModelPaths, ModelPaths};
+pub use download::{download_model, download_model_custom, BranchNameModelPaths, ModelPaths};
 pub use engine::{LlmEngine, LlmStatus};
 pub use prompt::build_chat_prompt;

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use tauri::{Emitter, State};
 
 use crate::llm_state::LlmState;
-use godly_llm::{download_model, generate_branch_name, LlmEngine, LlmStatus, ModelPaths};
+use godly_llm::{
+    download_model, download_model_custom, generate_branch_name, LlmEngine, LlmStatus, ModelPaths,
+};
 
 #[tauri::command]
 pub async fn llm_get_status(llm: State<'_, Arc<LlmState>>) -> Result<LlmStatus, String> {
@@ -14,6 +16,10 @@ pub async fn llm_get_status(llm: State<'_, Arc<LlmState>>) -> Result<LlmStatus, 
 pub async fn llm_download_model(
     app_handle: tauri::AppHandle,
     llm: State<'_, Arc<LlmState>>,
+    hf_repo: Option<String>,
+    hf_filename: Option<String>,
+    tokenizer_repo: Option<String>,
+    subdir: Option<String>,
 ) -> Result<(), String> {
     let app_data_dir = llm
         .get_app_data_dir()
@@ -25,14 +31,22 @@ pub async fn llm_download_model(
     let status_ref = Arc::clone(&llm);
 
     tokio::task::spawn_blocking(move || {
-        let result = download_model(&app_data_dir, |downloaded, total| {
+        let progress_cb = |downloaded: u64, total: u64| {
             let progress = if total > 0 {
                 (downloaded as f32) / (total as f32)
             } else {
                 0.0
             };
             let _ = handle.emit("llm-download-progress", progress);
-        });
+        };
+
+        let result = match (hf_repo, hf_filename, tokenizer_repo, subdir) {
+            (Some(repo), Some(filename), Some(tok_repo), Some(sub)) => {
+                download_model_custom(&app_data_dir, &repo, &filename, &tok_repo, &sub, progress_cb)
+                    .map(|_| ())
+            }
+            _ => download_model(&app_data_dir, progress_cb).map(|_| ()),
+        };
 
         match result {
             Ok(_) => {
@@ -51,7 +65,13 @@ pub async fn llm_download_model(
 }
 
 #[tauri::command]
-pub async fn llm_load_model(llm: State<'_, Arc<LlmState>>) -> Result<(), String> {
+pub async fn llm_load_model(
+    llm: State<'_, Arc<LlmState>>,
+    gguf_path: Option<String>,
+    tokenizer_path: Option<String>,
+    subdir: Option<String>,
+    gguf_filename: Option<String>,
+) -> Result<(), String> {
     let app_data_dir = llm
         .get_app_data_dir()
         .ok_or_else(|| "App data directory not initialized".to_string())?;
@@ -61,7 +81,20 @@ pub async fn llm_load_model(llm: State<'_, Arc<LlmState>>) -> Result<(), String>
     let status_ref = Arc::clone(&llm);
 
     tokio::task::spawn_blocking(move || {
-        let paths = ModelPaths::new(&app_data_dir);
+        let paths = match (gguf_path, tokenizer_path) {
+            // Explicit file paths (custom GGUF picker)
+            (Some(gguf), Some(tok)) => {
+                ModelPaths::from_paths(gguf.into(), tok.into())
+            }
+            _ => {
+                // Preset subdir or default
+                match (subdir, gguf_filename) {
+                    (Some(sub), Some(filename)) => ModelPaths::custom(&app_data_dir, &sub, &filename),
+                    _ => ModelPaths::new(&app_data_dir),
+                }
+            }
+        };
+
         match LlmEngine::load(&paths) {
             Ok(engine) => {
                 *status_ref.engine.write() = Some(engine);
@@ -118,24 +151,56 @@ pub async fn llm_generate(
 pub async fn llm_generate_branch_name(
     llm: State<'_, Arc<LlmState>>,
     description: String,
+    use_tiny: Option<bool>,
 ) -> Result<String, String> {
     let status_ref = Arc::clone(&llm);
 
     tokio::task::spawn_blocking(move || {
-        let mut engine_guard = status_ref.engine.write();
-        let engine = engine_guard
-            .as_mut()
-            .ok_or_else(|| "Model not loaded".to_string())?;
+        if use_tiny.unwrap_or(false) {
+            // Use the tiny branch-name-gen engine
+            status_ref
+                .try_generate_branch_name(&description)
+                .ok_or_else(|| "Tiny branch name engine not available".to_string())
+        } else {
+            // Use the full SmolLM2 engine
+            let mut engine_guard = status_ref.engine.write();
+            let engine = engine_guard
+                .as_mut()
+                .ok_or_else(|| "Model not loaded".to_string())?;
 
-        let prev_status = status_ref.status.read().clone();
-        *status_ref.status.write() = LlmStatus::Generating;
+            let prev_status = status_ref.status.read().clone();
+            *status_ref.status.write() = LlmStatus::Generating;
 
-        let result = generate_branch_name(engine, &description);
+            let result = generate_branch_name(engine, &description);
 
-        *status_ref.status.write() = prev_status;
+            *status_ref.status.write() = prev_status;
 
-        result.map_err(|e| format!("Branch name generation failed: {}", e))
+            result.map_err(|e| format!("Branch name generation failed: {}", e))
+        }
     })
     .await
     .map_err(|e| format!("Task join error: {}", e))?
+}
+
+#[tauri::command]
+pub async fn llm_check_model_files(
+    llm: State<'_, Arc<LlmState>>,
+    subdir: Option<String>,
+    gguf_filename: Option<String>,
+    gguf_path: Option<String>,
+    tokenizer_path: Option<String>,
+) -> Result<bool, String> {
+    let app_data_dir = llm
+        .get_app_data_dir()
+        .ok_or_else(|| "App data directory not initialized".to_string())?;
+
+    let paths = match (gguf_path, tokenizer_path) {
+        (Some(gguf), Some(tok)) => ModelPaths::from_paths(gguf.into(), tok.into()),
+        _ => match (subdir, gguf_filename) {
+            (Some(sub), Some(filename)) => ModelPaths::custom(&app_data_dir, &sub, &filename),
+            _ => ModelPaths::new(&app_data_dir),
+        },
+    };
+
+    Ok(paths.is_downloaded())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -389,6 +389,7 @@ pub fn run() {
             commands::llm_unload_model,
             commands::llm_generate,
             commands::llm_generate_branch_name,
+            commands::llm_check_model_files,
             persistence::save_layout,
             persistence::load_layout,
             persistence::save_scrollback,

--- a/src/plugins/smollm2/download-retry.test.ts
+++ b/src/plugins/smollm2/download-retry.test.ts
@@ -16,6 +16,10 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: (...args: unknown[]) => mockListen(...args),
 }));
 
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn().mockResolvedValue(null),
+}));
+
 // Mock localStorage
 const storage = new Map<string, string>();
 vi.stubGlobal('localStorage', {
@@ -57,16 +61,16 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
     plugin = new SmolLM2Plugin();
   });
 
-  describe('Retry button behavior', () => {
-    it('calls llm_download_model when clicking Retry Download after error', async () => {
-      // Bug #199: Retry must call llm_download_model, not just llm_get_status
+  describe('Download button after error state', () => {
+    it('calls llm_download_model when clicking Download after error', async () => {
+      // Bug #199: Download/retry must call llm_download_model, not just llm_get_status
+      // In the new preset UI, error state shows Download button (files don't exist yet)
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'llm_get_status') {
           return Promise.resolve({ status: 'Error', detail: 'Download failed: Failed to download tokenizer: connection refused' });
         }
-        if (cmd === 'llm_download_model') {
-          return Promise.resolve(undefined);
-        }
+        if (cmd === 'llm_check_model_files') return Promise.resolve(false);
+        if (cmd === 'llm_download_model') return Promise.resolve(undefined);
         return Promise.resolve(undefined);
       });
 
@@ -74,14 +78,24 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
       await plugin.init(ctx);
 
       const el = plugin.renderSettings!();
-      const retryBtn = Array.from(el.querySelectorAll('button'))
-        .find(b => b.textContent?.includes('Retry'));
+      // Wait for async preset buttons to render
+      await new Promise(r => setTimeout(r, 50));
 
-      expect(retryBtn).toBeDefined();
-      expect(retryBtn!.textContent).toContain('Download');
+      const downloadBtn = Array.from(el.querySelectorAll('button'))
+        .find(b => b.textContent?.includes('Download'));
+
+      expect(downloadBtn).toBeDefined();
 
       mockInvoke.mockClear();
-      await retryBtn!.click();
+      // Re-set mocks for the click
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'llm_get_status') return Promise.resolve({ status: 'Downloaded' });
+        if (cmd === 'llm_download_model') return Promise.resolve(undefined);
+        if (cmd === 'llm_check_model_files') return Promise.resolve(true);
+        return Promise.resolve(undefined);
+      });
+
+      await downloadBtn!.click();
       await new Promise(r => setTimeout(r, 50));
 
       const downloadCalls = mockInvoke.mock.calls.filter(
@@ -90,7 +104,7 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
       expect(downloadCalls.length).toBeGreaterThan(0);
     });
 
-    it('updates status after successful retry', async () => {
+    it('updates status after successful download retry', async () => {
       let callCount = 0;
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'llm_get_status') {
@@ -100,9 +114,8 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
           }
           return Promise.resolve({ status: 'Downloaded' });
         }
-        if (cmd === 'llm_download_model') {
-          return Promise.resolve(undefined);
-        }
+        if (cmd === 'llm_check_model_files') return Promise.resolve(false);
+        if (cmd === 'llm_download_model') return Promise.resolve(undefined);
         return Promise.resolve(undefined);
       });
 
@@ -110,13 +123,23 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
       await plugin.init(ctx);
 
       const el = plugin.renderSettings!();
+      await new Promise(r => setTimeout(r, 50));
+
       const statusValue = el.querySelector('.shortcut-keys') as HTMLElement;
       expect(statusValue?.textContent).toContain('Error');
 
-      const retryBtn = Array.from(el.querySelectorAll('button'))
-        .find(b => b.textContent?.includes('Retry'));
+      const downloadBtn = Array.from(el.querySelectorAll('button'))
+        .find(b => b.textContent?.includes('Download'));
 
-      await retryBtn!.click();
+      // After click, check_model_files should return true
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'llm_get_status') return Promise.resolve({ status: 'Downloaded' });
+        if (cmd === 'llm_check_model_files') return Promise.resolve(true);
+        if (cmd === 'llm_download_model') return Promise.resolve(undefined);
+        return Promise.resolve(undefined);
+      });
+
+      await downloadBtn!.click();
       await new Promise(r => setTimeout(r, 50));
 
       expect(statusValue?.textContent).not.toContain('Error');
@@ -147,9 +170,9 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
     });
   });
 
-  describe('Download button after error', () => {
-    it('shows a button labeled "Retry Download" in error state', async () => {
-      // Bug #199 regression: error state must have a button that clearly retries
+  describe('Download button visible in error state', () => {
+    it('shows a Download button in error state (files not yet on disk)', async () => {
+      // Bug #199 regression: error state must have a button to retry download
       mockInvoke.mockImplementation((cmd: string) => {
         if (cmd === 'llm_get_status') {
           return Promise.resolve({
@@ -157,6 +180,7 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
             detail: 'Download failed: Failed to download tokenizer: connection refused',
           });
         }
+        if (cmd === 'llm_check_model_files') return Promise.resolve(false);
         return Promise.resolve(undefined);
       });
 
@@ -164,11 +188,13 @@ describe('Bug #199 regression: SmolLM2 download retry and error quality', () => 
       await plugin.init(ctx);
 
       const el = plugin.renderSettings!();
+      await new Promise(r => setTimeout(r, 50));
+
       const buttons = Array.from(el.querySelectorAll('button'));
       const buttonTexts = buttons.map(b => b.textContent);
 
       const hasDownloadAction = buttonTexts.some(
-        t => t?.includes('Download') || t?.includes('Retry Download')
+        t => t?.includes('Download')
       );
       expect(hasDownloadAction).toBe(true);
     });

--- a/src/plugins/smollm2/index.ts
+++ b/src/plugins/smollm2/index.ts
@@ -1,16 +1,19 @@
 import type { GodlyPlugin, PluginContext } from '../types';
 import { listen } from '@tauri-apps/api/event';
+import { open } from '@tauri-apps/plugin-dialog';
 import {
   llmGetStatus,
   llmDownloadModel,
   llmLoadModel,
   llmUnloadModel,
   llmGenerateBranchName,
+  llmCheckModelFiles,
   isModelReady,
   isModelDownloaded,
   getStatusLabel,
   type LlmStatus,
 } from './llm-service';
+import { MODEL_PRESETS, DEFAULT_PRESET_ID, type ModelPreset } from './model-presets';
 
 export class SmolLM2Plugin implements GodlyPlugin {
   id = 'smollm2';
@@ -31,11 +34,26 @@ export class SmolLM2Plugin implements GodlyPlugin {
   }
 
   async enable(): Promise<void> {
-    // Auto-load model if downloaded and auto-load is enabled
     const autoLoad = this.ctx.getSetting('autoLoad', true);
     if (autoLoad && isModelDownloaded(this.status) && !isModelReady(this.status)) {
       try {
-        await llmLoadModel();
+        // Load using the saved model source settings
+        const modelSource = this.ctx.getSetting<string>('modelSource', 'preset');
+        if (modelSource === 'custom') {
+          const ggufPath = this.ctx.getSetting<string | null>('customGgufPath', null);
+          const tokenizerPath = this.ctx.getSetting<string | null>('customTokenizerPath', null);
+          if (ggufPath && tokenizerPath) {
+            await llmLoadModel({ ggufPath, tokenizerPath });
+          }
+        } else {
+          const presetId = this.ctx.getSetting<string>('selectedPreset', DEFAULT_PRESET_ID);
+          const preset = MODEL_PRESETS.find(p => p.id === presetId);
+          if (preset) {
+            await llmLoadModel({ subdir: preset.subdir, ggufFilename: preset.hfFilename });
+          } else {
+            await llmLoadModel();
+          }
+        }
         this.status = await llmGetStatus();
       } catch (e) {
         console.warn('[SmolLM2] Auto-load failed:', e);
@@ -62,160 +80,95 @@ export class SmolLM2Plugin implements GodlyPlugin {
     const container = document.createElement('div');
     container.className = 'smollm2-settings';
 
-    // Status indicator
-    const statusRow = document.createElement('div');
-    statusRow.className = 'shortcut-row';
-    const statusLabel = document.createElement('span');
-    statusLabel.className = 'shortcut-label';
-    statusLabel.textContent = 'Status';
-    statusRow.appendChild(statusLabel);
+    // ── Status indicator ──
+    const statusRow = this.createRow('Status');
     const statusValue = document.createElement('span');
     statusValue.className = 'shortcut-keys';
     statusValue.textContent = getStatusLabel(this.status);
     statusRow.appendChild(statusValue);
     container.appendChild(statusRow);
 
-    // Download / Load / Unload buttons
-    const actionRow = document.createElement('div');
-    actionRow.className = 'shortcut-row';
-    const actionLabel = document.createElement('span');
-    actionLabel.className = 'shortcut-label';
-    actionLabel.textContent = 'Model';
-    actionRow.appendChild(actionLabel);
+    // ── Section A: Branch Name Engine Toggle ──
+    const engineSection = document.createElement('div');
+    engineSection.className = 'settings-section';
+    const engineTitle = document.createElement('div');
+    engineTitle.className = 'settings-section-title';
+    engineTitle.textContent = 'Branch Name Engine';
+    engineSection.appendChild(engineTitle);
 
-    // Show which model files are loaded
-    const modelInfo = document.createElement('span');
-    modelInfo.style.cssText = 'font-size: 10px; color: var(--text-secondary); font-family: monospace; margin-left: 4px;';
-    if (isModelReady(this.status)) {
-      modelInfo.textContent = 'SmolLM2-135M-Q4_K_M + branch-name-gen';
-    } else if (isModelDownloaded(this.status)) {
-      modelInfo.textContent = 'Downloaded (not loaded)';
+    const engineRow = this.createRow('Engine');
+    const engineSelect = document.createElement('select');
+    engineSelect.className = 'dialog-input';
+    engineSelect.style.cssText = 'width: auto; font-size: 12px; padding: 4px 8px;';
+
+    const currentEngine = this.ctx.getSetting<string>('branchNameEngine', 'tiny');
+
+    for (const opt of [
+      { value: 'tiny', label: 'Tiny (branch-name-gen) — Fast, ~20M params' },
+      { value: 'smollm2', label: 'SmolLM2 — Better quality, requires model loaded' },
+    ]) {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === currentEngine) option.selected = true;
+      engineSelect.appendChild(option);
     }
-    actionLabel.appendChild(modelInfo);
-
-    const actionBtnContainer = document.createElement('div');
-    actionBtnContainer.style.display = 'flex';
-    actionBtnContainer.style.gap = '8px';
-    actionBtnContainer.style.alignItems = 'center';
-
-    // Progress bar (hidden by default)
-    const progressBar = document.createElement('div');
-    progressBar.style.cssText = 'width: 100px; height: 6px; background: var(--bg-tertiary); border-radius: 3px; overflow: hidden; display: none;';
-    const progressFill = document.createElement('div');
-    progressFill.style.cssText = 'height: 100%; background: var(--accent); width: 0%; transition: width 0.3s;';
-    progressBar.appendChild(progressFill);
-
-    const updateButtons = () => {
-      actionBtnContainer.innerHTML = '';
-
-      if (this.status.status === 'NotDownloaded') {
-        const downloadBtn = document.createElement('button');
-        downloadBtn.className = 'dialog-btn dialog-btn-primary';
-        downloadBtn.textContent = 'Download (~110MB)';
-        downloadBtn.onclick = async () => {
-          downloadBtn.disabled = true;
-          downloadBtn.textContent = 'Downloading...';
-          progressBar.style.display = 'block';
-
-          const unlisten = await listen<number>('llm-download-progress', (event) => {
-            const progress = event.payload;
-            progressFill.style.width = `${Math.round(progress * 100)}%`;
-          });
-
-          try {
-            await llmDownloadModel();
-            this.status = await llmGetStatus();
-            statusValue.textContent = getStatusLabel(this.status);
-          } catch (e) {
-            statusValue.textContent = `Error: ${e}`;
-          } finally {
-            unlisten();
-            progressBar.style.display = 'none';
-            updateButtons();
-          }
-        };
-        actionBtnContainer.appendChild(downloadBtn);
-        actionBtnContainer.appendChild(progressBar);
-      } else if (this.status.status === 'Downloaded') {
-        const loadBtn = document.createElement('button');
-        loadBtn.className = 'dialog-btn dialog-btn-primary';
-        loadBtn.textContent = 'Load Model';
-        loadBtn.onclick = async () => {
-          loadBtn.disabled = true;
-          loadBtn.textContent = 'Loading...';
-          try {
-            await llmLoadModel();
-            this.status = await llmGetStatus();
-            statusValue.textContent = getStatusLabel(this.status);
-          } catch (e) {
-            statusValue.textContent = `Error: ${e}`;
-          }
-          updateButtons();
-        };
-        actionBtnContainer.appendChild(loadBtn);
-      } else if (this.status.status === 'Ready') {
-        const unloadBtn = document.createElement('button');
-        unloadBtn.className = 'dialog-btn dialog-btn-secondary';
-        unloadBtn.textContent = 'Unload Model';
-        unloadBtn.onclick = async () => {
-          try {
-            await llmUnloadModel();
-            this.status = await llmGetStatus();
-            statusValue.textContent = getStatusLabel(this.status);
-          } catch (e) {
-            statusValue.textContent = `Error: ${e}`;
-          }
-          updateButtons();
-        };
-        actionBtnContainer.appendChild(unloadBtn);
-      } else if (this.status.status === 'Loading' || this.status.status === 'Downloading') {
-        const spinner = document.createElement('span');
-        spinner.textContent = this.status.status === 'Loading' ? 'Loading...' : 'Downloading...';
-        spinner.style.color = 'var(--text-secondary)';
-        actionBtnContainer.appendChild(spinner);
-      } else if (this.status.status === 'Error') {
-        const retryBtn = document.createElement('button');
-        retryBtn.className = 'dialog-btn dialog-btn-primary';
-        retryBtn.textContent = 'Retry Download';
-        retryBtn.onclick = async () => {
-          retryBtn.disabled = true;
-          retryBtn.textContent = 'Downloading...';
-          progressBar.style.display = 'block';
-
-          const unlisten = await listen<number>('llm-download-progress', (event) => {
-            const progress = event.payload;
-            progressFill.style.width = `${Math.round(progress * 100)}%`;
-          });
-
-          try {
-            await llmDownloadModel();
-            this.status = await llmGetStatus();
-            statusValue.textContent = getStatusLabel(this.status);
-          } catch (e) {
-            this.status = { status: 'Error', detail: `${e}` };
-            statusValue.textContent = `Error: ${e}`;
-          } finally {
-            unlisten();
-            progressBar.style.display = 'none';
-            updateButtons();
-          }
-        };
-        actionBtnContainer.appendChild(retryBtn);
-        actionBtnContainer.appendChild(progressBar);
-      }
+    engineSelect.onchange = () => {
+      this.ctx.setSetting('branchNameEngine', engineSelect.value);
     };
+    engineRow.appendChild(engineSelect);
+    engineSection.appendChild(engineRow);
+    container.appendChild(engineSection);
 
-    updateButtons();
-    actionRow.appendChild(actionBtnContainer);
-    container.appendChild(actionRow);
+    // ── Section B: Model Source ──
+    const modelSection = document.createElement('div');
+    modelSection.className = 'settings-section';
+    const modelTitle = document.createElement('div');
+    modelTitle.className = 'settings-section-title';
+    modelTitle.textContent = 'Model Source';
+    modelSection.appendChild(modelTitle);
 
-    // Auto-load toggle
-    const autoLoadRow = document.createElement('div');
-    autoLoadRow.className = 'shortcut-row';
-    const autoLoadLabel = document.createElement('span');
-    autoLoadLabel.className = 'shortcut-label';
-    autoLoadLabel.textContent = 'Auto-load on enable';
-    autoLoadRow.appendChild(autoLoadLabel);
+    const modelSource = this.ctx.getSetting<string>('modelSource', 'preset');
+    const presetContent = document.createElement('div');
+    const customContent = document.createElement('div');
+
+    // Source toggle
+    const sourceRow = this.createRow('Source');
+    const sourceSelect = document.createElement('select');
+    sourceSelect.className = 'dialog-input';
+    sourceSelect.style.cssText = 'width: auto; font-size: 12px; padding: 4px 8px;';
+    for (const opt of [
+      { value: 'preset', label: 'Preset Models' },
+      { value: 'custom', label: 'Custom GGUF File' },
+    ]) {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === modelSource) option.selected = true;
+      sourceSelect.appendChild(option);
+    }
+    sourceSelect.onchange = () => {
+      this.ctx.setSetting('modelSource', sourceSelect.value);
+      presetContent.style.display = sourceSelect.value === 'preset' ? '' : 'none';
+      customContent.style.display = sourceSelect.value === 'custom' ? '' : 'none';
+    };
+    sourceRow.appendChild(sourceSelect);
+    modelSection.appendChild(sourceRow);
+
+    // ── Preset content ──
+    this.buildPresetContent(presetContent, statusValue);
+    presetContent.style.display = modelSource === 'preset' ? '' : 'none';
+    modelSection.appendChild(presetContent);
+
+    // ── Custom content ──
+    this.buildCustomContent(customContent, statusValue);
+    customContent.style.display = modelSource === 'custom' ? '' : 'none';
+    modelSection.appendChild(customContent);
+
+    container.appendChild(modelSection);
+
+    // ── Auto-load toggle ──
+    const autoLoadRow = this.createRow('Auto-load on enable');
     const autoLoadCheckbox = document.createElement('input');
     autoLoadCheckbox.type = 'checkbox';
     autoLoadCheckbox.className = 'notification-checkbox';
@@ -226,7 +179,7 @@ export class SmolLM2Plugin implements GodlyPlugin {
     autoLoadRow.appendChild(autoLoadCheckbox);
     container.appendChild(autoLoadRow);
 
-    // Test generation input
+    // ── Section C: Test Generation ──
     const testSection = document.createElement('div');
     testSection.className = 'settings-section';
     const testTitle = document.createElement('div');
@@ -263,7 +216,8 @@ export class SmolLM2Plugin implements GodlyPlugin {
       testBtn.textContent = 'Thinking...';
       testResult.textContent = '';
       try {
-        const result = await llmGenerateBranchName(desc);
+        const engine = this.ctx.getSetting<string>('branchNameEngine', 'tiny');
+        const result = await llmGenerateBranchName(desc, engine === 'tiny');
         testResult.textContent = result;
         testResult.style.color = 'var(--accent)';
       } catch (e) {
@@ -285,5 +239,281 @@ export class SmolLM2Plugin implements GodlyPlugin {
     container.appendChild(testSection);
 
     return container;
+  }
+
+  // ── Helper: create a shortcut-row with a label ──
+  private createRow(label: string): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'shortcut-row';
+    const lbl = document.createElement('span');
+    lbl.className = 'shortcut-label';
+    lbl.textContent = label;
+    row.appendChild(lbl);
+    return row;
+  }
+
+  // ── Build preset dropdown + download/load buttons ──
+  private buildPresetContent(container: HTMLElement, statusValue: HTMLElement): void {
+    const selectedPresetId = this.ctx.getSetting<string>('selectedPreset', DEFAULT_PRESET_ID);
+
+    // Preset dropdown
+    const presetRow = this.createRow('Model');
+    const presetSelect = document.createElement('select');
+    presetSelect.className = 'dialog-input';
+    presetSelect.style.cssText = 'width: auto; font-size: 12px; padding: 4px 8px;';
+
+    for (const preset of MODEL_PRESETS) {
+      const option = document.createElement('option');
+      option.value = preset.id;
+      option.textContent = `${preset.label} — ${preset.size}`;
+      if (preset.id === selectedPresetId) option.selected = true;
+      presetSelect.appendChild(option);
+    }
+    presetSelect.onchange = () => {
+      this.ctx.setSetting('selectedPreset', presetSelect.value);
+      updatePresetButtons();
+    };
+    presetRow.appendChild(presetSelect);
+    container.appendChild(presetRow);
+
+    // Quality hint
+    const hintRow = document.createElement('div');
+    hintRow.style.cssText = 'padding: 0 12px; font-size: 10px; color: var(--text-secondary);';
+    const updateHint = () => {
+      const preset = MODEL_PRESETS.find(p => p.id === presetSelect.value);
+      hintRow.textContent = preset ? preset.quality : '';
+    };
+    presetSelect.addEventListener('change', updateHint);
+    updateHint();
+    container.appendChild(hintRow);
+
+    // Action buttons
+    const actionRow = this.createRow('');
+    const btnContainer = document.createElement('div');
+    btnContainer.style.display = 'flex';
+    btnContainer.style.gap = '8px';
+    btnContainer.style.alignItems = 'center';
+
+    const progressBar = document.createElement('div');
+    progressBar.style.cssText = 'width: 100px; height: 6px; background: var(--bg-tertiary); border-radius: 3px; overflow: hidden; display: none;';
+    const progressFill = document.createElement('div');
+    progressFill.style.cssText = 'height: 100%; background: var(--accent); width: 0%; transition: width 0.3s;';
+    progressBar.appendChild(progressFill);
+
+    const getSelectedPreset = (): ModelPreset | undefined =>
+      MODEL_PRESETS.find(p => p.id === presetSelect.value);
+
+    const updatePresetButtons = async () => {
+      btnContainer.innerHTML = '';
+      const preset = getSelectedPreset();
+      if (!preset) return;
+
+      // Check if this preset's files exist
+      let downloaded = false;
+      try {
+        downloaded = await llmCheckModelFiles({
+          subdir: preset.subdir,
+          ggufFilename: preset.hfFilename,
+        });
+      } catch { /* assume not downloaded */ }
+
+      if (!downloaded) {
+        const downloadBtn = document.createElement('button');
+        downloadBtn.className = 'dialog-btn dialog-btn-primary';
+        downloadBtn.textContent = `Download (${preset.size})`;
+        downloadBtn.onclick = async () => {
+          downloadBtn.disabled = true;
+          downloadBtn.textContent = 'Downloading...';
+          progressBar.style.display = 'block';
+
+          const unlisten = await listen<number>('llm-download-progress', (event) => {
+            progressFill.style.width = `${Math.round(event.payload * 100)}%`;
+          });
+
+          try {
+            await llmDownloadModel(
+              preset.hfRepo,
+              preset.hfFilename,
+              preset.tokenizerRepo,
+              preset.subdir,
+            );
+            this.status = await llmGetStatus();
+            statusValue.textContent = getStatusLabel(this.status);
+          } catch (e) {
+            statusValue.textContent = `Error: ${e}`;
+          } finally {
+            unlisten();
+            progressBar.style.display = 'none';
+            updatePresetButtons();
+          }
+        };
+        btnContainer.appendChild(downloadBtn);
+        btnContainer.appendChild(progressBar);
+      } else if (!isModelReady(this.status)) {
+        const loadBtn = document.createElement('button');
+        loadBtn.className = 'dialog-btn dialog-btn-primary';
+        loadBtn.textContent = 'Load Model';
+        loadBtn.onclick = async () => {
+          loadBtn.disabled = true;
+          loadBtn.textContent = 'Loading...';
+          try {
+            await llmLoadModel({ subdir: preset.subdir, ggufFilename: preset.hfFilename });
+            this.status = await llmGetStatus();
+            statusValue.textContent = getStatusLabel(this.status);
+          } catch (e) {
+            statusValue.textContent = `Error: ${e}`;
+          }
+          updatePresetButtons();
+        };
+        btnContainer.appendChild(loadBtn);
+      } else {
+        const unloadBtn = document.createElement('button');
+        unloadBtn.className = 'dialog-btn dialog-btn-secondary';
+        unloadBtn.textContent = 'Unload Model';
+        unloadBtn.onclick = async () => {
+          try {
+            await llmUnloadModel();
+            this.status = await llmGetStatus();
+            statusValue.textContent = getStatusLabel(this.status);
+          } catch (e) {
+            statusValue.textContent = `Error: ${e}`;
+          }
+          updatePresetButtons();
+        };
+        btnContainer.appendChild(unloadBtn);
+      }
+    };
+
+    actionRow.appendChild(btnContainer);
+    container.appendChild(actionRow);
+
+    // Initial button state
+    updatePresetButtons();
+  }
+
+  // ── Build custom GGUF file picker ──
+  private buildCustomContent(container: HTMLElement, statusValue: HTMLElement): void {
+    let customGguf = this.ctx.getSetting<string | null>('customGgufPath', null);
+    let customTokenizer = this.ctx.getSetting<string | null>('customTokenizerPath', null);
+
+    // GGUF file picker
+    const ggufRow = this.createRow('GGUF File');
+    const ggufLabel = document.createElement('span');
+    ggufLabel.style.cssText = 'font-size: 11px; font-family: monospace; color: var(--text-secondary); max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
+    ggufLabel.textContent = customGguf ? this.basename(customGguf) : 'None selected';
+    ggufLabel.title = customGguf || '';
+
+    const ggufBtn = document.createElement('button');
+    ggufBtn.className = 'dialog-btn dialog-btn-secondary';
+    ggufBtn.textContent = 'Choose...';
+    ggufBtn.style.fontSize = '11px';
+    ggufBtn.onclick = async () => {
+      const result = await open({
+        filters: [{ name: 'GGUF Models', extensions: ['gguf'] }],
+        multiple: false,
+      });
+      if (result) {
+        customGguf = result as string;
+        this.ctx.setSetting('customGgufPath', customGguf);
+        ggufLabel.textContent = this.basename(customGguf);
+        ggufLabel.title = customGguf;
+        updateLoadBtn();
+      }
+    };
+
+    const ggufContainer = document.createElement('div');
+    ggufContainer.style.display = 'flex';
+    ggufContainer.style.gap = '8px';
+    ggufContainer.style.alignItems = 'center';
+    ggufContainer.appendChild(ggufLabel);
+    ggufContainer.appendChild(ggufBtn);
+    ggufRow.appendChild(ggufContainer);
+    container.appendChild(ggufRow);
+
+    // Tokenizer file picker
+    const tokRow = this.createRow('Tokenizer');
+    const tokLabel = document.createElement('span');
+    tokLabel.style.cssText = 'font-size: 11px; font-family: monospace; color: var(--text-secondary); max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
+    tokLabel.textContent = customTokenizer ? this.basename(customTokenizer) : 'None selected';
+    tokLabel.title = customTokenizer || '';
+
+    const tokBtn = document.createElement('button');
+    tokBtn.className = 'dialog-btn dialog-btn-secondary';
+    tokBtn.textContent = 'Choose...';
+    tokBtn.style.fontSize = '11px';
+    tokBtn.onclick = async () => {
+      const result = await open({
+        filters: [{ name: 'Tokenizer JSON', extensions: ['json'] }],
+        multiple: false,
+      });
+      if (result) {
+        customTokenizer = result as string;
+        this.ctx.setSetting('customTokenizerPath', customTokenizer);
+        tokLabel.textContent = this.basename(customTokenizer);
+        tokLabel.title = customTokenizer;
+        updateLoadBtn();
+      }
+    };
+
+    const tokContainer = document.createElement('div');
+    tokContainer.style.display = 'flex';
+    tokContainer.style.gap = '8px';
+    tokContainer.style.alignItems = 'center';
+    tokContainer.appendChild(tokLabel);
+    tokContainer.appendChild(tokBtn);
+    tokRow.appendChild(tokContainer);
+    container.appendChild(tokRow);
+
+    // Load/Unload button
+    const actionRow = this.createRow('');
+    const loadBtn = document.createElement('button');
+    loadBtn.className = 'dialog-btn dialog-btn-primary';
+
+    const updateLoadBtn = () => {
+      actionRow.querySelectorAll('button').forEach(b => b.remove());
+
+      if (isModelReady(this.status)) {
+        const unloadBtn = document.createElement('button');
+        unloadBtn.className = 'dialog-btn dialog-btn-secondary';
+        unloadBtn.textContent = 'Unload Model';
+        unloadBtn.onclick = async () => {
+          try {
+            await llmUnloadModel();
+            this.status = await llmGetStatus();
+            statusValue.textContent = getStatusLabel(this.status);
+          } catch (e) {
+            statusValue.textContent = `Error: ${e}`;
+          }
+          updateLoadBtn();
+        };
+        actionRow.appendChild(unloadBtn);
+      } else {
+        const btn = document.createElement('button');
+        btn.className = 'dialog-btn dialog-btn-primary';
+        btn.textContent = 'Load Custom Model';
+        btn.disabled = !customGguf || !customTokenizer;
+        btn.onclick = async () => {
+          if (!customGguf || !customTokenizer) return;
+          btn.disabled = true;
+          btn.textContent = 'Loading...';
+          try {
+            await llmLoadModel({ ggufPath: customGguf!, tokenizerPath: customTokenizer! });
+            this.status = await llmGetStatus();
+            statusValue.textContent = getStatusLabel(this.status);
+          } catch (e) {
+            statusValue.textContent = `Error: ${e}`;
+          }
+          updateLoadBtn();
+        };
+        actionRow.appendChild(btn);
+      }
+    };
+
+    container.appendChild(actionRow);
+    updateLoadBtn();
+  }
+
+  private basename(path: string): string {
+    return path.split(/[\\/]/).pop() || path;
   }
 }

--- a/src/plugins/smollm2/llm-service.test.ts
+++ b/src/plugins/smollm2/llm-service.test.ts
@@ -14,6 +14,7 @@ import {
   llmUnloadModel,
   llmGenerate,
   llmGenerateBranchName,
+  llmCheckModelFiles,
   isModelReady,
   isModelDownloaded,
   getStatusLabel,
@@ -32,16 +33,48 @@ describe('llm-service', () => {
     expect(result.status).toBe('Ready');
   });
 
-  it('llmDownloadModel invokes correct command', async () => {
+  it('llmDownloadModel invokes correct command with default params', async () => {
     mockInvoke.mockResolvedValue(undefined);
     await llmDownloadModel();
-    expect(mockInvoke).toHaveBeenCalledWith('llm_download_model');
+    expect(mockInvoke).toHaveBeenCalledWith('llm_download_model', {
+      hfRepo: null,
+      hfFilename: null,
+      tokenizerRepo: null,
+      subdir: null,
+    });
   });
 
-  it('llmLoadModel invokes correct command', async () => {
+  it('llmDownloadModel passes custom params', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    await llmDownloadModel('repo/name', 'model.gguf', 'tok/repo', 'mymodel');
+    expect(mockInvoke).toHaveBeenCalledWith('llm_download_model', {
+      hfRepo: 'repo/name',
+      hfFilename: 'model.gguf',
+      tokenizerRepo: 'tok/repo',
+      subdir: 'mymodel',
+    });
+  });
+
+  it('llmLoadModel invokes correct command with default params', async () => {
     mockInvoke.mockResolvedValue(undefined);
     await llmLoadModel();
-    expect(mockInvoke).toHaveBeenCalledWith('llm_load_model');
+    expect(mockInvoke).toHaveBeenCalledWith('llm_load_model', {
+      ggufPath: null,
+      tokenizerPath: null,
+      subdir: null,
+      ggufFilename: null,
+    });
+  });
+
+  it('llmLoadModel passes custom paths', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    await llmLoadModel({ ggufPath: '/path/model.gguf', tokenizerPath: '/path/tok.json' });
+    expect(mockInvoke).toHaveBeenCalledWith('llm_load_model', {
+      ggufPath: '/path/model.gguf',
+      tokenizerPath: '/path/tok.json',
+      subdir: null,
+      ggufFilename: null,
+    });
   });
 
   it('llmUnloadModel invokes correct command', async () => {
@@ -71,13 +104,35 @@ describe('llm-service', () => {
     });
   });
 
-  it('llmGenerateBranchName passes description', async () => {
+  it('llmGenerateBranchName passes description with default useTiny', async () => {
     mockInvoke.mockResolvedValue('feat/add-login');
     const result = await llmGenerateBranchName('Add login page');
     expect(mockInvoke).toHaveBeenCalledWith('llm_generate_branch_name', {
       description: 'Add login page',
+      useTiny: null,
     });
     expect(result).toBe('feat/add-login');
+  });
+
+  it('llmGenerateBranchName passes useTiny flag', async () => {
+    mockInvoke.mockResolvedValue('feat/add-login');
+    await llmGenerateBranchName('Add login page', true);
+    expect(mockInvoke).toHaveBeenCalledWith('llm_generate_branch_name', {
+      description: 'Add login page',
+      useTiny: true,
+    });
+  });
+
+  it('llmCheckModelFiles invokes with subdir and filename', async () => {
+    mockInvoke.mockResolvedValue(true);
+    const result = await llmCheckModelFiles({ subdir: 'smollm2-135m', ggufFilename: 'model.gguf' });
+    expect(mockInvoke).toHaveBeenCalledWith('llm_check_model_files', {
+      subdir: 'smollm2-135m',
+      ggufFilename: 'model.gguf',
+      ggufPath: null,
+      tokenizerPath: null,
+    });
+    expect(result).toBe(true);
   });
 
   describe('isModelReady', () => {

--- a/src/plugins/smollm2/llm-service.ts
+++ b/src/plugins/smollm2/llm-service.ts
@@ -9,12 +9,34 @@ export async function llmGetStatus(): Promise<LlmStatus> {
   return invoke<LlmStatus>('llm_get_status');
 }
 
-export async function llmDownloadModel(): Promise<void> {
-  return invoke<void>('llm_download_model');
+export async function llmDownloadModel(
+  hfRepo?: string,
+  hfFilename?: string,
+  tokenizerRepo?: string,
+  subdir?: string,
+): Promise<void> {
+  return invoke<void>('llm_download_model', {
+    hfRepo: hfRepo ?? null,
+    hfFilename: hfFilename ?? null,
+    tokenizerRepo: tokenizerRepo ?? null,
+    subdir: subdir ?? null,
+  });
 }
 
-export async function llmLoadModel(): Promise<void> {
-  return invoke<void>('llm_load_model');
+export async function llmLoadModel(
+  opts?: {
+    ggufPath?: string;
+    tokenizerPath?: string;
+    subdir?: string;
+    ggufFilename?: string;
+  },
+): Promise<void> {
+  return invoke<void>('llm_load_model', {
+    ggufPath: opts?.ggufPath ?? null,
+    tokenizerPath: opts?.tokenizerPath ?? null,
+    subdir: opts?.subdir ?? null,
+    ggufFilename: opts?.ggufFilename ?? null,
+  });
 }
 
 export async function llmUnloadModel(): Promise<void> {
@@ -33,8 +55,30 @@ export async function llmGenerate(
   });
 }
 
-export async function llmGenerateBranchName(description: string): Promise<string> {
-  return invoke<string>('llm_generate_branch_name', { description });
+export async function llmGenerateBranchName(
+  description: string,
+  useTiny?: boolean,
+): Promise<string> {
+  return invoke<string>('llm_generate_branch_name', {
+    description,
+    useTiny: useTiny ?? null,
+  });
+}
+
+export async function llmCheckModelFiles(
+  opts?: {
+    subdir?: string;
+    ggufFilename?: string;
+    ggufPath?: string;
+    tokenizerPath?: string;
+  },
+): Promise<boolean> {
+  return invoke<boolean>('llm_check_model_files', {
+    subdir: opts?.subdir ?? null,
+    ggufFilename: opts?.ggufFilename ?? null,
+    ggufPath: opts?.ggufPath ?? null,
+    tokenizerPath: opts?.tokenizerPath ?? null,
+  });
 }
 
 export function isModelReady(status: LlmStatus): boolean {

--- a/src/plugins/smollm2/model-presets.ts
+++ b/src/plugins/smollm2/model-presets.ts
@@ -1,0 +1,47 @@
+export interface ModelPreset {
+  id: string;
+  label: string;
+  size: string;
+  quality: string;
+  hfRepo: string;
+  hfFilename: string;
+  tokenizerRepo: string;
+  subdir: string;
+}
+
+// Only Llama-architecture models are supported as presets because the engine
+// uses candle's quantized_llama::ModelWeights.
+export const MODEL_PRESETS: ModelPreset[] = [
+  {
+    id: 'smollm2-135m-q4',
+    label: 'SmolLM2 135M (Q4_K_M)',
+    size: '~110 MB',
+    quality: 'Fast, basic quality',
+    hfRepo: 'bartowski/SmolLM2-135M-Instruct-GGUF',
+    hfFilename: 'SmolLM2-135M-Instruct-Q4_K_M.gguf',
+    tokenizerRepo: 'HuggingFaceTB/SmolLM2-135M-Instruct',
+    subdir: 'smollm2-135m',
+  },
+  {
+    id: 'smollm2-360m-q4',
+    label: 'SmolLM2 360M (Q4_K_M)',
+    size: '~250 MB',
+    quality: 'Better quality, slower',
+    hfRepo: 'bartowski/SmolLM2-360M-Instruct-GGUF',
+    hfFilename: 'SmolLM2-360M-Instruct-Q4_K_M.gguf',
+    tokenizerRepo: 'HuggingFaceTB/SmolLM2-360M-Instruct',
+    subdir: 'smollm2-360m',
+  },
+  {
+    id: 'tinyllama-1.1b-q4',
+    label: 'TinyLlama 1.1B (Q4_K_M)',
+    size: '~670 MB',
+    quality: 'Good quality, Llama arch',
+    hfRepo: 'TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF',
+    hfFilename: 'tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf',
+    tokenizerRepo: 'TinyLlama/TinyLlama-1.1B-Chat-v1.0',
+    subdir: 'tinyllama-1.1b',
+  },
+];
+
+export const DEFAULT_PRESET_ID = 'smollm2-135m-q4';

--- a/src/plugins/smollm2/smollm2.test.ts
+++ b/src/plugins/smollm2/smollm2.test.ts
@@ -11,6 +11,10 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn().mockResolvedValue(null),
+}));
+
 // Mock localStorage
 const storage = new Map<string, string>();
 vi.stubGlobal('localStorage', {
@@ -39,6 +43,11 @@ function createMockContext(overrides: Partial<PluginContext> = {}): PluginContex
     playSound: vi.fn(),
     ...overrides,
   };
+}
+
+/** Wait for pending microtasks (async button rendering). */
+function flushMicrotasks(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 describe('SmolLM2Plugin', () => {
@@ -80,15 +89,15 @@ describe('SmolLM2Plugin', () => {
     expect(el.className).toBe('smollm2-settings');
   });
 
-  it('renderSettings includes status, action, auto-load, and test sections', async () => {
+  it('renderSettings includes status, engine, model source, auto-load, and test sections', async () => {
     mockInvoke.mockResolvedValue({ status: 'Ready' });
     const ctx = createMockContext();
     await plugin.init(ctx);
 
     const el = plugin.renderSettings!();
     const rows = el.querySelectorAll('.shortcut-row');
-    // Status row + Action row + Auto-load row + Test row
-    expect(rows.length).toBeGreaterThanOrEqual(3);
+    // Status + Engine + Source + Preset model + hint + preset action + Auto-load + Test row
+    expect(rows.length).toBeGreaterThanOrEqual(4);
   });
 
   it('renderSettings has auto-load checkbox defaulting to true', async () => {
@@ -102,36 +111,84 @@ describe('SmolLM2Plugin', () => {
     expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
   });
 
-  it('renderSettings shows download button when not downloaded', async () => {
-    mockInvoke.mockResolvedValue({ status: 'NotDownloaded' });
+  it('renderSettings shows download button when preset not downloaded', async () => {
+    // llm_get_status returns NotDownloaded
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'llm_get_status') return Promise.resolve({ status: 'NotDownloaded' });
+      if (cmd === 'llm_check_model_files') return Promise.resolve(false);
+      return Promise.resolve(null);
+    });
     const ctx = createMockContext();
     await plugin.init(ctx);
 
     const el = plugin.renderSettings!();
+    // Wait for async updatePresetButtons to populate
+    await flushMicrotasks();
+
     const buttons = el.querySelectorAll('button');
     const downloadBtn = Array.from(buttons).find(b => b.textContent?.includes('Download'));
     expect(downloadBtn).toBeDefined();
   });
 
-  it('renderSettings shows load button when downloaded but not loaded', async () => {
-    mockInvoke.mockResolvedValue({ status: 'Downloaded' });
+  it('renderSettings shows load button when preset downloaded but not loaded', async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'llm_get_status') return Promise.resolve({ status: 'Downloaded' });
+      if (cmd === 'llm_check_model_files') return Promise.resolve(true);
+      return Promise.resolve(null);
+    });
     const ctx = createMockContext();
     await plugin.init(ctx);
 
     const el = plugin.renderSettings!();
+    await flushMicrotasks();
+
     const buttons = el.querySelectorAll('button');
     const loadBtn = Array.from(buttons).find(b => b.textContent?.includes('Load'));
     expect(loadBtn).toBeDefined();
   });
 
   it('renderSettings shows unload button when ready', async () => {
-    mockInvoke.mockResolvedValue({ status: 'Ready' });
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'llm_get_status') return Promise.resolve({ status: 'Ready' });
+      if (cmd === 'llm_check_model_files') return Promise.resolve(true);
+      return Promise.resolve(null);
+    });
     const ctx = createMockContext();
     await plugin.init(ctx);
 
     const el = plugin.renderSettings!();
+    await flushMicrotasks();
+
     const buttons = el.querySelectorAll('button');
     const unloadBtn = Array.from(buttons).find(b => b.textContent?.includes('Unload'));
     expect(unloadBtn).toBeDefined();
+  });
+
+  it('renderSettings has engine toggle defaulting to tiny', async () => {
+    mockInvoke.mockResolvedValue({ status: 'NotDownloaded' });
+    const ctx = createMockContext();
+    await plugin.init(ctx);
+
+    const el = plugin.renderSettings!();
+    const selects = el.querySelectorAll('select');
+    const engineSelect = Array.from(selects).find(s =>
+      Array.from(s.options).some(o => o.value === 'tiny'),
+    );
+    expect(engineSelect).toBeDefined();
+    expect((engineSelect as HTMLSelectElement).value).toBe('tiny');
+  });
+
+  it('renderSettings has model source toggle defaulting to preset', async () => {
+    mockInvoke.mockResolvedValue({ status: 'NotDownloaded' });
+    const ctx = createMockContext();
+    await plugin.init(ctx);
+
+    const el = plugin.renderSettings!();
+    const selects = el.querySelectorAll('select');
+    const sourceSelect = Array.from(selects).find(s =>
+      Array.from(s.options).some(o => o.value === 'preset'),
+    );
+    expect(sourceSelect).toBeDefined();
+    expect((sourceSelect as HTMLSelectElement).value).toBe('preset');
   });
 });


### PR DESCRIPTION
## Summary
- Add **preset model dropdown** (SmolLM2-135M, SmolLM2-360M, TinyLlama-1.1B) with download/load per-preset
- Add **engine toggle** for branch name generation: tiny (~20M) vs full SmolLM2
- Add **custom GGUF file picker** via Tauri dialog for arbitrary `.gguf` models
- New `llm_check_model_files` command for lightweight file existence checks
- Parameterized `download_model_custom()` Rust function for arbitrary HF repos

## Test plan
- [x] `cargo check -p godly-llm` passes
- [x] `cargo nextest run -p godly-llm` — 33 tests pass (incl. 2 new)
- [x] `npx tsc --noEmit` — TypeScript clean
- [x] `npm test` — 763 tests pass across 59 files
- [ ] Manual: Settings → SmolLM2 → verify engine toggle, preset dropdown, custom file picker

Fixes #283