### PR TITLE
feat: mobile navigation buttons + smart select menu detection

### DIFF
--- a/src-tauri/remote/src/detection.rs
+++ b/src-tauri/remote/src/detection.rs
@@ -11,7 +11,19 @@ const DEFAULT_PATTERNS: &[(&str, &str)] = &[
     (r"Allow .+ to run", "tool_approval"),
     (r"Approve\?", "tool_approval"),
     (r"\[Y/n\]", "yes_no_prompt"),
+    (r"Enter to select.*to navigate", "select_menu"),
 ];
+
+/// A single option in a select menu.
+#[derive(Debug, Clone, Serialize)]
+pub struct SelectMenuOption {
+    /// 0-based index of this option in the list.
+    pub index: usize,
+    /// Display label (e.g. "Full snapshot (Recommended)").
+    pub label: String,
+    /// Whether this option is currently highlighted (has the `>` cursor).
+    pub selected: bool,
+}
 
 /// A detected prompt with metadata.
 #[derive(Debug, Clone, Serialize)]
@@ -19,6 +31,9 @@ pub struct DetectedPrompt {
     pub matched_pattern: String,
     pub prompt_type: String,
     pub context_text: String,
+    /// For `select_menu` prompts, the parsed options with their selection state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub menu_options: Option<Vec<SelectMenuOption>>,
 }
 
 /// Compiled set of patterns for detecting prompts in terminal output.
@@ -45,10 +60,16 @@ impl PromptDetector {
     pub fn detect(&self, text: &str) -> Option<DetectedPrompt> {
         for (regex, source, type_label) in &self.patterns {
             if regex.is_match(text) {
+                let menu_options = if type_label == "select_menu" {
+                    Some(parse_select_menu(text))
+                } else {
+                    None
+                };
                 return Some(DetectedPrompt {
                     matched_pattern: source.clone(),
                     prompt_type: type_label.clone(),
                     context_text: text.to_string(),
+                    menu_options,
                 });
             }
         }
@@ -60,15 +81,57 @@ impl PromptDetector {
         let mut results = Vec::new();
         for (regex, source, type_label) in &self.patterns {
             if regex.is_match(text) {
+                let menu_options = if type_label == "select_menu" {
+                    Some(parse_select_menu(text))
+                } else {
+                    None
+                };
                 results.push(DetectedPrompt {
                     matched_pattern: source.clone(),
                     prompt_type: type_label.clone(),
                     context_text: text.to_string(),
+                    menu_options,
                 });
             }
         }
         results
     }
+}
+
+/// Parse a Claude Code select menu from terminal output.
+///
+/// Looks for lines matching `> N. Label` (selected) or `  N. Label` (unselected).
+/// Returns the list of options with their selection state.
+fn parse_select_menu(text: &str) -> Vec<SelectMenuOption> {
+    // Match lines like:  "> 1. Full snapshot (Recommended)"  or  "  2. Daemon-level only"
+    // The `>` prefix indicates the currently selected option.
+    // Also handle cases where the `>` may have varying whitespace.
+    let option_re = Regex::new(r"(?m)^[>\s]{0,4}\s*(\d+)\.\s+(.+?)$").unwrap();
+    let selected_re = Regex::new(r"(?m)^>\s*(\d+)\.").unwrap();
+
+    // Find which option number is selected (has `>` prefix)
+    let selected_num: Option<u32> = selected_re.captures(text).and_then(|c| {
+        c.get(1).and_then(|m| m.as_str().parse().ok())
+    });
+
+    let mut options = Vec::new();
+    for (idx, cap) in option_re.captures_iter(text).enumerate() {
+        let num: u32 = cap[1].parse().unwrap_or(0);
+        let label = cap[2].trim().to_string();
+
+        // Skip the "Enter to select" footer line if it accidentally matches
+        if label.contains("to navigate") || label.contains("to cancel") {
+            continue;
+        }
+
+        options.push(SelectMenuOption {
+            index: idx,
+            label,
+            selected: selected_num == Some(num),
+        });
+    }
+
+    options
 }
 
 #[cfg(test)]
@@ -148,5 +211,57 @@ mod tests {
         // Text that matches both yes_no and tool_approval
         let result = detector.detect_all("Do you want to allow this? (Y)es (N)o");
         assert!(result.len() >= 2);
+    }
+
+    #[test]
+    fn detects_select_menu() {
+        let detector = PromptDetector::new();
+        let text = r#"What level of detail?
+
+> 1. Full snapshot (Recommended)
+  2. Daemon-level only
+  3. Per-session only
+  4. Type something.
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"#;
+
+        let result = detector.detect(text);
+        assert!(result.is_some());
+        let det = result.unwrap();
+        assert_eq!(det.prompt_type, "select_menu");
+        assert!(det.menu_options.is_some());
+
+        let opts = det.menu_options.unwrap();
+        assert_eq!(opts.len(), 4);
+        assert_eq!(opts[0].label, "Full snapshot (Recommended)");
+        assert!(opts[0].selected);
+        assert_eq!(opts[1].label, "Daemon-level only");
+        assert!(!opts[1].selected);
+        assert_eq!(opts[2].label, "Per-session only");
+        assert!(!opts[2].selected);
+        assert_eq!(opts[3].label, "Type something.");
+        assert!(!opts[3].selected);
+    }
+
+    #[test]
+    fn select_menu_tracks_selected_option() {
+        let text = r#"  1. Option A
+> 2. Option B
+  3. Option C
+
+Enter to select · ↑/↓ to navigate · Esc to cancel"#;
+
+        let opts = parse_select_menu(text);
+        assert_eq!(opts.len(), 3);
+        assert!(!opts[0].selected);
+        assert!(opts[1].selected);
+        assert!(!opts[2].selected);
+    }
+
+    #[test]
+    fn select_menu_empty_on_no_options() {
+        let text = "Enter to select · ↑/↓ to navigate · Esc to cancel";
+        let opts = parse_select_menu(text);
+        assert!(opts.is_empty());
     }
 }

