### PR TITLE
feat: pause/resume for invisible sessions + global scrollback budget

### DIFF
--- a/src-tauri/daemon/src/main.rs
+++ b/src-tauri/daemon/src/main.rs
@@ -1,5 +1,6 @@
 mod debug_log;
 mod pid;
+mod scrollback_budget;
 mod server;
 mod session;
 mod shim_client;

--- a/src-tauri/daemon/src/scrollback_budget.rs
+++ b/src-tauri/daemon/src/scrollback_budget.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+
+use crate::debug_log::daemon_log;
+
+/// Default scrollback length per session (rows).
+pub const DEFAULT_SCROLLBACK_LEN: usize = 10_000;
+
+/// Global scrollback memory budget in bytes (512 MB).
+/// When total scrollback across all sessions exceeds this, background
+/// (paused) sessions get their scrollback trimmed first.
+const GLOBAL_BUDGET_BYTES: usize = 512 * 1024 * 1024;
+
+/// Minimum scrollback length a session can be trimmed to (rows).
+/// Even under memory pressure, every session keeps at least this much history.
+const MIN_SCROLLBACK_LEN: usize = 500;
+
+/// Per-session scrollback tracking info.
+struct SessionInfo {
+    scrollback_rows: usize,
+    cols: u16,
+    is_paused: bool,
+    last_output_epoch_ms: u64,
+    current_scrollback_len: usize,
+}
+
+/// Coordinates scrollback memory across all daemon sessions.
+/// Periodically called from the health-check loop to enforce a global budget.
+pub struct ScrollbackBudget {
+    sessions: HashMap<String, SessionInfo>,
+    budget_bytes: usize,
+}
+
+impl ScrollbackBudget {
+    pub fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            budget_bytes: GLOBAL_BUDGET_BYTES,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn register_session(&mut self, id: String, cols: u16) {
+        self.sessions.insert(
+            id,
+            SessionInfo {
+                scrollback_rows: 0,
+                cols,
+                is_paused: false,
+                last_output_epoch_ms: 0,
+                current_scrollback_len: DEFAULT_SCROLLBACK_LEN,
+            },
+        );
+    }
+
+    #[allow(dead_code)]
+    pub fn remove_session(&mut self, id: &str) {
+        self.sessions.remove(id);
+    }
+
+    /// Remove entries for sessions that no longer exist.
+    pub fn retain_sessions(&mut self, active_ids: &[String]) {
+        self.sessions.retain(|id, _| active_ids.contains(id));
+    }
+
+    /// Update a session's current stats. Called from the health-check loop.
+    /// Auto-registers the session if it's not already tracked.
+    pub fn update_session(
+        &mut self,
+        id: &str,
+        scrollback_rows: usize,
+        cols: u16,
+        is_paused: bool,
+        last_output_epoch_ms: u64,
+    ) {
+        let info = self.sessions.entry(id.to_string()).or_insert_with(|| SessionInfo {
+            scrollback_rows: 0,
+            cols,
+            is_paused: false,
+            last_output_epoch_ms: 0,
+            current_scrollback_len: DEFAULT_SCROLLBACK_LEN,
+        });
+        info.scrollback_rows = scrollback_rows;
+        info.cols = cols;
+        info.is_paused = is_paused;
+        info.last_output_epoch_ms = last_output_epoch_ms;
+    }
+
+    /// Estimate total scrollback memory across all sessions.
+    fn total_memory(&self) -> usize {
+        const CELL_BYTES: usize = 32;
+        self.sessions
+            .values()
+            .map(|s| s.scrollback_rows * usize::from(s.cols) * CELL_BYTES)
+            .sum()
+    }
+
+    /// Check if the global budget is exceeded and compute trimming actions.
+    /// Returns a list of (session_id, new_scrollback_len) pairs.
+    pub fn check_and_trim(&mut self) -> Vec<(String, usize)> {
+        let total = self.total_memory();
+        if total <= self.budget_bytes {
+            return Vec::new();
+        }
+
+        let overshoot = total - self.budget_bytes;
+        daemon_log!(
+            "ScrollbackBudget: total={:.1}MB, budget={:.1}MB, overshoot={:.1}MB, sessions={}",
+            total as f64 / (1024.0 * 1024.0),
+            self.budget_bytes as f64 / (1024.0 * 1024.0),
+            overshoot as f64 / (1024.0 * 1024.0),
+            self.sessions.len()
+        );
+
+        // Sort candidates: paused sessions first, then by oldest output time
+        let mut candidates: Vec<(&String, &SessionInfo)> = self
+            .sessions
+            .iter()
+            .filter(|(_, s)| s.current_scrollback_len > MIN_SCROLLBACK_LEN)
+            .collect();
+
+        candidates.sort_by(|a, b| {
+            // Paused first (true > false, so reverse)
+            b.1.is_paused
+                .cmp(&a.1.is_paused)
+                .then_with(|| a.1.last_output_epoch_ms.cmp(&b.1.last_output_epoch_ms))
+        });
+
+        let mut freed: usize = 0;
+        let mut actions = Vec::new();
+        const CELL_BYTES: usize = 32;
+
+        for (id, info) in &candidates {
+            if freed >= overshoot {
+                break;
+            }
+
+            let current_bytes =
+                info.scrollback_rows * usize::from(info.cols) * CELL_BYTES;
+            if current_bytes == 0 {
+                continue;
+            }
+
+            // Target: halve scrollback, but not below minimum
+            let new_len = (info.current_scrollback_len / 2).max(MIN_SCROLLBACK_LEN);
+            if new_len >= info.current_scrollback_len {
+                continue;
+            }
+
+            let rows_freed = info.scrollback_rows.saturating_sub(new_len);
+            let bytes_freed = rows_freed * usize::from(info.cols) * CELL_BYTES;
+
+            actions.push(((*id).clone(), new_len));
+            freed += bytes_freed;
+
+            daemon_log!(
+                "ScrollbackBudget: trim session {} from {} to {} rows (freed ~{:.1}MB, paused={})",
+                id,
+                info.current_scrollback_len,
+                new_len,
+                bytes_freed as f64 / (1024.0 * 1024.0),
+                info.is_paused
+            );
+        }
+
+        // Update our internal tracking for the trimmed sessions
+        for (id, new_len) in &actions {
+            if let Some(info) = self.sessions.get_mut(id.as_str()) {
+                info.current_scrollback_len = *new_len;
+            }
+        }
+
+        actions
+    }
+}

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 use godly_protocol::{DaemonMessage, Event, Request, Response, read_request, write_daemon_message};
 
 use crate::debug_log::daemon_log;
