### PR TITLE
feat: clipboard image paste for terminal

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -127,6 +127,33 @@ pub fn write_remote_config(config: serde_json::Value) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub fn save_clipboard_image(image_data: Vec<u8>, extension: String) -> Result<String, String> {
+    use std::time::SystemTime;
+
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|e| format!("Failed to get timestamp: {e}"))?
+        .as_millis();
+
+    // Sanitize extension to prevent path traversal
+    let ext = extension
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>();
+    let ext = if ext.is_empty() { "png".to_string() } else { ext };
+
+    let filename = format!("godly-clipboard-{timestamp}.{ext}");
+    let path = std::env::temp_dir().join(filename);
+
+    std::fs::write(&path, &image_data)
+        .map_err(|e| format!("Failed to write clipboard image: {e}"))?;
+
+    path.to_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| "Invalid path encoding".to_string())
+}
+
+#[tauri::command]
 pub fn get_user_claude_md_path() -> Result<String, String> {
     let home = std::env::var("USERPROFILE")
         .or_else(|_| std::env::var("HOME"))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -395,6 +395,7 @@ pub fn run() {
             persistence::save_scrollback,
             persistence::load_scrollback,
             persistence::delete_scrollback,
+            commands::save_clipboard_image,
             commands::write_remote_config,
             scrollback_save_complete,
         ])

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -361,15 +361,11 @@ export class TerminalPane {
       return;
     }
 
-    // Paste: paste from clipboard into terminal
+    // Paste: paste from clipboard into terminal (supports images)
     if (action === 'clipboard.paste') {
       event.preventDefault();
       this.snapToBottom();
-      navigator.clipboard.readText().then((text) => {
-        if (text) {
-          terminalService.writeToTerminal(this.terminalId, text);
-        }
-      });
+      this.handleClipboardPaste();
       return;
     }
 
@@ -544,6 +540,42 @@ export class TerminalPane {
   }
 
   /** Snap viewport back to live view (offset 0). */
+  private async handleClipboardPaste() {
+    try {
+      const items = await navigator.clipboard.read();
+      for (const item of items) {
+        const imageType = item.types.find((t) => t.startsWith('image/'));
+        if (imageType) {
+          const blob = await item.getType(imageType);
+          const buffer = await blob.arrayBuffer();
+          const bytes = Array.from(new Uint8Array(buffer));
+          const ext = imageType.split('/')[1] || 'png';
+          const path = await invoke<string>('save_clipboard_image', {
+            imageData: bytes,
+            extension: ext,
+          });
+          terminalService.writeToTerminal(this.terminalId, path);
+          return;
+        }
+      }
+      // No image found — fall back to text paste
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        terminalService.writeToTerminal(this.terminalId, text);
+      }
+    } catch {
+      // clipboard.read() may not be available — fall back to text
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text) {
+          terminalService.writeToTerminal(this.terminalId, text);
+        }
+      } catch {
+        // Clipboard not available at all
+      }
+    }
+  }
+
   private snapToBottom() {
     if (this.scrollbackOffset === 0) return;
     // Bug #242: adjust selection before resetting offset


### PR DESCRIPTION
## Summary

- Add `save_clipboard_image` Tauri command that saves image bytes to `%TEMP%/godly-clipboard-{timestamp}.{ext}` with extension sanitization
- Extend `TerminalPane` paste handler to detect clipboard images via `navigator.clipboard.read()` and paste the saved file path
- Falls back to `readText()` when no image is present or when the Clipboard API is unavailable

Fixes #297

## Test plan

- [ ] Copy an image to clipboard (ShareX, Win+Shift+S, or browser right-click copy)
- [ ] Ctrl+Shift+V in a terminal pane → should paste a temp file path like `C:\Users\...\Temp\godly-clipboard-1234567890.png`
- [ ] In a Claude Code session, verify the pasted path is readable as an image
- [ ] Copy text to clipboard → Ctrl+Shift+V → should paste text as before
- [ ] Drag-drop an image file onto the terminal → should continue to work unchanged