### PR TITLE
feat: add terminal zoom in/out

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -472,6 +472,26 @@ export class App {
           break;
         }
 
+        case 'zoom.in': {
+          e.preventDefault();
+          const current = terminalSettingsStore.getFontSize();
+          terminalSettingsStore.setFontSize(current + 1);
+          break;
+        }
+
+        case 'zoom.out': {
+          e.preventDefault();
+          const current = terminalSettingsStore.getFontSize();
+          terminalSettingsStore.setFontSize(current - 1);
+          break;
+        }
+
+        case 'zoom.reset': {
+          e.preventDefault();
+          terminalSettingsStore.setFontSize(13);
+          break;
+        }
+
         case 'tabs.quickClaude': {
           e.preventDefault();
           if (!state.activeWorkspaceId) break;

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -1131,7 +1131,7 @@ export function showSettingsDialog(): Promise<void> {
     function renderShortcuts() {
       shortcutsContainer.textContent = '';
 
-      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace', 'Scroll', 'Debug'];
+      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace', 'Scroll', 'Zoom', 'Debug'];
 
       for (const category of categories) {
         const defs = DEFAULT_SHORTCUTS.filter((d) => {

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -25,6 +25,7 @@ export class TerminalPane {
   private unsubscribeOutput: (() => void) | null = null;
   private unsubscribeGridDiff: (() => void) | null = null;
   private unsubscribeTheme: (() => void) | null = null;
+  private unsubscribeFontSize: (() => void) | null = null;
 
   // Debounce grid snapshot requests: on terminal-output we schedule a snapshot
   // fetch via setTimeout(SNAPSHOT_MIN_INTERVAL_MS). Multiple output events
@@ -90,6 +91,13 @@ export class TerminalPane {
       this.renderer.setTheme(themeStore.getTerminalTheme());
     });
 
+    // Propagate font size changes to the renderer
+    this.unsubscribeFontSize = terminalSettingsStore.subscribe(() => {
+      const newSize = terminalSettingsStore.getFontSize();
+      this.renderer.setFontSize(newSize);
+      this.fit();
+    });
+
     // Forward OSC title changes to the store
     this.renderer.setOnTitleChange((title) => {
       store.updateTerminal(this.terminalId, { oscTitle: title || undefined });
@@ -108,6 +116,12 @@ export class TerminalPane {
     // When the user finishes a drag selection, catch up with any missed output
     this.renderer.setOnSelectionEnd(() => {
       this.fetchAndRenderSnapshot();
+    });
+
+    // Ctrl+wheel zoom: adjust font size
+    this.renderer.setOnZoom((delta) => {
+      const current = terminalSettingsStore.getFontSize();
+      terminalSettingsStore.setFontSize(current + delta);
     });
 
     this.container = document.createElement('div');
@@ -994,6 +1008,7 @@ export class TerminalPane {
       this.unsubscribeGridDiff();
     }
     this.unsubscribeTheme?.();
+    this.unsubscribeFontSize?.();
     this.renderer.dispose();
     this.container.remove();
   }

--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -16,6 +16,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { WebGLRenderer } from './renderer/WebGLRenderer';
 import { perfTracer } from '../utils/PerfTracer';
 import { themeStore } from '../state/theme-store';
+import { terminalSettingsStore } from '../state/terminal-settings-store';
 import type { TerminalTheme } from '../themes/types';
 
 export type { TerminalTheme } from '../themes/types';
@@ -117,7 +118,7 @@ export class TerminalRenderer {
 
   // Font metrics
   private fontFamily = 'Cascadia Code, Consolas, monospace';
-  private fontSize = 13;
+  private fontSize = terminalSettingsStore.getFontSize();
   private cellWidth = 0;
   private cellHeight = 0;
   private baselineOffset = 0;
@@ -166,6 +167,7 @@ export class TerminalRenderer {
   private onTitleChange?: (title: string) => void;
   private onScrollCallback?: (deltaLines: number) => void;
   private onScrollToCallback?: (absoluteOffset: number) => void;
+  private onZoomCallback?: (delta: number) => void;
 
   constructor(theme?: Partial<TerminalTheme>) {
     this.theme = theme ? { ...themeStore.getTerminalTheme(), ...theme } : themeStore.getTerminalTheme();
@@ -246,6 +248,25 @@ export class TerminalRenderer {
   setTheme(theme: TerminalTheme): void {
     this.theme = theme;
     this.repaint();
+  }
+
+  /** Update font size and re-measure. Triggers repaint. */
+  setFontSize(size: number): void {
+    if (size === this.fontSize) return;
+    this.fontSize = size;
+    if (this.useWebGL && this.webglRenderer) {
+      const metrics = this.webglRenderer.setFontSize(size);
+      this.cellWidth = metrics.cellWidth;
+      this.cellHeight = metrics.cellHeight;
+    } else {
+      this.measureFont();
+    }
+    this.repaint();
+  }
+
+  /** Set zoom callback. delta > 0 = zoom in, < 0 = zoom out. */
+  setOnZoom(cb: (delta: number) => void) {
+    this.onZoomCallback = cb;
   }
 
   /** Get the current grid dimensions in rows/cols based on canvas size. */
@@ -983,6 +1004,14 @@ export class TerminalRenderer {
   private setupWheelHandler() {
     this.canvas.addEventListener('wheel', (e) => {
       e.preventDefault();
+
+      // Ctrl+wheel: zoom in/out instead of scrolling
+      if (e.ctrlKey && this.onZoomCallback) {
+        const delta = e.deltaY < 0 ? 1 : -1;
+        this.onZoomCallback(delta);
+        return;
+      }
+
       if (!this.onScrollCallback) return;
 
       // Convert pixel delta to lines (3 lines per standard wheel tick of 100px)

--- a/src/components/renderer/GlyphAtlas.ts
+++ b/src/components/renderer/GlyphAtlas.ts
@@ -96,9 +96,10 @@ export class GlyphAtlas {
     }
   }
 
-  /** Invalidate entire atlas (e.g., on DPR change). Clears everything. */
-  invalidate(newDpr: number): void {
+  /** Invalidate entire atlas (e.g., on DPR or font size change). Clears everything. */
+  invalidate(newDpr: number, newFontSize?: number): void {
     this.dpr = newDpr;
+    if (newFontSize !== undefined) this.fontSize = newFontSize;
     this.glyphs.clear();
     this.shelfX = 0;
     this.shelfY = 0;

--- a/src/components/renderer/WebGLRenderer.ts
+++ b/src/components/renderer/WebGLRenderer.ts
@@ -203,6 +203,16 @@ export class WebGLRenderer {
     }
   }
 
+  setFontSize(size: number): { cellWidth: number; cellHeight: number } {
+    this.fontSize = size;
+    this.atlas.invalidate(this.dpr, size);
+    this.atlas.populateAscii();
+    const metrics = this.measureFont();
+    this.cellWidth = metrics.cellWidth;
+    this.cellHeight = metrics.cellHeight;
+    return metrics;
+  }
+
   measureFont(): { cellWidth: number; cellHeight: number } {
     const scaledSize = Math.round(this.fontSize * this.dpr);
     const canvas = new OffscreenCanvas(64, 64);

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -30,9 +30,12 @@ export type ActionId =
   | 'scroll.toBottom'
   | 'tabs.renameTerminal'
   | 'tabs.quickClaude'
+  | 'zoom.in'
+  | 'zoom.out'
+  | 'zoom.reset'
   | 'debug.togglePerfOverlay';
 
-export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll' | 'Debug';
+export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll' | 'Zoom' | 'Debug';
 
 /** Whether the shortcut is an app-level action or a terminal control key. */
 export type ShortcutType = 'app' | 'terminal-control';
@@ -201,6 +204,27 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Tabs',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'q' },
+  },
+  {
+    id: 'zoom.in',
+    label: 'Zoom In',
+    category: 'Zoom',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: false, key: '=' },
+  },
+  {
+    id: 'zoom.out',
+    label: 'Zoom Out',
+    category: 'Zoom',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: false, key: '-' },
+  },
+  {
+    id: 'zoom.reset',
+    label: 'Reset Zoom',
+    category: 'Zoom',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: false, key: '0' },
   },
   {
     id: 'debug.togglePerfOverlay',

--- a/src/state/terminal-settings-store.ts
+++ b/src/state/terminal-settings-store.ts
@@ -6,14 +6,21 @@ export interface TerminalSettings {
   defaultShell: ShellType;
   /** When true, new output snaps the view to bottom even when scrolled up. */
   autoScrollOnOutput: boolean;
+  /** Terminal font size in CSS pixels (clamped to 8–32). */
+  fontSize: number;
 }
 
 type Subscriber = () => void;
 
 class TerminalSettingsStore {
+  private static readonly DEFAULT_FONT_SIZE = 13;
+  private static readonly MIN_FONT_SIZE = 8;
+  private static readonly MAX_FONT_SIZE = 32;
+
   private settings: TerminalSettings = {
     defaultShell: { type: 'windows' },
     autoScrollOnOutput: false,
+    fontSize: TerminalSettingsStore.DEFAULT_FONT_SIZE,
   };
 
   private subscribers: Subscriber[] = [];
@@ -38,6 +45,21 @@ class TerminalSettingsStore {
 
   setAutoScrollOnOutput(enabled: boolean): void {
     this.settings.autoScrollOnOutput = enabled;
+    this.saveToStorage();
+    this.notify();
+  }
+
+  getFontSize(): number {
+    return this.settings.fontSize;
+  }
+
+  setFontSize(size: number): void {
+    const clamped = Math.max(
+      TerminalSettingsStore.MIN_FONT_SIZE,
+      Math.min(TerminalSettingsStore.MAX_FONT_SIZE, Math.round(size))
+    );
+    if (clamped === this.settings.fontSize) return;
+    this.settings.fontSize = clamped;
     this.saveToStorage();
     this.notify();
   }
@@ -68,6 +90,9 @@ class TerminalSettingsStore {
       }
       if (typeof data.autoScrollOnOutput === 'boolean') {
         this.settings.autoScrollOnOutput = data.autoScrollOnOutput;
+      }
+      if (typeof data.fontSize === 'number' && data.fontSize >= TerminalSettingsStore.MIN_FONT_SIZE && data.fontSize <= TerminalSettingsStore.MAX_FONT_SIZE) {
+        this.settings.fontSize = data.fontSize;
       }
     } catch {
       // Corrupt data — use defaults


### PR DESCRIPTION
## Summary

- Add `fontSize` setting to `TerminalSettingsStore` (persisted in localStorage, clamped 8–32px, default 13)
- Add `Ctrl+=` / `Ctrl+-` / `Ctrl+0` keyboard shortcuts for zoom in / out / reset
- Add `Ctrl+mousewheel` zoom support in the terminal canvas
- Font size changes propagate to all terminal panes via store subscription, triggering re-measure and resize for both Canvas2D and WebGL rendering paths
- GlyphAtlas invalidation on font size change ensures correct glyph rendering at new sizes
- Zoom shortcuts appear in Settings > Shortcuts under new "Zoom" category

## Files Changed

| File | Change |
|------|--------|
| `terminal-settings-store.ts` | `fontSize` field + `getFontSize()`/`setFontSize()` |
| `keybinding-store.ts` | `zoom.in`/`zoom.out`/`zoom.reset` actions + `Zoom` category |
| `WebGLRenderer.ts` | `setFontSize()` method |
| `GlyphAtlas.ts` | Accept optional `newFontSize` in `invalidate()` |
| `TerminalRenderer.ts` | `setFontSize()`, `setOnZoom()`, Ctrl+wheel handler |
| `TerminalPane.ts` | Subscribe to font size changes, wire zoom callback |
| `App.ts` | Handle zoom keyboard shortcuts |
| `SettingsDialog.ts` | Add Zoom to shortcut categories |

## Test plan

- [x] `npm test` — 768/768 tests pass
- [ ] Manual: `Ctrl+=` increases font size, `Ctrl+-` decreases, `Ctrl+0` resets to 13px
- [ ] Manual: `Ctrl+scroll` zooms in/out
- [ ] Manual: Font size persists across app restart
- [ ] Manual: All terminals update simultaneously on zoom
- [ ] Manual: Zoom shortcuts visible in Settings > Shortcuts > Zoom