+use crate::scrollback_budget::ScrollbackBudget;
 use crate::session::DaemonSession;
 
 /// Log current process memory usage (Windows: working set via GetProcessMemoryInfo).
@@ -47,6 +48,7 @@ pub struct DaemonServer {
     /// it set has_clients=false even if other clients were still connected,
     /// allowing the idle timeout to kill the daemon prematurely.
     client_count: Arc<AtomicUsize>,
+    scrollback_budget: Arc<parking_lot::Mutex<ScrollbackBudget>>,
 }
 
 impl DaemonServer {
@@ -55,6 +57,7 @@ impl DaemonServer {
             sessions: Arc::new(RwLock::new(HashMap::new())),
             running: Arc::new(AtomicBool::new(true)),
             client_count: Arc::new(AtomicUsize::new(0)),
+            scrollback_budget: Arc::new(parking_lot::Mutex::new(ScrollbackBudget::new())),
         }
     }
 
@@ -77,6 +80,7 @@ impl DaemonServer {
         let client_count = self.client_count.clone();
         let last_activity = Arc::new(RwLock::new(Instant::now()));
         let last_activity_for_timeout = last_activity.clone();
+        let scrollback_budget = self.scrollback_budget.clone();
 
         tokio::spawn(async move {
             let idle_timeout = Duration::from_secs(300); // 5 minutes
@@ -108,6 +112,34 @@ impl DaemonServer {
                         session_ids
                     );
                     log_memory_usage("health_check");
+                }
+
+                // Scrollback budget enforcement (every 6th tick = ~60s)
+                if health_tick % 6 == 0 && session_count > 0 {
+                    let mut budget = scrollback_budget.lock();
+                    budget.retain_sessions(&session_ids);
+                    {
+                        let guard = sessions.read();
+                        for (id, session) in guard.iter() {
+                            let (rows, _bytes) = session.scrollback_stats();
+                            budget.update_session(
+                                id,
+                                rows,
+                                session.cols(),
+                                session.is_paused(),
+                                session.last_output_epoch_ms(),
+                            );
+                        }
+                    }
+                    let actions = budget.check_and_trim();
+                    if !actions.is_empty() {
+                        let guard = sessions.read();
+                        for (id, new_len) in &actions {
+                            if let Some(session) = guard.get(id.as_str()) {
+                                session.set_scrollback_len(*new_len);
+                            }
+                        }
+                    }
                 }
 
                 if session_count == 0 && num_clients == 0 && elapsed > idle_timeout {
@@ -558,6 +590,52 @@ fn io_thread(
                                 let msg = DaemonMessage::Response(response);
                                 if write_daemon_message(&mut pipe, &msg).is_err() {
                                     daemon_log!("Write error on direct Resize response, stopping");
+                                    io_running.store(false, Ordering::Relaxed);
+                                    break;
+                                }
+                                total_resp_writes += 1;
+                                total_writes += 1;
+                                did_work = true;
+                            }
+                            Request::PauseSession { session_id } => {
+                                let response = {
+                                    let sessions_guard = sessions.read();
+                                    match sessions_guard.get(session_id) {
+                                        Some(session) => {
+                                            session.pause();
+                                            Response::Ok
+                                        }
+                                        None => Response::Error {
+                                            message: format!("Session {} not found", session_id),
+                                        },
+                                    }
+                                };
+                                let msg = DaemonMessage::Response(response);
+                                if write_daemon_message(&mut pipe, &msg).is_err() {
+                                    daemon_log!("Write error on direct PauseSession response, stopping");
+                                    io_running.store(false, Ordering::Relaxed);
+                                    break;
+                                }
+                                total_resp_writes += 1;
+                                total_writes += 1;
+                                did_work = true;
+                            }
+                            Request::ResumeSession { session_id } => {
+                                let response = {
+                                    let sessions_guard = sessions.read();
+                                    match sessions_guard.get(session_id) {
+                                        Some(session) => {
+                                            session.resume();
+                                            Response::Ok
+                                        }
+                                        None => Response::Error {
+                                            message: format!("Session {} not found", session_id),
+                                        },
+                                    }
+                                };
+                                let msg = DaemonMessage::Response(response);
+                                if write_daemon_message(&mut pipe, &msg).is_err() {
+                                    daemon_log!("Write error on direct ResumeSession response, stopping");
                                     io_running.store(false, Ordering::Relaxed);
                                     break;
                                 }
@@ -1433,6 +1511,34 @@ async fn handle_request(
                     eprintln!("[daemon] Closed session {}", session_id);
                     daemon_log!("Closed session {} (remaining sessions: {})", session_id, remaining);
                     log_memory_usage(&format!("session_close({})", remaining));
+                    Response::Ok
+                }
+                None => Response::Error {
+                    message: format!("Session {} not found", session_id),
+                },
+            }
+        }
+
+        // PauseSession/ResumeSession are handled directly in the I/O thread
+        // for low latency. If they somehow reach here, handle them gracefully.
+        Request::PauseSession { session_id } => {
+            let sessions_guard = sessions.read();
+            match sessions_guard.get(session_id) {
+                Some(session) => {
+                    session.pause();
+                    Response::Ok
+                }
+                None => Response::Error {
+                    message: format!("Session {} not found", session_id),
+                },
+            }
+        }
+
+        Request::ResumeSession { session_id } => {
+            let sessions_guard = sessions.read();
+            match sessions_guard.get(session_id) {
+                Some(session) => {
+                    session.resume();
                     Response::Ok
                 }
                 None => Response::Error {

--- a/src-tauri/daemon/src/session.rs
+++ b/src-tauri/daemon/src/session.rs
@@ -218,6 +218,7 @@ pub struct DaemonSession {
     /// Lock-free attachment flag -- readable without locking output_tx.
     /// Updated in attach()/detach()/close() and by the reader thread on send failure.
     is_attached_flag: Arc<AtomicBool>,
+    is_paused_flag: Arc<AtomicBool>,
     /// Always-on output history buffer -- captures all PTY output regardless of
     /// attachment state. Used by the ReadBuffer command to let MCP clients read
     /// terminal output without attaching.
@@ -326,6 +327,8 @@ impl DaemonSession {
             vt_parser.lock().process(&early_output);
         }
 
+        let is_paused_flag = Arc::new(AtomicBool::new(false));
+
         // Spawn I/O thread that handles all pipe reads AND writes.
         // This avoids the DuplicateHandle deadlock by keeping all pipe I/O
         // in a single thread with a single file object.
@@ -341,6 +344,7 @@ impl DaemonSession {
             last_output_epoch_ms.clone(),
             vt_parser.clone(),
             exit_code.clone(),
+            is_paused_flag.clone(),
         );
 
         Ok(Self {
@@ -360,6 +364,7 @@ impl DaemonSession {
             ring_buffer,
             output_tx,
             is_attached_flag,
+            is_paused_flag,
             output_history,
             last_output_epoch_ms,
             vt_parser,
@@ -499,6 +504,7 @@ impl DaemonSession {
         let last_output_epoch_ms = Arc::new(AtomicU64::new(now_ms));
 
         let exit_code = Arc::new(AtomicI64::new(exit_code_val));
+        let is_paused_flag = Arc::new(AtomicBool::new(false));
 
         // Spawn I/O thread for ongoing shim communication
         if is_running {
@@ -514,6 +520,7 @@ impl DaemonSession {
                 last_output_epoch_ms.clone(),
                 vt_parser.clone(),
                 exit_code.clone(),
+                is_paused_flag.clone(),
             );
         }
 
@@ -545,6 +552,7 @@ impl DaemonSession {
             ring_buffer,
             output_tx,
             is_attached_flag,
+            is_paused_flag,
             output_history,
             last_output_epoch_ms,
             vt_parser,
@@ -621,6 +629,7 @@ impl DaemonSession {
         reader_last_output: Arc<AtomicU64>,
         reader_vt: Arc<Mutex<godly_vt::Parser>>,
         reader_exit_code: Arc<AtomicI64>,
+        reader_paused: Arc<AtomicBool>,
     ) {
         thread::spawn(move || {
             daemon_log!("Session {} shim I/O thread started", session_id);
@@ -713,6 +722,7 @@ impl DaemonSession {
                             &mut last_diff_time,
                             DIFF_INTERVAL,
                             &mut channel_send_failures,
+                            &reader_paused,
                         );
                         did_work = true;
                     }
@@ -760,6 +770,7 @@ impl DaemonSession {
                                         &mut last_diff_time,
                                         DIFF_INTERVAL,
                                         &mut channel_send_failures,
+                                        &reader_paused,
                                     );
                                 }
 
@@ -776,6 +787,7 @@ impl DaemonSession {
                                     &mut last_diff_time,
                                     DIFF_INTERVAL,
                                     &mut channel_send_failures,
+                                    &reader_paused,
                                 );
                             }
                             OutputMode::Bulk => {
@@ -807,6 +819,7 @@ impl DaemonSession {
                                         &mut last_diff_time,
                                         DIFF_INTERVAL,
                                         &mut channel_send_failures,
+                                        &reader_paused,
                                     );
                                 }
                             }
@@ -911,6 +924,7 @@ impl DaemonSession {
                     &mut last_diff_time,
                     DIFF_INTERVAL,
                     &mut channel_send_failures,
+                    &reader_paused,
                 );
             }
 
@@ -978,6 +992,34 @@ impl DaemonSession {
     /// Check if a client is currently attached (lock-free).
     pub fn is_attached(&self) -> bool {
         self.is_attached_flag.load(Ordering::Relaxed)
+    }
+
+    pub fn pause(&self) {
+        self.is_paused_flag.store(true, Ordering::Relaxed);
+    }
+
+    pub fn resume(&self) {
+        self.is_paused_flag.store(false, Ordering::Relaxed);
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.is_paused_flag.load(Ordering::Relaxed)
+    }
+
+    pub fn set_scrollback_len(&self, len: usize) {
+        let mut vt = self.vt_parser.lock();
+        vt.screen_mut().set_scrollback_len(len);
+    }
+
+    pub fn scrollback_stats(&self) -> (usize, usize) {
+        let vt = self.vt_parser.lock();
+        let rows = vt.screen().scrollback_count();
+        let bytes = vt.screen().scrollback_memory_estimate();
+        (rows, bytes)
+    }
+
+    pub fn cols(&self) -> u16 {
+        self.cols
     }
 
     /// Write data to the PTY via the shim pipe.
@@ -1101,6 +1143,7 @@ impl DaemonSession {
 
     /// Get the session info for protocol messages
     pub fn info(&self) -> godly_protocol::SessionInfo {
+        let (scrollback_rows, scrollback_memory_bytes) = self.scrollback_stats();
         godly_protocol::SessionInfo {
             id: self.id.clone(),
             shell_type: self.shell_type.clone(),
@@ -1114,6 +1157,9 @@ impl DaemonSession {
             created_at: self.created_at,
             attached: self.is_attached(),
             running: self.is_running(),
+            scrollback_rows,
+            scrollback_memory_bytes,
+            paused: self.is_paused(),
         }
     }
 
@@ -1378,6 +1424,7 @@ fn flush_output(
     last_diff_time: &mut Instant,
     diff_interval: Duration,
     channel_send_failures: &mut u64,
+    reader_paused: &Arc<AtomicBool>,
 ) {
     if data.is_empty() {
         return;
@@ -1394,6 +1441,14 @@ fn flush_output(
     {
         let mut history = reader_history.lock();
         append_to_ring(&mut history, data);
+    }
+
+    // Always feed VT parser (grid state must stay current even when paused)
+    // but skip sending Output/GridDiff events to the client when paused.
+    if reader_paused.load(Ordering::Relaxed) {
+        let mut vt = reader_vt.lock();
+        vt.process(data);
+        return;
     }
 
     // Feed PTY output into godly-vt parser for grid state.

--- a/src-tauri/daemon/tests/pause_resume.rs
+++ b/src-tauri/daemon/tests/pause_resume.rs
@@ -1,0 +1,411 @@
+//! Pause/Resume test: verify that paused sessions suppress output events
+//! while keeping the VT parser up-to-date, and that resume restores streaming.
+//!
+//! Run with:
+//!   cd src-tauri && cargo test -p godly-daemon --test pause_resume -- --test-threads=1
+
+#![cfg(windows)]
+
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::AsRawHandle;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+use godly_protocol::{DaemonMessage, Event, Request, Response, ShellType};
+
+// ---------------------------------------------------------------------------
+// Helpers (DaemonFixture pattern — see handler_starvation.rs)
+// ---------------------------------------------------------------------------
+
+fn connect_pipe(pipe_name: &str, timeout: Duration) -> std::fs::File {
+    use std::os::windows::io::FromRawHandle;
+    use winapi::um::errhandlingapi::GetLastError;
+    use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
+    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+    use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+
+    let wide_name: Vec<u16> = OsStr::new(pipe_name)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let start = Instant::now();
+    loop {
+        let handle = unsafe {
+            CreateFileW(
+                wide_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            return unsafe { std::fs::File::from_raw_handle(handle as _) };
+        }
+        if start.elapsed() > timeout {
+            let err = unsafe { GetLastError() };
+            panic!("Failed to connect to pipe within {:?} (error: {})", timeout, err);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn pipe_has_data(pipe: &std::fs::File) -> bool {
+    use winapi::um::namedpipeapi::PeekNamedPipe;
+    let handle = pipe.as_raw_handle();
+    let mut bytes_available: u32 = 0;
+    let result = unsafe {
+        PeekNamedPipe(
+            handle as *mut _,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            &mut bytes_available,
+            std::ptr::null_mut(),
+        )
+    };
+    result != 0 && bytes_available > 0
+}
+
+/// Send a request and read the response (blocking). For setup/control only.
+fn send_request(pipe: &mut std::fs::File, request: &Request) -> Response {
+    godly_protocol::write_request(pipe, request).expect("Failed to write request");
+    loop {
+        let msg = godly_protocol::read_daemon_message(pipe)
+            .expect("Failed to read message")
+            .expect("Unexpected EOF");
+        match msg {
+            DaemonMessage::Response(resp) => return resp,
+            DaemonMessage::Event(_) => continue,
+        }
+    }
+}
+
+/// Create a session with retries (shim pipe can be flaky under parallel test runs).
+fn create_session_with_retry(
+    pipe: &mut std::fs::File,
+    session_id: &str,
+    max_attempts: u32,
+) -> Response {
+    for attempt in 1..=max_attempts {
+        let resp = send_request(
+            pipe,
+            &Request::CreateSession {
+                id: session_id.to_string(),
+                shell_type: ShellType::Windows,
+                cwd: None,
+                rows: 24,
+                cols: 80,
+                env: None,
+            },
+        );
+        match &resp {
+            Response::SessionCreated { .. } => return resp,
+            Response::Error { message } if attempt < max_attempts => {
+                eprintln!("CreateSession attempt {} failed: {}, retrying...", attempt, message);
+                std::thread::sleep(Duration::from_millis(500 * u64::from(attempt)));
+            }
+            _ => return resp,
+        }
+    }
+    unreachable!()
+}
+
+/// Drain all pending events from the pipe, returning the count.
+fn drain_events(pipe: &mut std::fs::File, timeout: Duration) -> u32 {
+    let start = Instant::now();
+    let mut count = 0u32;
+    while start.elapsed() < timeout {
+        if !pipe_has_data(pipe) {
+            std::thread::sleep(Duration::from_millis(5));
+            continue;
+        }
+        match godly_protocol::read_daemon_message(pipe) {
+            Ok(Some(DaemonMessage::Event(_))) => count += 1,
+            _ => break,
+        }
+    }
+    count
+}
+
+/// Count Output/GridDiff events for a specific session during a window.
+fn count_session_events(pipe: &mut std::fs::File, session_id: &str, window: Duration) -> u32 {
+    let start = Instant::now();
+    let mut count = 0u32;
+    while start.elapsed() < window {
+        if !pipe_has_data(pipe) {
+            std::thread::sleep(Duration::from_millis(5));
+            continue;
+        }
+        match godly_protocol::read_daemon_message(pipe) {
+            Ok(Some(DaemonMessage::Event(Event::Output { session_id: sid, .. })))
+                if sid == session_id =>
+            {
+                count += 1;
+            }
+            Ok(Some(DaemonMessage::Event(Event::GridDiff { session_id: sid, .. })))
+                if sid == session_id =>
+            {
+                count += 1;
+            }
+            Ok(Some(DaemonMessage::Event(Event::Bell { session_id: sid })))
+                if sid == session_id =>
+            {
+                count += 1;
+            }
+            Ok(Some(_)) => {} // other events/responses
+            _ => break,
+        }
+    }
+    count
+}
+
+struct DaemonFixture {
+    child: Child,
+    pipe_name: String,
+}
+
+impl DaemonFixture {
+    fn spawn(test_name: &str) -> Self {
+        let pipe_name = format!(
+            r"\\.\pipe\godly-test-{}-{}",
+            test_name,
+            std::process::id()
+        );
+
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let target_dir = manifest_dir.parent().unwrap().join("target").join("debug");
+        let daemon_exe = target_dir.join("godly-daemon.exe");
+        assert!(
+            daemon_exe.exists(),
+            "Daemon binary not found at {:?}. Run `cargo build -p godly-daemon` first.",
+            daemon_exe
+        );
+
+        let child = Command::new(&daemon_exe)
+            .env("GODLY_PIPE_NAME", &pipe_name)
+            .env("GODLY_NO_DETACH", "1")
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn daemon");
+
+        std::thread::sleep(Duration::from_millis(500));
+        Self { child, pipe_name }
+    }
+
+    fn connect(&self) -> std::fs::File {
+        connect_pipe(&self.pipe_name, Duration::from_secs(5))
+    }
+}
+
+impl Drop for DaemonFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Verify that PauseSession suppresses Output/GridDiff events and
+/// ResumeSession restores them. The VT parser stays current in both states.
+#[test]
+#[ntest::timeout(60_000)]
+fn test_pause_suppresses_output_resume_restores() {
+    let fixture = DaemonFixture::spawn("pause_resume");
+    let mut pipe = fixture.connect();
+
+    // Create a session that produces continuous output
+    let session_id = "pause-test-session";
+    let resp = create_session_with_retry(&mut pipe, session_id, 3);
+    assert!(matches!(resp, Response::SessionCreated { .. }));
+
+    // Attach to receive events
+    let resp = send_request(
+        &mut pipe,
+        &Request::Attach {
+            session_id: session_id.to_string(),
+        },
+    );
+    assert!(matches!(resp, Response::Ok | Response::Buffer { .. }));
+
+    // Send a command that produces output
+    let _ = send_request(
+        &mut pipe,
+        &Request::Write {
+            session_id: session_id.to_string(),
+            data: b"echo BEFORE_PAUSE\r\n".to_vec(),
+        },
+    );
+
+    // Wait for some events
+    std::thread::sleep(Duration::from_millis(500));
+    let _events_before = drain_events(&mut pipe, Duration::from_millis(500));
+
+    // Pause the session
+    let resp = send_request(
+        &mut pipe,
+        &Request::PauseSession {
+            session_id: session_id.to_string(),
+        },
+    );
+    assert!(matches!(resp, Response::Ok));
+
+    // Drain any in-flight events from before the pause took effect
+    std::thread::sleep(Duration::from_millis(200));
+    drain_events(&mut pipe, Duration::from_millis(200));
+
+    // Write while paused — should produce NO output events
+    let _ = send_request(
+        &mut pipe,
+        &Request::Write {
+            session_id: session_id.to_string(),
+            data: b"echo DURING_PAUSE\r\n".to_vec(),
+        },
+    );
+
+    // Count events during the paused window
+    let events_while_paused = count_session_events(
+        &mut pipe,
+        session_id,
+        Duration::from_secs(2),
+    );
+
+    // Should have zero output events while paused
+    assert_eq!(
+        events_while_paused, 0,
+        "Expected 0 output events while paused, got {}",
+        events_while_paused
+    );
+
+    // The VT parser should still have the content — verify via ReadRichGrid
+    let resp = send_request(
+        &mut pipe,
+        &Request::ReadRichGrid {
+            session_id: session_id.to_string(),
+        },
+    );
+    match &resp {
+        Response::RichGrid { grid } => {
+            // Grid should have content (the parser processed the "echo DURING_PAUSE" output)
+            let has_content = grid.rows.iter().any(|row| {
+                row.cells.iter().any(|cell| !cell.content.trim().is_empty())
+            });
+            assert!(has_content, "VT parser should have content even while paused");
+        }
+        other => panic!("Expected RichGrid, got {:?}", other),
+    }
+
+    // Resume the session
+    let resp = send_request(
+        &mut pipe,
+        &Request::ResumeSession {
+            session_id: session_id.to_string(),
+        },
+    );
+    assert!(matches!(resp, Response::Ok));
+
+    // Write after resume — should produce output events again
+    let _ = send_request(
+        &mut pipe,
+        &Request::Write {
+            session_id: session_id.to_string(),
+            data: b"echo AFTER_RESUME\r\n".to_vec(),
+        },
+    );
+
+    let events_after_resume = count_session_events(
+        &mut pipe,
+        session_id,
+        Duration::from_secs(2),
+    );
+
+    assert!(
+        events_after_resume > 0,
+        "Expected output events after resume, got 0"
+    );
+
+    // ListSessions should report paused=false
+    let resp = send_request(&mut pipe, &Request::ListSessions);
+    match resp {
+        Response::SessionList { sessions } => {
+            let info = sessions.iter().find(|s| s.id == session_id).unwrap();
+            assert!(!info.paused, "Session should not be paused after ResumeSession");
+            assert!(info.scrollback_rows > 0 || info.scrollback_memory_bytes == 0,
+                "Session info should include scrollback stats");
+        }
+        other => panic!("Expected SessionList, got {:?}", other),
+    }
+
+    // Clean up
+    let _ = send_request(
+        &mut pipe,
+        &Request::CloseSession {
+            session_id: session_id.to_string(),
+        },
+    );
+}
+
+/// Verify ListSessions reports paused=true for a paused session.
+#[test]
+#[ntest::timeout(60_000)]
+fn test_list_sessions_reports_paused_state() {
+    let fixture = DaemonFixture::spawn("pause_list");
+    let mut pipe = fixture.connect();
+
+    let session_id = "pause-list-session";
+    let resp = create_session_with_retry(&mut pipe, session_id, 3);
+    assert!(matches!(resp, Response::SessionCreated { .. }));
+
+    // Attach so pause has effect
+    let resp = send_request(
+        &mut pipe,
+        &Request::Attach {
+            session_id: session_id.to_string(),
+        },
+    );
+    assert!(matches!(resp, Response::Ok | Response::Buffer { .. }));
+
+    // Before pause: paused=false
+    let resp = send_request(&mut pipe, &Request::ListSessions);
+    match &resp {
+        Response::SessionList { sessions } => {
+            let info = sessions.iter().find(|s| s.id == session_id).unwrap();
+            assert!(!info.paused);
+        }
+        other => panic!("Expected SessionList, got {:?}", other),
+    }
+
+    // Pause
+    let resp = send_request(
+        &mut pipe,
+        &Request::PauseSession {
+            session_id: session_id.to_string(),
+        },
+    );
+    assert!(matches!(resp, Response::Ok));
+
+    // After pause: paused=true
+    let resp = send_request(&mut pipe, &Request::ListSessions);
+    match &resp {
+        Response::SessionList { sessions } => {
+            let info = sessions.iter().find(|s| s.id == session_id).unwrap();
+            assert!(info.paused, "Session should be reported as paused");
+        }
+        other => panic!("Expected SessionList, got {:?}", other),
+    }
+
+    // Clean up
+    let _ = send_request(
+        &mut pipe,
+        &Request::CloseSession {
+            session_id: session_id.to_string(),
+        },
+    );
+}

--- a/src-tauri/godly-vt/src/grid.rs
+++ b/src-tauri/godly-vt/src/grid.rs
@@ -791,6 +791,18 @@ impl Grid {
             self.pos.col = self.size.cols - 1;
         }
     }
+
+    pub fn set_scrollback_len(&mut self, len: usize) {
+        self.scrollback_len = len;
+        while self.scrollback.len() > self.scrollback_len {
+            self.scrollback.pop_front();
+        }
+        self.scrollback_offset = self.scrollback_offset.min(self.scrollback.len());
+    }
+
+    pub fn scrollback_memory_estimate(&self, cell_bytes: usize) -> usize {
+        self.scrollback.len() * usize::from(self.size.cols) * cell_bytes
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]

--- a/src-tauri/godly-vt/src/screen.rs
+++ b/src-tauri/godly-vt/src/screen.rs
@@ -152,6 +152,15 @@ impl Screen {
         self.grid().scrollback()
     }
 
+    pub fn set_scrollback_len(&mut self, len: usize) {
+        self.grid_mut().set_scrollback_len(len);
+    }
+
+    #[must_use]
+    pub fn scrollback_memory_estimate(&self) -> usize {
+        self.grid().scrollback_memory_estimate(std::mem::size_of::<crate::Cell>())
+    }
+
     /// Returns the text contents of the terminal.
     ///
     /// This will not include any formatting information, and will be in plain

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -73,6 +73,15 @@ pub enum Request {
         session_id: String,
         offset: usize,
     },
+    /// Pause output streaming for a session (session stays alive, VT parser
+    /// keeps running, but no Output/GridDiff events are sent to the client).
+    PauseSession {
+        session_id: String,
+    },
+    /// Resume output streaming for a previously paused session.
+    ResumeSession {
+        session_id: String,
+    },
     Ping,
 }
 

--- a/src-tauri/protocol/src/types.rs
+++ b/src-tauri/protocol/src/types.rs
@@ -50,6 +50,12 @@ pub struct SessionInfo {
     pub created_at: u64,
     pub attached: bool,
     pub running: bool,
+    #[serde(default)]
+    pub scrollback_rows: usize,
+    #[serde(default)]
+    pub scrollback_memory_bytes: usize,
+    #[serde(default)]
+    pub paused: bool,
 }
 
 /// Grid snapshot from the godly-vt terminal state engine.

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -639,6 +639,31 @@ fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, timeout_ms: 
     }
 }
 
+/// Pause output streaming for a session (session stays alive, VT parser
+/// keeps running, but no Output/GridDiff events are sent to the client).
+#[tauri::command]
+pub fn pause_session(
+    session_id: String,
+    daemon: State<Arc<DaemonClient>>,
+) -> Result<(), String> {
+    let request = Request::PauseSession {
+        session_id,
+    };
+    daemon.send_fire_and_forget(&request)
+}
+
+/// Resume output streaming for a previously paused session.
+#[tauri::command]
+pub fn resume_session(
+    session_id: String,
+    daemon: State<Arc<DaemonClient>>,
+) -> Result<(), String> {
+    let request = Request::ResumeSession {
+        session_id,
+    };
+    daemon.send_fire_and_forget(&request)
+}
+
 /// Detach all sessions (called on window close instead of killing them)
 #[tauri::command]
 pub fn detach_all_sessions(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -335,6 +335,8 @@ pub fn run() {
             commands::attach_session,
             commands::sync_active_terminal,
             commands::quick_claude,
+            commands::pause_session,
+            commands::resume_session,
             commands::detach_all_sessions,
             commands::create_workspace,
             commands::delete_workspace,

--- a/src/services/terminal-service.ts
+++ b/src/services/terminal-service.ts
@@ -211,6 +211,16 @@ class TerminalService {
     await invoke('set_scrollback', { terminalId, offset });
   }
 
+  /** Pause output streaming for a session (background optimization). */
+  async pauseSession(sessionId: string): Promise<void> {
+    await invoke('pause_session', { sessionId });
+  }
+
+  /** Resume output streaming for a previously paused session. */
+  async resumeSession(sessionId: string): Promise<void> {
+    await invoke('resume_session', { sessionId });
+  }
+
   onTerminalOutput(terminalId: string, callback: () => void) {
     this.outputListeners.set(terminalId, callback);
     return () => this.outputListeners.delete(terminalId);

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -64,6 +64,9 @@ class Store {
   private lastActiveTerminalByWorkspace: Map<string, string> = new Map();
   private suspendedSplitViews: Map<string, SplitView> = new Map();
   private pendingNotify = false;
+  /** Sessions currently resumed (not paused). Tracks which sessions we've
+   *  sent resumeSession to, so we can pause them when they become invisible. */
+  private resumedSessions: Set<string> = new Set();
 
   getState(): AppState {
     return this.state;
@@ -154,6 +157,7 @@ class Store {
       activeWorkspaceId: id,
       activeTerminalId: rememberedStillExists ? rememberedId : (workspaceTerminals[0]?.id ?? null),
     });
+    this.syncSessionPauseState();
   }
 
   // Terminal operations
@@ -174,6 +178,7 @@ class Store {
         activeTerminalId: terminal.id,
       });
     }
+    this.syncSessionPauseState();
   }
 
   updateTerminal(id: string, updates: Partial<Terminal>) {
@@ -232,6 +237,8 @@ class Store {
       activeTerminalId: newActiveId,
       splitViews,
     });
+    this.resumedSessions.delete(id);
+    this.syncSessionPauseState();
   }
 
   setActiveTerminal(id: string | null) {
@@ -247,6 +254,7 @@ class Store {
         this.setState({ activeTerminalId: id, splitViews: rest });
         invoke('clear_split_view', { workspaceId: wsId }).catch(() => {});
         invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+        this.syncSessionPauseState();
         return;
       }
 
@@ -266,11 +274,13 @@ class Store {
           ratio: suspended.ratio,
         }).catch(() => {});
         invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+        this.syncSessionPauseState();
         return;
       }
     }
     this.setState({ activeTerminalId: id });
     invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+    this.syncSessionPauseState();
   }
 
   moveTerminalToWorkspace(terminalId: string, workspaceId: string) {
@@ -351,6 +361,44 @@ class Store {
         [workspaceId]: { ...split, ratio },
       },
     });
+  }
+
+  /**
+   * Sync session pause/resume state based on currently visible terminals.
+   * Visible terminals are resumed, all others are paused.
+   * This reduces daemon output overhead for background sessions.
+   */
+  syncSessionPauseState() {
+    const { activeTerminalId, activeWorkspaceId, splitViews } = this.state;
+    const visibleIds = new Set<string>();
+
+    if (activeTerminalId) {
+      visibleIds.add(activeTerminalId);
+    }
+
+    // Also include split view terminals
+    if (activeWorkspaceId) {
+      const split = splitViews[activeWorkspaceId];
+      if (split) {
+        visibleIds.add(split.leftTerminalId);
+        visibleIds.add(split.rightTerminalId);
+      }
+    }
+
+    // Resume visible, pause invisible
+    for (const terminal of this.state.terminals) {
+      if (visibleIds.has(terminal.id)) {
+        if (!this.resumedSessions.has(terminal.id)) {
+          this.resumedSessions.add(terminal.id);
+          invoke('resume_session', { sessionId: terminal.id }).catch(() => {});
+        }
+      } else {
+        if (this.resumedSessions.has(terminal.id)) {
+          this.resumedSessions.delete(terminal.id);
+          invoke('pause_session', { sessionId: terminal.id }).catch(() => {});
+        }
+      }
+    }
   }
 
   getWorkspaceTerminals(workspaceId: string): Terminal[] {


### PR DESCRIPTION
## Summary

Implements the remaining high-value items from #263 (Multi-session Scalability):

- **P0: Pause/Resume for invisible sessions** — when a session is not visible (background tab/workspace), the daemon suppresses Output/GridDiff events while keeping the VT parser current. This eliminates wasted IPC serialization for 18+ hidden sessions when only 2 are visible.
- **P1: Global scrollback memory budget** — a 512MB coordinator that periodically trims scrollback on paused/oldest sessions first, preventing OOM at 20+ concurrent sessions.
- **Frontend integration** — `syncSessionPauseState()` auto-pauses hidden sessions and resumes visible ones on workspace/tab switch.

### Key design decisions

- Pause is lock-free (AtomicBool checked in flush_output) — zero overhead on the hot path
- PauseSession/ResumeSession are fast-path I/O thread operations (like Resize), not async handler round-trips
- VT parser stays current while paused — grid state is always up-to-date for instant resume
- ScrollbackBudget runs in health loop (~60s), trims paused sessions with oldest output first, minimum 500 rows

### Files changed (13 files, 868 lines)

| Layer | Files | Changes |
|-------|-------|---------|
| godly-vt | `grid.rs`, `screen.rs` | `set_scrollback_len()`, `scrollback_memory_estimate()` |
| Protocol | `messages.rs`, `types.rs` | +PauseSession/ResumeSession, +SessionInfo fields |
| Daemon | `session.rs`, `server.rs`, `scrollback_budget.rs`, `main.rs` | Pause flag, fast-path handling, budget coordinator |
| Tauri commands | `terminal.rs`, `lib.rs` | `pause_session`, `resume_session` commands |
| Frontend | `terminal-service.ts`, `store.ts` | `syncSessionPauseState()` on visibility changes |
| Tests | `pause_resume.rs` | Integration tests for pause/resume + ListSessions state |

## Test plan

- [x] `cargo check -p godly-daemon -p godly-protocol -p godly-vt` — compiles clean
- [x] `cargo nextest run -p godly-protocol -p godly-vt` — 295/295 pass
- [x] `cargo nextest run -p godly-daemon --test pause_resume` — 2/2 pass
- [x] `cargo nextest run -p godly-daemon --test test_isolation_guardrail` — passes
- [x] `npx tsc --noEmit` — TypeScript clean
- [x] `npm test` — 768/768 frontend tests pass

Fixes #263