### PR TITLE
fix: prevent notification sound overlap from multiple sources

### DIFF
--- a/src/plugins/event-bus.test.ts
+++ b/src/plugins/event-bus.test.ts
@@ -110,7 +110,8 @@ describe('PluginEventBus', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('emits both classified and notification events for classified messages', () => {
+  it('emits only the classified event (no redundant notification) for classified messages', () => {
+    // Bug #289: Previously emitted both classified AND notification, causing double sounds
     const errorHandler = vi.fn();
     const notifHandler = vi.fn();
     bus.on('agent:error', errorHandler);
@@ -119,8 +120,8 @@ describe('PluginEventBus', () => {
     bus.emitMcpNotify('t1', 'Build failed');
 
     expect(errorHandler).toHaveBeenCalledTimes(1);
-    // Also emits a generic notification
-    expect(notifHandler).toHaveBeenCalledTimes(1);
+    // Should NOT emit a redundant notification event
+    expect(notifHandler).not.toHaveBeenCalled();
   });
 
   it('removeAllHandlers clears all subscriptions', () => {

--- a/src/plugins/event-bus.ts
+++ b/src/plugins/event-bus.ts
@@ -77,30 +77,20 @@ export class PluginEventBus {
   /**
    * Classify an mcp-notify message and emit the appropriate event.
    * Returns the emit result so callers can check if sound was handled.
+   *
+   * Bug #289: Previously emitted both the classified event AND a generic
+   * 'notification' event, causing plugins subscribed to both to fire twice
+   * (double sound play). Now only emits the classified event.
    */
   emitMcpNotify(terminalId: string, message: string | null): EmitResult {
     const classifiedType = classifyMessage(message);
 
-    // First emit the classified event
-    const classifiedResult = this.emit({
+    return this.emit({
       type: classifiedType,
       terminalId,
       message: message ?? undefined,
       timestamp: Date.now(),
     });
-
-    // If the classified type is different from 'notification', also emit
-    // a generic 'notification' event (but only for non-sound purposes)
-    if (classifiedType !== 'notification') {
-      this.emit({
-        type: 'notification',
-        terminalId,
-        message: message ?? undefined,
-        timestamp: Date.now(),
-      });
-    }
-
-    return classifiedResult;
   }
 
   removeAllHandlers(): void {

--- a/src/plugins/notification-sound-overlap.test.ts
+++ b/src/plugins/notification-sound-overlap.test.ts
@@ -187,12 +187,11 @@ describe('Bug #289: Notification sound overlap', () => {
   });
 
   describe('Sub-bug 2: No global sound throttle across terminals', () => {
-    it('should coalesce sounds when multiple terminals notify within a short window', () => {
+    it('should coalesce sounds when multiple terminals notify within a short window', async () => {
       // Bug #289: When multiple terminals go idle simultaneously, each fires
       // its own notification. The store debounces per-terminal (2s) but there
       // is no global cross-terminal debounce.
 
-      // Re-import fresh store
       vi.resetModules();
       vi.stubGlobal('localStorage', {
         getItem: (key: string) => storage.get(key) ?? null,
@@ -201,25 +200,29 @@ describe('Bug #289: Notification sound overlap', () => {
         clear: () => storage.clear(),
       });
 
-      // Simulate the notification flow from App.ts where each recordNotify
-      // triggers a sound play
-      const soundPlayCount = { value: 0 };
+      vi.mock('../services/notification-sound', () => ({
+        isBuiltinPreset: (s: string) => ['chime', 'bell'].includes(s),
+        isCustomPreset: (s: string) => s.startsWith('custom:'),
+      }));
+
+      const { notificationStore } = await import('../state/notification-store');
 
       // Simulate 5 terminals going idle at the exact same time
       const terminals = ['term-1', 'term-2', 'term-3', 'term-4', 'term-5'];
+      let soundPlayCount = 0;
 
-      // Each terminal's recordNotify returns true (not debounced) because
-      // each has its own independent debounce timer
-      for (const _termId of terminals) {
-        // In real code: notificationStore.recordNotify(termId) returns true
-        // because it's per-terminal debounce. Then playNotificationSound is called.
-        // We simulate the effect:
-        soundPlayCount.value++;
+      for (const termId of terminals) {
+        const played = notificationStore.recordNotify(termId);
+        if (played) soundPlayCount++;
       }
 
-      // BUG: All 5 sounds play simultaneously. Expected: at most 1 sound
-      // (or sounds spaced out with minimum interval between them).
-      expect(soundPlayCount.value).toBeLessThanOrEqual(1);
+      // With global debounce: at most 1 sound plays
+      expect(soundPlayCount).toBeLessThanOrEqual(1);
+
+      // But all 5 terminals should still have badges
+      for (const termId of terminals) {
+        expect(notificationStore.hasBadge(termId)).toBe(true);
+      }
     });
 
     it('notificationStore.recordNotify should have a global debounce across all terminals', async () => {
@@ -257,40 +260,46 @@ describe('Bug #289: Notification sound overlap', () => {
   });
 
   describe('Sub-bug 3: playBuffer has no overlap prevention', () => {
-    it('should not allow multiple AudioBufferSourceNodes to start simultaneously', () => {
+    it('should throttle rapid calls to playBuffer', async () => {
       // Bug #289: playBuffer creates a new source and calls start() every time.
       // Concurrent calls produce overlapping audio with no rate-limiting.
 
-      const startCalls: number[] = [];
-      const mockCtx = {
-        currentTime: 0,
-        createBufferSource: vi.fn().mockImplementation(() => ({
-          connect: vi.fn(),
-          start: vi.fn().mockImplementation(() => startCalls.push(Date.now())),
-          buffer: null,
-        })),
-        createGain: vi.fn().mockReturnValue({
-          connect: vi.fn(),
-          gain: { value: 1, setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() },
-        }),
+      // Get the REAL module via importActual (bypasses the vi.mock at the top)
+      const real = await vi.importActual<typeof import('../services/notification-sound')>(
+        '../services/notification-sound'
+      );
+
+      // Mock the AudioContext globally so the real playBuffer can use it
+      const startSpy = vi.fn();
+      const mockSource = {
+        connect: vi.fn(),
+        start: startSpy,
+        buffer: null as AudioBuffer | null,
+      };
+      const mockGain = {
+        connect: vi.fn(),
+        gain: { value: 1 },
+      };
+      const mockAudioCtx = {
+        createBufferSource: vi.fn().mockReturnValue(mockSource),
+        createGain: vi.fn().mockReturnValue(mockGain),
         destination: {},
-        state: 'running',
+        state: 'running' as AudioContextState,
         resume: vi.fn(),
       };
+      vi.stubGlobal('AudioContext', vi.fn().mockImplementation(() => mockAudioCtx));
 
-      // Simulate what playBuffer does: create source → connect → start
-      // Call it 5 times in rapid succession (as happens with overlapping notifications)
+      real._resetPlayThrottle();
+
+      const mockBuffer = { duration: 1 } as AudioBuffer;
+
+      // Call playBuffer 5 times in rapid succession
       for (let i = 0; i < 5; i++) {
-        const source = mockCtx.createBufferSource();
-        const gain = mockCtx.createGain();
-        source.connect(gain);
-        gain.connect(mockCtx.destination);
-        source.start();
+        real.playBuffer(mockBuffer, 0.5);
       }
 
-      // BUG: All 5 sounds start simultaneously. Expected: only 1 should play,
-      // or sounds should be queued with minimum spacing.
-      expect(startCalls).toHaveLength(1);
+      // With throttle: only 1 should actually start
+      expect(startSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/notification-sound.ts
+++ b/src/services/notification-sound.ts
@@ -17,8 +17,24 @@ export function getSharedAudioContext(): AudioContext {
   return getAudioContext();
 }
 
+/**
+ * Bug #289: Minimum interval between sound plays to prevent overlapping audio.
+ * Acts as defense-in-depth alongside the notification store's global debounce.
+ */
+const MIN_PLAY_INTERVAL_MS = 500;
+let lastPlayTime = 0;
+
+/** For testing: reset the play throttle state */
+export function _resetPlayThrottle(): void {
+  lastPlayTime = 0;
+}
+
 /** Play an AudioBuffer at the given volume (for plugin reuse) */
 export function playBuffer(buffer: AudioBuffer, volume: number): void {
+  const now = Date.now();
+  if (now - lastPlayTime < MIN_PLAY_INTERVAL_MS) return;
+  lastPlayTime = now;
+
   const ctx = getAudioContext();
   const source = ctx.createBufferSource();
   source.buffer = buffer;
@@ -93,6 +109,11 @@ export async function playNotificationSound(
   preset: SoundPreset = 'chime',
   volume: number = 0.5,
 ): Promise<void> {
+  // Bug #289: Throttle at the audio layer as defense-in-depth
+  const now = Date.now();
+  if (now - lastPlayTime < MIN_PLAY_INTERVAL_MS) return;
+  lastPlayTime = now;
+
   if (isCustomPreset(preset)) {
     try {
       const filename = getCustomFilename(preset);

--- a/src/state/notification-store.ts
+++ b/src/state/notification-store.ts
@@ -4,6 +4,8 @@ import { globMatch } from '../utils/glob-match';
 const STORAGE_KEY = 'godly-notification-settings';
 const WORKSPACE_MUTE_KEY = 'godly-workspace-mute-settings';
 const DEBOUNCE_MS = 2000;
+/** Bug #289: Global debounce across all terminals to prevent overlapping sounds */
+const GLOBAL_SOUND_DEBOUNCE_MS = 500;
 
 export interface NotificationSettings {
   globalEnabled: boolean;
@@ -37,6 +39,9 @@ class NotificationStore {
 
   /** Debounce: terminal_id → last notify timestamp */
   private lastNotify: Map<string, number> = new Map();
+
+  /** Bug #289: Global sound debounce — timestamp of last sound-eligible notification */
+  private lastGlobalSoundTime = 0;
 
   private subscribers: Subscriber[] = [];
 
@@ -102,12 +107,31 @@ class NotificationStore {
 
   // ── Mutations ────────────────────────────────────────────────────
 
-  /** Record a notification event and add badge. Returns false if debounced. */
+  /**
+   * Record a notification event and add badge.
+   * Returns false if debounced (per-terminal or global sound debounce).
+   * Badge is always added regardless of debounce result.
+   *
+   * Bug #289: Added global sound debounce so simultaneous notifications from
+   * different terminals don't each play a sound.
+   */
   recordNotify(terminalId: string): boolean {
+    // Per-terminal debounce: suppress repeated notifications from the same terminal
     if (this.isDebounced(terminalId)) return false;
-    this.lastNotify.set(terminalId, Date.now());
+
+    const now = Date.now();
+    this.lastNotify.set(terminalId, now);
+
+    // Always add badge regardless of global sound debounce
     this.badgedTerminals.add(terminalId);
     this.notify();
+
+    // Global sound debounce: suppress simultaneous sounds from different terminals
+    if (now - this.lastGlobalSoundTime < GLOBAL_SOUND_DEBOUNCE_MS) {
+      return false;
+    }
+
+    this.lastGlobalSoundTime = now;
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fixes #289 — notification sounds overlapping when multiple notifications fire simultaneously.

**Three root causes fixed:**

- **event-bus double emission**: `emitMcpNotify()` emitted both the classified event (e.g., `agent:error`) AND a redundant `notification` event. PeonPing subscribes to all categories, so it played **two sounds per notification**. Fix: only emit the classified event.

- **No global sound debounce**: `notificationStore.recordNotify()` only debounced per-terminal (2s). When 5+ terminals went idle simultaneously, 5+ sounds played at once. Fix: added 500ms global debounce across all terminals. Badges still light up for every terminal.

- **No audio throttle**: `playBuffer()` and `playNotificationSound()` created new `AudioBufferSourceNode`s and started them immediately with no rate-limiting. Fix: added 500ms throttle as defense-in-depth.

## Test plan

- [x] 5 reproduction tests in `src/plugins/notification-sound-overlap.test.ts` all pass (were red before fix)
- [x] All 49 existing tests in affected files pass (event-bus, peon-ping, notification-store, App.notification)
- [x] Full frontend suite: 773/773 tests pass
- [x] `tsc --noEmit` passes