### PR TITLE
fix: detect session death on phone remote

### DIFF
--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -1271,6 +1271,25 @@ async fn handle_request(
         }
 
         Request::Write { session_id, data } => {
+            // Pre-check: reject writes to dead or missing sessions immediately
+            // so remote clients get actionable errors instead of silent success.
+            {
+                let sessions_guard = sessions.read();
+                match sessions_guard.get(session_id) {
+                    None => {
+                        return Response::Error {
+                            message: format!("Session {} not found", session_id),
+                        };
+                    }
+                    Some(session) if !session.is_running() => {
+                        return Response::Error {
+                            message: format!("Session {} has exited", session_id),
+                        };
+                    }
+                    _ => {}
+                }
+            }
+
             // Fire-and-forget: spawn_blocking so write_all() never blocks
             // the async handler or the I/O thread. This breaks the circular
             // deadlock when ConPTY input fills during heavy output.
@@ -1328,6 +1347,7 @@ async fn handle_request(
                 Some(session) => Response::LastOutputTime {
                     epoch_ms: session.last_output_epoch_ms(),
                     running: session.is_running(),
+                    exit_code: session.exit_code(),
                 },
                 None => Response::Error {
                     message: format!("Session {} not found", session_id),

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -348,7 +348,7 @@ impl Backend for DaemonDirectBackend {
                     })?;
 
                     match resp {
-                        Response::LastOutputTime { epoch_ms, running } => {
+                        Response::LastOutputTime { epoch_ms, running, .. } => {
                             let now_ms = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
@@ -523,6 +523,7 @@ impl Backend for DaemonDirectBackend {
                         Response::LastOutputTime {
                             epoch_ms,
                             running: is_running,
+                            ..
                         } => {
                             let now_ms = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -87,7 +87,12 @@ pub enum Response {
     Pong,
     /// Initial buffer replay when attaching to a session
     Buffer { session_id: String, data: Vec<u8> },
-    LastOutputTime { epoch_ms: u64, running: bool },
+    LastOutputTime {
+        epoch_ms: u64,
+        running: bool,
+        #[serde(default)]
+        exit_code: Option<i64>,
+    },
     SearchResult { found: bool, running: bool },
     /// Grid snapshot from the godly-vt terminal state engine.
     Grid { grid: crate::types::GridData },
@@ -239,6 +244,58 @@ mod tests {
                 assert_eq!(exit_code, Some(1));
             }
             other => panic!("Expected ShellExited, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn last_output_time_with_exit_code_roundtrip() {
+        let resp = Response::LastOutputTime {
+            epoch_ms: 1700000000000,
+            running: false,
+            exit_code: Some(1),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"exit_code\":1"));
+        let deserialized: Response = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            Response::LastOutputTime { epoch_ms, running, exit_code } => {
+                assert_eq!(epoch_ms, 1700000000000);
+                assert!(!running);
+                assert_eq!(exit_code, Some(1));
+            }
+            other => panic!("Expected LastOutputTime, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn last_output_time_without_exit_code_backward_compat() {
+        // Simulate an older daemon that doesn't send exit_code
+        let json = r#"{"type":"LastOutputTime","epoch_ms":1700000000000,"running":true}"#;
+        let deserialized: Response = serde_json::from_str(json).unwrap();
+        match deserialized {
+            Response::LastOutputTime { epoch_ms, running, exit_code } => {
+                assert_eq!(epoch_ms, 1700000000000);
+                assert!(running);
+                assert_eq!(exit_code, None);
+            }
+            other => panic!("Expected LastOutputTime, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn last_output_time_none_exit_code_roundtrip() {
+        let resp = Response::LastOutputTime {
+            epoch_ms: 1700000000000,
+            running: true,
+            exit_code: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: Response = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            Response::LastOutputTime { exit_code, .. } => {
+                assert_eq!(exit_code, None);
+            }
+            other => panic!("Expected LastOutputTime, got {:?}", other),
         }
     }
 

--- a/src-tauri/remote/src/routes/quick_claude.rs
+++ b/src-tauri/remote/src/routes/quick_claude.rs
@@ -177,7 +177,7 @@ async fn poll_idle(
         .await;
 
         match resp {
-            Ok(Response::LastOutputTime { epoch_ms, running }) => {
+            Ok(Response::LastOutputTime { epoch_ms, running, .. }) => {
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()

--- a/src-tauri/remote/src/routes/sessions.rs
+++ b/src-tauri/remote/src/routes/sessions.rs
@@ -255,7 +255,7 @@ pub async fn get_idle(
     .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
 
     match resp {
-        Response::LastOutputTime { epoch_ms, running } => {
+        Response::LastOutputTime { epoch_ms, running, .. } => {
             let now_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -320,10 +320,14 @@ fn default_text_lines() -> usize {
 pub struct TextResponse {
     pub lines: Vec<String>,
     pub total_rows: usize,
+    pub running: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
 }
 
 /// GET /api/sessions/:id/text?lines=50
 /// Returns last N lines of terminal output as plain text (strips empty trailing lines).
+/// Includes `running` and `exit_code` so the phone UI can detect session death.
 pub async fn get_text(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -332,7 +336,7 @@ pub async fn get_text(
     let resp = async_request(
         &state.daemon,
         Request::ReadGrid {
-            session_id: id,
+            session_id: id.clone(),
         },
     )
     .await
@@ -352,7 +356,18 @@ pub async fn get_text(
             let n = query.lines.min(200).min(rows.len());
             let lines: Vec<String> = rows[rows.len().saturating_sub(n)..].to_vec();
 
-            Ok(Json(TextResponse { lines, total_rows }))
+            // Fetch session status (running/exit_code) via GetLastOutputTime
+            let (running, exit_code) = match async_request(
+                &state.daemon,
+                Request::GetLastOutputTime { session_id: id },
+            )
+            .await
+            {
+                Ok(Response::LastOutputTime { running, exit_code, .. }) => (running, exit_code),
+                _ => (true, None), // default to running if status check fails
+            };
+
+            Ok(Json(TextResponse { lines, total_rows, running, exit_code }))
         }
         Response::Error { message } => Err((StatusCode::BAD_REQUEST, message)),
         other => Err((
@@ -412,6 +427,33 @@ mod tests {
                 has_traversal
             );
         }
+    }
+
+    #[test]
+    fn text_response_includes_running_and_exit_code() {
+        let resp = super::TextResponse {
+            lines: vec!["hello".into()],
+            total_rows: 1,
+            running: true,
+            exit_code: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"running\":true"));
+        // exit_code should be omitted when None (skip_serializing_if)
+        assert!(!json.contains("exit_code"));
+    }
+
+    #[test]
+    fn text_response_with_exit_code() {
+        let resp = super::TextResponse {
+            lines: vec!["goodbye".into()],
+            total_rows: 1,
+            running: false,
+            exit_code: Some(137),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"running\":false"));
+        assert!(json.contains("\"exit_code\":137"));
     }
 
     #[test]

--- a/src-tauri/remote/static/phone.html
+++ b/src-tauri/remote/static/phone.html
@@ -438,6 +438,10 @@ function renderWorkspaces(workspaces) {
 // --- Session ---
 async function openSession(id, name) {
   currentSessionId = id;
+  // Reset input state when opening a new session
+  const field = document.getElementById('inputField');
+  field.disabled = false;
+  field.placeholder = 'Type command...';
   showView('session', name || id.slice(0, 8));
   await refreshSession();
 }
@@ -450,6 +454,18 @@ async function refreshSession() {
     const output = document.getElementById('sessionOutput');
     output.textContent = (data.lines || []).join('\n') || '(empty)';
     output.scrollTop = output.scrollHeight;
+
+    // Detect session death
+    if (data.running === false) {
+      const code = data.exit_code != null ? ` (exit code ${data.exit_code})` : '';
+      output.textContent += `\n\n--- Session ended${code} ---`;
+      output.scrollTop = output.scrollHeight;
+      // Disable input and stop polling
+      const field = document.getElementById('inputField');
+      field.disabled = true;
+      field.placeholder = 'Session ended';
+      stopSessionRefresh();
+    }
   } catch (e) {
     document.getElementById('sessionOutput').textContent = 'Error: ' + e.message;
   }
@@ -495,6 +511,19 @@ async function sendToSession(sid, text) {
     }, 300);
   } catch (e) {
     console.error('Write failed:', e);
+    // Detect dead session errors from daemon
+    const msg = e.message || '';
+    if (msg.includes('has exited') || msg.includes('not found')) {
+      const output = document.getElementById('sessionOutput');
+      if (output) {
+        output.textContent += '\n\n--- Session ended ---';
+        output.scrollTop = output.scrollHeight;
+      }
+      const field = document.getElementById('inputField');
+      field.disabled = true;
+      field.placeholder = 'Session ended';
+      stopSessionRefresh();
+    }
   }
 }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -612,7 +612,7 @@ fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, timeout_ms: 
             session_id: session_id.to_string(),
         };
         match daemon.send_request(&req) {
-            Ok(Response::LastOutputTime { epoch_ms, running }) => {
+            Ok(Response::LastOutputTime { epoch_ms, running, .. }) => {
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1009,6 +1009,7 @@ pub fn handle_mcp_request(
                     Ok(godly_protocol::Response::LastOutputTime {
                         epoch_ms,
                         running: is_running,
+                        ..
                     }) => {
                         let now_ms = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
@@ -1093,7 +1094,7 @@ pub fn handle_mcp_request(
                     session_id: terminal_id.clone(),
                 };
                 match daemon.send_request(&req) {
-                    Ok(godly_protocol::Response::LastOutputTime { epoch_ms, running }) => {
+                    Ok(godly_protocol::Response::LastOutputTime { epoch_ms, running, .. }) => {
                         let now_ms = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()


### PR DESCRIPTION
## Summary

- Add `exit_code` field to `Response::LastOutputTime` so the daemon reports session death status alongside output timestamps
- Update the remote `/sessions/:id/text` endpoint to include `running` and `exit_code` fields in the JSON response, enabling clients to detect dead sessions
- Add session death UI on `phone.html`: disables input, shows a "Session ended" message, and stops polling when a session is no longer running
- Add write pre-check in the daemon to return clear errors when writing to dead or missing sessions
- Update all `LastOutputTime` destructuring patterns across MCP, commands, and daemon_direct to accommodate the new field

Fixes #294

## Test plan

- [ ] Verify `protocol::messages` unit tests pass: `cargo nextest run -p godly-protocol`
- [ ] Verify `godly-remote` unit tests pass: `cargo nextest run -p godly-remote`
- [ ] Start a phone remote session, kill the shell process, and confirm the phone UI shows "Session ended" with input disabled
- [ ] Confirm writing to a dead session from the phone returns an error instead of silently failing
- [ ] Confirm existing MCP tools (`read_terminal`, `execute_command`) still work without regression after the `LastOutputTime` destructuring changes