--- a/src-tauri/remote/src/event_pump.rs
+++ b/src-tauri/remote/src/event_pump.rs
@@ -8,7 +8,7 @@ use tokio::sync::broadcast;
 use godly_protocol::{Request, Response};
 
 use crate::daemon_client::{async_request, DaemonClient};
-use crate::detection::PromptDetector;
+use crate::detection::{PromptDetector, SelectMenuOption};
 
 /// SSE event types.
 #[derive(Debug, Clone, Serialize)]
@@ -20,6 +20,8 @@ pub enum SseEvent {
         matched_pattern: String,
         prompt_type: String,
         context_text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        menu_options: Option<Vec<SelectMenuOption>>,
     },
     #[serde(rename = "prompt_resolved")]
     PromptResolved {
@@ -120,6 +122,7 @@ impl EventPump {
                                 matched_pattern: det.matched_pattern.clone(),
                                 prompt_type: det.prompt_type.clone(),
                                 context_text: det.context_text.clone(),
+                                menu_options: det.menu_options.clone(),
                             });
                         }
                         (None, Some(_)) => {
@@ -140,6 +143,7 @@ impl EventPump {
                                 matched_pattern: det.matched_pattern.clone(),
                                 prompt_type: det.prompt_type.clone(),
                                 context_text: det.context_text.clone(),
+                                menu_options: det.menu_options.clone(),
                             });
                         }
                         _ => {

--- a/src-tauri/remote/src/routes/prompts.rs
+++ b/src-tauri/remote/src/routes/prompts.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use godly_protocol::{Request, Response};
 
 use crate::daemon_client::async_request;
-use crate::detection::PromptDetector;
+use crate::detection::{PromptDetector, SelectMenuOption};
 use crate::AppState;
 
 #[derive(Serialize)]
@@ -15,6 +15,8 @@ pub struct PromptItem {
     pub matched_pattern: String,
     pub prompt_type: String,
     pub context_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub menu_options: Option<Vec<SelectMenuOption>>,
 }
 
 #[derive(Serialize)]
@@ -59,6 +61,7 @@ pub async fn list_prompts(
                 matched_pattern: det.matched_pattern,
                 prompt_type: det.prompt_type,
                 context_text: det.context_text,
+                menu_options: det.menu_options,
             });
         }
     }
@@ -99,6 +102,7 @@ pub async fn session_prompts(
             matched_pattern: det.matched_pattern,
             prompt_type: det.prompt_type,
             context_text: det.context_text,
+            menu_options: det.menu_options,
         }],
         None => Vec::new(),
     };

--- a/src-tauri/remote/static/phone.html
+++ b/src-tauri/remote/static/phone.html
@@ -162,7 +162,7 @@
     border-radius: 8px; font-size: 16px; cursor: pointer;
   }
   .send-btn:active { background: var(--accent); }
-  .quick-actions { display: flex; gap: 6px; }
+  .quick-actions { display: flex; gap: 6px; flex-wrap: wrap; }
   .quick-btn {
     min-height: 40px; padding: 0 16px;
     background: var(--bg-input); border: 1px solid var(--border);
@@ -171,6 +171,37 @@
     cursor: pointer;
   }
   .quick-btn:active { background: var(--border); }
+
+  /* --- Select Menu Cards --- */
+  .menu-card {
+    background: var(--bg-card); border: 1px solid var(--accent-dim);
+    border-radius: var(--radius); padding: 16px; margin-bottom: 12px;
+  }
+  .menu-card .alert-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+  .menu-card .menu-question {
+    font-size: 14px; font-weight: 600; color: var(--text); margin-bottom: 12px;
+  }
+  .menu-options { display: flex; flex-direction: column; gap: 6px; }
+  .menu-option-btn {
+    display: flex; align-items: center; gap: 10px;
+    width: 100%; min-height: var(--touch-min); padding: 10px 14px;
+    background: var(--bg-input); border: 1px solid var(--border);
+    border-radius: 8px; color: var(--text); font-size: 14px;
+    text-align: left; cursor: pointer; transition: border-color 0.15s;
+  }
+  .menu-option-btn:active { background: var(--border); }
+  .menu-option-btn.selected {
+    border-color: var(--accent); background: rgba(88, 166, 255, 0.08);
+  }
+  .menu-option-num {
+    min-width: 24px; height: 24px; border-radius: 6px;
+    background: var(--bg); display: flex; align-items: center; justify-content: center;
+    font-size: 12px; font-weight: 700; color: var(--text-dim); flex-shrink: 0;
+  }
+  .menu-option-btn.selected .menu-option-num {
+    background: var(--accent-dim); color: #fff;
+  }
+  .menu-option-label { flex: 1; line-height: 1.3; }
 
   /* --- Settings --- */
   .settings-group {
@@ -263,6 +294,10 @@
     <button class="quick-btn" onclick="sendQuick('y')">y</button>
     <button class="quick-btn" onclick="sendQuick('n')">n</button>
     <button class="quick-btn" onclick="sendQuick('\r')">Enter</button>
+    <button class="quick-btn" onclick="sendArrow('up')">&#9650;</button>
+    <button class="quick-btn" onclick="sendArrow('down')">&#9660;</button>
+    <button class="quick-btn" onclick="sendEsc()">Esc</button>
+    <button class="quick-btn" onclick="sendTab()">Tab</button>
     <button class="quick-btn" onclick="sendCtrlC()">Ctrl+C</button>
   </div>
 </div>
@@ -392,7 +427,16 @@ function renderAlerts(prompts) {
     return;
   }
 
-  container.innerHTML = prompts.map(p => `
+  container.innerHTML = prompts.map(p => {
+    if (p.prompt_type === 'select_menu' && p.menu_options && p.menu_options.length > 0) {
+      return renderMenuCard(p);
+    }
+    return renderStandardAlert(p);
+  }).join('');
+}
+
+function renderStandardAlert(p) {
+  return `
     <div class="alert-card">
       <div class="alert-header">
         <span class="alert-badge">${escHtml(p.prompt_type)}</span>
@@ -403,8 +447,40 @@ function renderAlerts(prompts) {
         <button class="btn-approve" onclick="sendToSession('${escAttr(p.session_id)}', 'y\\r')">Approve</button>
         <button class="btn-deny" onclick="sendToSession('${escAttr(p.session_id)}', 'n\\r')">Deny</button>
       </div>
-    </div>
+    </div>`;
+}
+
+function renderMenuCard(p) {
+  // Find the currently selected option index
+  const selectedIdx = p.menu_options.findIndex(o => o.selected);
+  const currentSel = selectedIdx >= 0 ? selectedIdx : 0;
+
+  // Extract question text from context (lines before the first option)
+  const lines = (p.context_text || '').split('\n');
+  let question = '';
+  for (const line of lines) {
+    if (/^\s*>?\s*\d+\./.test(line)) break;
+    const trimmed = line.trim();
+    if (trimmed) question = trimmed;
+  }
+
+  const optionButtons = p.menu_options.map((opt, idx) => `
+    <button class="menu-option-btn${opt.selected ? ' selected' : ''}"
+            onclick="selectMenuOption('${escAttr(p.session_id)}', ${idx}, ${currentSel})">
+      <span class="menu-option-num">${idx + 1}</span>
+      <span class="menu-option-label">${escHtml(opt.label)}</span>
+    </button>
   `).join('');
+
+  return `
+    <div class="menu-card">
+      <div class="alert-header">
+        <span class="alert-badge">Select</span>
+        <span class="alert-session">${escHtml(p.session_id.slice(0, 8))}...</span>
+      </div>
+      ${question ? `<div class="menu-question">${escHtml(question)}</div>` : ''}
+      <div class="menu-options">${optionButtons}</div>
+    </div>`;
 }
 
 function renderWorkspaces(workspaces) {
@@ -480,9 +556,42 @@ async function sendQuick(text) {
   await sendToSession(currentSessionId, text);
 }
 
+async function sendArrow(direction) {
+  if (!currentSessionId) return;
+  // ANSI escape sequences for arrow keys
+  const seq = direction === 'up' ? '\x1b[A' : '\x1b[B';
+  await sendToSession(currentSessionId, seq);
+}
+
+async function sendEsc() {
+  if (!currentSessionId) return;
+  await sendToSession(currentSessionId, '\x1b');
+}
+
+async function sendTab() {
+  if (!currentSessionId) return;
+  await sendToSession(currentSessionId, '\t');
+}
+
 async function sendCtrlC() {
   if (!currentSessionId) return;
   await sendToSession(currentSessionId, '\x03');
+}
+
+async function selectMenuOption(sessionId, targetIndex, currentSelectedIndex) {
+  // Calculate the arrow key sequence to reach the target option from the current selection
+  const delta = targetIndex - currentSelectedIndex;
+  let seq = '';
+  if (delta > 0) {
+    // Move down
+    for (let i = 0; i < delta; i++) seq += '\x1b[B';
+  } else if (delta < 0) {
+    // Move up
+    for (let i = 0; i < Math.abs(delta); i++) seq += '\x1b[A';
+  }
+  // Press Enter to confirm
+  seq += '\r';
+  await sendToSession(sessionId, seq);
 }
 
 async function sendToSession(sid, text) {


### PR DESCRIPTION
## Summary
- Add arrow key (↑↓), Esc, and Tab quick buttons to the mobile remote UI for manual TUI navigation
- Extend prompt detection to recognize Claude Code's interactive select menus (`AskUserQuestion`)
- Render detected menus as tappable option cards on the mobile dashboard — tapping computes the arrow key delta and sends the correct escape sequence + Enter

## Changes
- **`detection.rs`**: New `select_menu` pattern + `parse_select_menu()` parser that extracts numbered options and tracks the `>` cursor position
- **`prompts.rs`**: Extended `PromptItem` with optional `menu_options` field
- **`event_pump.rs`**: Extended `SseEvent::PromptDetected` with `menu_options` for real-time SSE push
- **`phone.html`**: Added ↑↓/Esc/Tab buttons, `sendArrow()`/`sendEsc()`/`sendTab()` functions, `selectMenuOption()` with delta computation, and `renderMenuCard()` for tappable option cards

## Test plan
- [x] All 74 godly-remote tests pass (including 3 new: `detects_select_menu`, `select_menu_tracks_selected_option`, `select_menu_empty_on_no_options`)
- [ ] Manual: open mobile UI, navigate to a terminal running Claude Code with an active `AskUserQuestion` prompt
- [ ] Verify numbered options render as tappable cards on the dashboard
- [ ] Verify tapping an option correctly navigates and selects it
- [ ] Verify ↑↓/Esc/Tab buttons work in the session view for manual navigation

Fixes #288