### PR TITLE
fix: multi-screen selection copy

### DIFF
--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -1397,11 +1397,12 @@ async fn handle_request(
             start_col,
             end_row,
             end_col,
+            scrollback_offset,
         } => {
             let sessions_guard = sessions.read();
             match sessions_guard.get(session_id) {
                 Some(session) => {
-                    let text = session.read_grid_text(*start_row, *start_col, *end_row, *end_col);
+                    let text = session.read_grid_text(*start_row, *start_col, *end_row, *end_col, *scrollback_offset);
                     Response::GridText { text }
                 }
                 None => Response::Error {

--- a/src-tauri/daemon/src/session.rs
+++ b/src-tauri/daemon/src/session.rs
@@ -1302,16 +1302,34 @@ impl DaemonSession {
     }
 
     /// Read text between two grid positions (for selection/copy).
+    /// Row coordinates are viewport-relative (can be negative for multi-screen
+    /// selections). scrollback_offset is used to convert to absolute buffer
+    /// positions so the full selection range can be read across scrollback.
     pub fn read_grid_text(
         &self,
-        start_row: u16,
+        start_row: i32,
         start_col: u16,
-        end_row: u16,
+        end_row: i32,
         end_col: u16,
+        scrollback_offset: usize,
     ) -> String {
         let vt = self.vt_parser.lock();
         let screen = vt.screen();
-        screen.contents_between(start_row, start_col, end_row, end_col)
+        let scrollback_count = screen.scrollback_count();
+        let (grid_rows, _) = screen.size();
+
+        // Convert viewport-relative rows to absolute buffer positions.
+        // Absolute row 0 = oldest scrollback row.
+        // Viewport row 0 at scrollback_offset S maps to:
+        //   absolute = scrollback_count - S
+        let base = scrollback_count as i64 - scrollback_offset as i64;
+        let abs_start = (base + start_row as i64).max(0) as usize;
+        let total_rows = scrollback_count + usize::from(grid_rows);
+        let abs_end = (base + end_row as i64)
+            .max(0)
+            .min(total_rows as i64 - 1) as usize;
+
+        screen.contents_between_absolute(abs_start, start_col, abs_end, end_col)
     }
 
     /// Search the output history for a text string.

--- a/src-tauri/godly-vt/src/grid.rs
+++ b/src-tauri/godly-vt/src/grid.rs
@@ -157,6 +157,12 @@ impl Grid {
             )
     }
 
+    /// Returns all rows in order: scrollback (oldest first) then active grid.
+    /// Used for absolute-indexed text extraction across the full buffer.
+    pub fn all_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
+        self.scrollback.iter().chain(self.rows.iter())
+    }
+
     pub fn drawing_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
         self.rows.iter()
     }

--- a/src-tauri/godly-vt/src/screen.rs
+++ b/src-tauri/godly-vt/src/screen.rs
@@ -245,6 +245,65 @@ impl Screen {
         }
     }
 
+    /// Returns the text contents between two absolute row positions in the
+    /// combined scrollback + active grid buffer. Row 0 is the oldest
+    /// scrollback row; row `scrollback_count + grid_rows - 1` is the last
+    /// active grid row.
+    ///
+    /// This is used for multi-screen selections where the selected range
+    /// spans more rows than fit in a single viewport.
+    #[must_use]
+    pub fn contents_between_absolute(
+        &self,
+        start_row: usize,
+        start_col: u16,
+        end_row: usize,
+        end_col: u16,
+    ) -> String {
+        if start_row > end_row {
+            return String::new();
+        }
+        let (_, cols) = self.size();
+        let mut contents = String::new();
+        for (i, row) in self
+            .grid()
+            .all_rows()
+            .enumerate()
+            .skip(start_row)
+            .take(end_row - start_row + 1)
+        {
+            if i == start_row && i == end_row {
+                // Single row selection
+                if start_col < end_col {
+                    row.write_contents(
+                        &mut contents,
+                        start_col,
+                        end_col - start_col,
+                        false,
+                    );
+                }
+            } else if i == start_row {
+                row.write_contents(
+                    &mut contents,
+                    start_col,
+                    cols - start_col,
+                    false,
+                );
+                if !row.wrapped() {
+                    contents.push('\n');
+                }
+            } else if i == end_row {
+                row.write_contents(&mut contents, 0, end_col, false);
+            } else {
+                row.write_contents(&mut contents, 0, cols, false);
+                if !row.wrapped() {
+                    contents.push('\n');
+                }
+            }
+        }
+        contents
+    }
+
     /// Return escape codes sufficient to reproduce the entire contents of the
     /// current terminal state. This is a convenience wrapper around
     /// [`contents_formatted`](Self::contents_formatted) and

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -56,12 +56,16 @@ pub enum Request {
         session_id: String,
     },
     /// Read text between two grid positions (for selection/copy).
+    /// Row coordinates are viewport-relative (can be negative for selections
+    /// extending above the viewport). scrollback_offset is needed to convert
+    /// to absolute buffer positions for multi-screen selections.
     ReadGridText {
         session_id: String,
-        start_row: u16,
+        start_row: i32,
         start_col: u16,
-        end_row: u16,
+        end_row: i32,
         end_col: u16,
+        scrollback_offset: usize,
     },
     /// Read differential rich grid snapshot (only dirty rows since last read).
     ReadRichGridDiff {

--- a/src-tauri/src/commands/grid.rs
+++ b/src-tauri/src/commands/grid.rs
@@ -89,13 +89,17 @@ pub fn set_scrollback(
 }
 
 /// Get selected text from the terminal grid between two positions.
+/// Row coordinates are viewport-relative (can be negative for multi-screen
+/// selections extending above the viewport). scrollback_offset converts
+/// viewport-relative rows to absolute buffer positions.
 #[tauri::command]
 pub fn get_grid_text(
     terminal_id: String,
-    start_row: u16,
+    start_row: i32,
     start_col: u16,
-    end_row: u16,
+    end_row: i32,
     end_col: u16,
+    scrollback_offset: usize,
     daemon: State<Arc<DaemonClient>>,
 ) -> Result<String, String> {
     let request = Request::ReadGridText {
@@ -104,6 +108,7 @@ pub fn get_grid_text(
         start_col,
         end_row,
         end_col,
+        scrollback_offset,
     };
     let response = daemon.send_request(&request)?;
     match response {

--- a/src/components/TerminalPane.multi-screen-selection.test.ts
+++ b/src/components/TerminalPane.multi-screen-selection.test.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Bug #290: Copy fails for selections spanning more than one viewport.
+ *
+ * When selecting text, scrolling up to extend the selection beyond the visible
+ * viewport, and copying (Ctrl+Shift+C), the copied text is either empty or
+ * truncated. Multi-screen selections cannot be copied correctly.
+ *
+ * Three root causes:
+ * 1. Auto-scroll double-adjusts the selection anchor (shifted by adjustSelectionForScroll
+ *    AND by the auto-scroll timer in the same tick)
+ * 2. Selection coordinates can go negative after scrolling (u16 overflow when passed to backend)
+ * 3. contents_between() only reads visible_rows() — limited to viewport height
+ *
+ * Related: #242 (selection anchoring), #227 (auto-scroll during drag)
+ */
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const mockSetScrollback = vi.fn().mockResolvedValue(undefined);
+const mockFetchSnapshot = vi.fn().mockResolvedValue(undefined);
+
+// ── Simulator ───────────────────────────────────────────────────────────
+
+/**
+ * Models the TerminalRenderer + TerminalPane selection/scroll/copy pipeline,
+ * mirroring the actual code paths for selection auto-scroll and text extraction.
+ *
+ * This simulator faithfully reproduces the bugs by using the same logic as the
+ * production code. The tests assert expected correct behavior, so they FAIL
+ * on the current buggy code.
+ */
+class MultiScreenSelectionSimulator {
+  // Grid geometry
+  gridRows = 24;
+  gridCols = 80;
+  cellWidth = 8;
+  cellHeight = 16;
+
+  // Selection state (mirrors TerminalRenderer)
+  selection = { startRow: 0, startCol: 0, endRow: 0, endCol: 0, active: false };
+  isSelecting = false;
+
+  // Scroll state (mirrors TerminalPane)
+  scrollbackOffset = 0;
+  totalScrollback = 200;
+  isUserScrolled = false;
+
+  // Auto-scroll (mirrors TerminalRenderer)
+  private autoScrollTimer: ReturnType<typeof setInterval> | null = null;
+  private autoScrollDelta = 0;
+
+  /**
+   * Mirrors TerminalRenderer.pixelToGrid() — clamped.
+   */
+  pixelToGrid(clientX: number, clientY: number): { row: number; col: number } {
+    const col = Math.floor(clientX / this.cellWidth);
+    const row = Math.floor(clientY / this.cellHeight);
+    return { row: Math.max(0, Math.min(this.gridRows - 1, row)), col: Math.max(0, col) };
+  }
+
+  /**
+   * Mirrors TerminalRenderer.pixelToGridRaw() — unclamped for edge detection.
+   */
+  pixelToGridRaw(clientX: number, clientY: number): { row: number; col: number } {
+    const col = Math.floor(clientX / this.cellWidth);
+    const row = Math.floor(clientY / this.cellHeight);
+    return { row, col };
+  }
+
+  mouseDown(clientX: number, clientY: number) {
+    const { row, col } = this.pixelToGrid(clientX, clientY);
+    this.selection = { startRow: row, startCol: col, endRow: row, endCol: col, active: false };
+    this.isSelecting = true;
+  }
+
+  /**
+   * Mirrors document-level mousemove during selection.
+   * Uses raw coords for edge detection, clamped coords for selection end.
+   */
+  mouseMove(clientX: number, clientY: number) {
+    if (!this.isSelecting) return;
+
+    const raw = this.pixelToGridRaw(clientX, clientY);
+    const clamped = this.pixelToGrid(clientX, clientY);
+
+    this.selection.endRow = Math.min(clamped.row, this.gridRows - 1);
+    this.selection.endCol = clamped.col;
+    if (this.selection.endRow !== this.selection.startRow || this.selection.endCol !== this.selection.startCol) {
+      this.selection.active = true;
+    }
+
+    // Edge detection for auto-scroll
+    if (raw.row < 0) {
+      const linesPerTick = Math.min(10, Math.ceil(Math.abs(raw.row)));
+      this.startAutoScroll(linesPerTick);
+    } else if (raw.row >= this.gridRows) {
+      const linesPerTick = -Math.min(10, raw.row - this.gridRows + 1);
+      this.startAutoScroll(linesPerTick);
+    } else {
+      this.stopAutoScroll();
+    }
+  }
+
+  mouseUp() {
+    this.isSelecting = false;
+    this.stopAutoScroll();
+  }
+
+  /**
+   * Mirrors TerminalRenderer.startSelectionAutoScroll() — now fixed.
+   *
+   * Bug #290 fix: Only call onScrollCallback (which triggers handleScroll →
+   * adjustSelectionForScroll). The previous code also adjusted startRow
+   * directly in the timer, causing a double-adjustment that made the anchor
+   * drift at 2x the scroll rate and get clamped to viewport bounds.
+   */
+  private startAutoScroll(linesPerTick: number) {
+    this.autoScrollDelta = linesPerTick;
+    if (this.autoScrollTimer) return;
+    this.autoScrollTimer = setInterval(() => {
+      // Only call handleScroll — adjustSelectionForScroll inside it handles
+      // shifting both startRow and endRow by the scroll delta.
+      this.handleScroll(this.autoScrollDelta);
+      // Bug #290: Pin endRow to viewport edge so selection extends into
+      // scrollback as new rows are revealed by auto-scroll.
+      if (this.selection.active) {
+        if (this.autoScrollDelta > 0) {
+          this.selection.endRow = 0; // Scrolling up: pin to top
+        } else {
+          this.selection.endRow = this.gridRows - 1; // Scrolling down: pin to bottom
+        }
+      }
+    }, 50);
+  }
+
+  private stopAutoScroll() {
+    this.autoScrollDelta = 0;
+    if (this.autoScrollTimer) {
+      clearInterval(this.autoScrollTimer);
+      this.autoScrollTimer = null;
+    }
+  }
+
+  /**
+   * Mirrors TerminalPane.handleScroll().
+   */
+  private handleScroll(deltaLines: number) {
+    const newOffset = Math.max(0, Math.min(this.totalScrollback, this.scrollbackOffset + deltaLines));
+    if (newOffset === this.scrollbackOffset) return;
+    const actualDelta = newOffset - this.scrollbackOffset;
+    this.scrollbackOffset = newOffset;
+    this.isUserScrolled = newOffset > 0;
+    this.adjustSelectionForScroll(actualDelta);
+    mockSetScrollback(newOffset);
+    mockFetchSnapshot();
+  }
+
+  /**
+   * Mirrors TerminalRenderer.adjustSelectionForScroll().
+   */
+  private adjustSelectionForScroll(deltaLines: number) {
+    if (!this.selection.active) return;
+    this.selection.startRow += deltaLines;
+    this.selection.endRow += deltaLines;
+    // Bug #290: Only clear off-screen selection when not actively auto-scrolling.
+    // During auto-scroll, the selection extends beyond the viewport and
+    // endRow is pinned to the viewport edge in the auto-scroll timer.
+    if (!this.autoScrollTimer) {
+      const normStart = Math.min(this.selection.startRow, this.selection.endRow);
+      const normEnd = Math.max(this.selection.startRow, this.selection.endRow);
+      if (normEnd < 0 || normStart >= this.gridRows) {
+        this.selection.active = false;
+      }
+    }
+  }
+
+  /**
+   * Mirrors TerminalRenderer.normalizeSelection().
+   */
+  normalizeSelection() {
+    if (!this.selection.active) return null;
+    const sel = this.selection;
+    if (sel.startRow < sel.endRow || (sel.startRow === sel.endRow && sel.startCol <= sel.endCol)) {
+      return { ...sel };
+    }
+    return {
+      startRow: sel.endRow,
+      startCol: sel.endCol,
+      endRow: sel.startRow,
+      endCol: sel.startCol,
+      active: sel.active,
+    };
+  }
+
+  /**
+   * Mirrors the fixed TerminalRenderer.getSelectedText() + backend pipeline.
+   *
+   * The fix converts viewport-relative selection coordinates to absolute buffer
+   * positions using: absRow = totalScrollback - scrollbackOffset + viewportRow.
+   * The backend then reads from the combined scrollback + active grid buffer,
+   * supporting selections spanning any number of rows.
+   */
+  getSelectedText(): { text: string; error: string | null; rowsCopied: number } {
+    const sel = this.normalizeSelection();
+    if (!sel) return { text: '', error: 'no selection', rowsCopied: 0 };
+
+    // Convert viewport-relative rows to absolute buffer positions.
+    // This matches the daemon's read_grid_text() logic:
+    //   base = scrollback_count - scrollback_offset
+    //   abs_row = base + viewport_row
+    const base = this.totalScrollback - this.scrollbackOffset;
+    const absStartRow = Math.max(0, base + sel.startRow);
+    const totalRows = this.totalScrollback + this.gridRows;
+    const absEndRow = Math.max(0, Math.min(totalRows - 1, base + sel.endRow));
+
+    if (absStartRow > absEndRow) {
+      return { text: '', error: 'selection entirely outside buffer', rowsCopied: 0 };
+    }
+
+    const rowsCopied = absEndRow - absStartRow + 1;
+
+    // Simulate text content: one line per absolute row
+    const lines: string[] = [];
+    for (let r = absStartRow; r <= absEndRow; r++) {
+      lines.push(`line-${r}`);
+    }
+
+    return {
+      text: lines.join('\n'),
+      error: null,
+      rowsCopied,
+    };
+  }
+
+  /**
+   * Returns content-relative position for a viewport-relative row.
+   */
+  contentPosition(viewportRow: number): number {
+    return viewportRow - this.scrollbackOffset;
+  }
+
+  dispose() {
+    this.stopAutoScroll();
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('Bug #290: copy fails for selections spanning more than one viewport', () => {
+  let sim: MultiScreenSelectionSimulator;
+
+  beforeEach(() => {
+    sim = new MultiScreenSelectionSimulator();
+    mockSetScrollback.mockClear();
+    mockFetchSnapshot.mockClear();
+  });
+
+  afterEach(() => {
+    sim.dispose();
+  });
+
+  describe('auto-scroll double-adjustment bug', () => {
+    // Bug #290 (issue 1): The auto-scroll timer adjusts startRow twice per tick.
+    // adjustSelectionForScroll() adds delta, then the timer adds delta again.
+    // The anchor should only be adjusted once per scroll delta.
+
+    it('startRow should shift by exactly the scroll delta per auto-scroll tick, not 2x', async () => {
+      // Start selection near bottom of viewport
+      sim.mouseDown(0, 20 * sim.cellHeight);
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 22 * sim.cellHeight);
+
+      expect(sim.selection.active).toBe(true);
+      expect(sim.selection.startRow).toBe(20);
+
+      // Drag above viewport to trigger auto-scroll at 3 lines/tick
+      sim.mouseMove(100, -48); // ~3 rows above viewport
+
+      // Wait for one auto-scroll tick
+      await new Promise(resolve => setTimeout(resolve, 80));
+
+      // After one tick scrolling up by 3: offset should be 3
+      // startRow should be 20 + 3 = 23 (shifted once by the scroll delta)
+      // BUG: actual behavior is startRow = 20 + 3 + 3 = 26, then clamped to 23
+      // The double-adjustment is masked by clamping, but it means the anchor
+      // position is WRONG for content tracking.
+      const absAnchor = sim.contentPosition(sim.selection.startRow);
+
+      // The anchor was at absolute position 20 (viewport row 20, offset 0).
+      // After scrolling up 3 lines: offset=3, viewport row should be 23 → absolute = 23-3 = 20.
+      // Expected: absolute position is still 20 (anchor tracks content).
+      expect(absAnchor).toBe(20);
+    });
+
+    it('startRow should not be adjusted twice in a single auto-scroll tick', async () => {
+      sim.mouseDown(0, 10 * sim.cellHeight);
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 0);
+      expect(sim.selection.active).toBe(true);
+
+      const startRowBefore = sim.selection.startRow;
+
+      // Trigger auto-scroll at 2 lines/tick
+      sim.mouseMove(100, -32);
+
+      await new Promise(resolve => setTimeout(resolve, 80));
+
+      const scrolledLines = sim.scrollbackOffset;
+      // startRow should increase by exactly scrolledLines (one adjustment)
+      // BUG: it increases by 2x scrolledLines due to double adjustment
+      expect(sim.selection.startRow).toBe(startRowBefore + scrolledLines);
+    });
+  });
+
+  describe('multi-screen selection coordinates', () => {
+    // Bug #290 (issue 2): After scrolling, selection coordinates can exceed
+    // viewport bounds. When passed as u16 to the backend, negative values
+    // cause serialization errors (silently caught → empty copy).
+
+    it('selection spanning 2x viewport should have valid coordinates for copy', async () => {
+      // Start at row 22 (near bottom), drag up and scroll up to create
+      // a selection spanning ~48 rows (2x viewport of 24)
+      sim.mouseDown(0, 22 * sim.cellHeight);
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 0);
+      expect(sim.selection.active).toBe(true);
+
+      // Drag above viewport to trigger auto-scroll
+      sim.mouseMove(100, -48);
+
+      // Wait for enough ticks to scroll up 30 lines
+      await new Promise(resolve => setTimeout(resolve, 600));
+
+      // The selection should still be valid
+      expect(sim.selection.active).toBe(true);
+
+      // Try to copy — should not fail with negative rows
+      const result = sim.getSelectedText();
+
+      // Expected: all rows in the selection should be copyable
+      // BUG: coordinates may be negative (u16 overflow) or selection may be
+      // entirely outside viewport bounds after double-adjustment
+      expect(result.error).toBeNull();
+      expect(result.rowsCopied).toBeGreaterThan(sim.gridRows);
+    });
+
+    it('selection coordinates should never go negative during auto-scroll up', async () => {
+      // Start selection at row 5, auto-scroll up past it
+      sim.mouseDown(0, 5 * sim.cellHeight);
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 3 * sim.cellHeight);
+      expect(sim.selection.active).toBe(true);
+
+      // Auto-scroll up aggressively
+      sim.mouseMove(100, -160); // 10 lines above viewport
+
+      await new Promise(resolve => setTimeout(resolve, 400));
+
+      // After significant scrolling, the selection end (which was at row 0)
+      // shifts by scrollbackOffset due to adjustSelectionForScroll.
+      // The endRow should track content, but must not go negative for copy to work.
+      const sel = sim.normalizeSelection();
+
+      // Selection should still be active and have valid coordinates for u16
+      if (sel) {
+        // BUG: endRow can be clamped above startRow causing empty selection,
+        // or startRow can go negative from double-adjustment overflow
+        expect(sel.startRow).toBeGreaterThanOrEqual(0);
+        expect(sel.endRow).toBeGreaterThanOrEqual(0);
+        expect(sel.endRow).toBeGreaterThanOrEqual(sel.startRow);
+      }
+    });
+  });
+
+  describe('copy text extraction for multi-screen selection', () => {
+    // Bug #290 (issue 3): contents_between() only reads visible_rows()
+    // which is limited to the viewport height. A selection spanning more
+    // than gridRows rows gets truncated.
+
+    it('should copy all rows when selection spans 2 screens', async () => {
+      // Set up: scroll down first so we have room to scroll up
+      sim.scrollbackOffset = 0;
+
+      // Create selection from row 22 down to row 0
+      sim.mouseDown(0, 22 * sim.cellHeight);
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 0);
+
+      // Now auto-scroll up to extend selection into scrollback
+      sim.mouseMove(100, -48);
+
+      // Wait for auto-scroll to cover 24+ additional rows
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      sim.mouseUp();
+
+      const result = sim.getSelectedText();
+
+      // The selection should span at least 24 rows (one full viewport)
+      // plus the scrolled rows. Total should be > gridRows.
+      // BUG: contents_between truncates to gridRows (24), losing the rest.
+      expect(result.rowsCopied).toBeGreaterThan(sim.gridRows);
+      expect(result.error).toBeNull();
+    });
+
+    it('should not truncate text when selection extends above viewport', () => {
+      // Simulate the end state: selection goes from row -10 to row 23
+      // (i.e., 10 rows above viewport + full viewport = 34 rows total)
+      sim.selection = {
+        startRow: -10,
+        startCol: 0,
+        endRow: 23,
+        endCol: 80,
+        active: true,
+      };
+      sim.scrollbackOffset = 30;
+
+      const result = sim.getSelectedText();
+
+      // Expected: should extract all 34 rows (including the 10 above viewport)
+      // BUG: startRow=-10 causes u16 overflow → empty text
+      expect(result.error).toBeNull();
+      expect(result.rowsCopied).toBe(34);
+    });
+
+    it('should not truncate text when selection extends below viewport', () => {
+      // Simulate: selection goes from row 0 to row 30 (6 rows below viewport)
+      sim.selection = {
+        startRow: 0,
+        startCol: 0,
+        endRow: 30,
+        endCol: 80,
+        active: true,
+      };
+      sim.scrollbackOffset = 10;
+
+      const result = sim.getSelectedText();
+
+      // Expected: should extract all 31 rows
+      // BUG: contents_between only iterates visible_rows (24 rows max)
+      expect(result.error).toBeNull();
+      expect(result.rowsCopied).toBe(31);
+    });
+  });
+
+  describe('end-to-end multi-screen select + scroll + copy', () => {
+    it('select near bottom, scroll up 2 pages, copy should include all rows', async () => {
+      // Bug #290: Complete reproduction of the user scenario.
+      // 1. Start selection at row 20
+      sim.mouseDown(0, 20 * sim.cellHeight);
+      // 2. Drag to row 0
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 0);
+      expect(sim.selection.active).toBe(true);
+
+      // 3. Continue dragging above viewport (triggers auto-scroll)
+      sim.mouseMove(100, -32);
+
+      // 4. Wait for auto-scroll to scroll up ~48 lines (2 full pages)
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // 5. Release mouse
+      sim.mouseUp();
+
+      // At this point we expect:
+      // - scrollbackOffset >= 24 (scrolled up at least one full page)
+      // - selection should span from the original row 20 position to wherever
+      //   the viewport now shows (top of scrolled viewport)
+      expect(sim.scrollbackOffset).toBeGreaterThanOrEqual(24);
+
+      // 6. Copy
+      const result = sim.getSelectedText();
+
+      // Expected: copied text should include rows from the original selection
+      // all the way through the scrolled region. Total rows > gridRows.
+      // BUG: Either empty (u16 overflow), truncated (contents_between limit),
+      // or wrong content (double-adjustment of anchor).
+      expect(result.error).toBeNull();
+      expect(result.rowsCopied).toBeGreaterThan(sim.gridRows);
+    });
+
+    it('select at top, scroll down 2 pages, copy should include all rows', async () => {
+      // Start scrolled up into history
+      sim.scrollbackOffset = 60;
+      sim.isUserScrolled = true;
+
+      // Select at row 2
+      sim.mouseDown(0, 2 * sim.cellHeight);
+      // Drag to row 23
+      sim.mouseMove(sim.gridCols * sim.cellWidth, 23 * sim.cellHeight);
+
+      // Drag below viewport to trigger downward auto-scroll
+      sim.mouseMove(100, sim.gridRows * sim.cellHeight + 32);
+
+      // Wait for auto-scroll to scroll down ~48 lines
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      sim.mouseUp();
+
+      // Copy
+      const result = sim.getSelectedText();
+
+      // Expected: all selected rows copied
+      expect(result.error).toBeNull();
+      expect(result.rowsCopied).toBeGreaterThan(sim.gridRows);
+    });
+  });
+});

--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -376,11 +376,15 @@ export class TerminalRenderer {
     if (!this.selection.active) return;
     this.selection.startRow += deltaLines;
     this.selection.endRow += deltaLines;
-    // Clear if the entire selection is off-screen
-    const gridRows = this.currentSnapshot?.dimensions.rows ?? 24;
-    const normalized = this.normalizeSelection(this.selection);
-    if (normalized.endRow < 0 || normalized.startRow >= gridRows) {
-      this.selection.active = false;
+    // Bug #290: Only clear off-screen selection when not actively auto-scrolling.
+    // During auto-scroll, the selection extends beyond the viewport and the
+    // endRow is pinned to the viewport edge in the auto-scroll timer callback.
+    if (!this.autoScrollTimer) {
+      const gridRows = this.currentSnapshot?.dimensions.rows ?? 24;
+      const normalized = this.normalizeSelection(this.selection);
+      if (normalized.endRow < 0 || normalized.startRow >= gridRows) {
+        this.selection.active = false;
+      }
     }
   }
 
@@ -390,10 +394,16 @@ export class TerminalRenderer {
     this.repaint();
   }
 
-  /** Get selected text by calling the backend. */
+  /**
+   * Get selected text by calling the backend.
+   * Passes the current scrollback offset so the backend can convert
+   * viewport-relative selection coordinates to absolute buffer positions,
+   * supporting multi-screen selections that span more rows than the viewport.
+   */
   async getSelectedText(terminalId: string): Promise<string> {
     const sel = this.getSelection();
     if (!sel) return '';
+    const scrollbackOffset = this.currentSnapshot?.scrollback_offset ?? 0;
     try {
       return await invoke<string>('get_grid_text', {
         terminalId,
@@ -401,6 +411,7 @@ export class TerminalRenderer {
         startCol: sel.startCol,
         endRow: sel.endRow,
         endCol: sel.endCol,
+        scrollbackOffset,
       });
     } catch {
       return '';
@@ -856,12 +867,24 @@ export class TerminalRenderer {
     if (this.autoScrollTimer) return; // already running, just update delta
     this.autoScrollTimer = setInterval(() => {
       if (this.onScrollCallback) {
+        // Bug #290: Only call onScrollCallback — it triggers handleScroll()
+        // which calls adjustSelectionForScroll() to shift both startRow and
+        // endRow. Previously, startRow was also adjusted HERE, causing a
+        // double-adjustment that made the anchor drift at 2x the scroll rate
+        // and get clamped to viewport bounds, breaking multi-screen selections.
         this.onScrollCallback(this.autoScrollDelta);
-        // Adjust selection anchor: scrolling shifts the viewport, so the anchor
-        // row moves in the opposite direction in viewport-relative coordinates.
-        const gridRows = this.currentSnapshot?.dimensions.rows ?? 24;
-        this.selection.startRow = Math.max(0, Math.min(gridRows - 1,
-          this.selection.startRow + this.autoScrollDelta));
+        // Bug #290: Pin endRow to the viewport edge so the selection extends
+        // into scrollback as new rows are revealed by auto-scroll.
+        // Without this, endRow drifts away from the viewport edge (shifted
+        // by adjustSelectionForScroll) and the selection doesn't grow.
+        if (this.selection.active) {
+          const gridRows = this.currentSnapshot?.dimensions.rows ?? 24;
+          if (this.autoScrollDelta > 0) {
+            this.selection.endRow = 0; // Scrolling up: pin to top
+          } else {
+            this.selection.endRow = gridRows - 1; // Scrolling down: pin to bottom
+          }
+        }
       }
     }, 50);
   }


### PR DESCRIPTION
Fixes #290

## Summary

Multi-screen selection (selecting text that spans scrollback + visible viewport) was broken — the copied text was empty or incorrect. This was caused by five interrelated issues across the frontend and backend.

## Changes

### Frontend (TerminalRenderer.ts)

1. **Remove double-adjustment of selection anchor in `startSelectionAutoScroll()`** — both `adjustSelectionForScroll()` and the auto-scroll timer were shifting `startRow`, causing the anchor to drift incorrectly.

2. **Skip viewport-bounds deactivation during auto-scroll in `adjustSelectionForScroll()`** — the selection was being killed when coordinates went outside `[0, gridRows)`, which is expected behavior during auto-scroll into scrollback.

3. **Pin `endRow` to viewport edge in auto-scroll timer** — extends the selection into scrollback as new rows are revealed by scrolling.

4. **Pass `scrollbackOffset` from cached snapshot in `getSelectedText()`** — ensures correct absolute coordinate conversion when reading text across the scrollback boundary.

### Backend (Rust)

5. **Widen `ReadGridText` row types from `u16` to `i32`** in protocol messages to support negative viewport-relative coordinates (rows in scrollback above the visible viewport).

6. **Add `all_rows()` method to `grid.rs`** — chains scrollback rows + active rows into a single iterator over the full buffer.

7. **Add `contents_between_absolute()` to `screen.rs`** — reads text across the full buffer using absolute row indices (scrollback + active).

8. **Update `session.rs` `read_grid_text()`** — converts viewport-relative coordinates to absolute buffer positions and delegates to `contents_between_absolute()`.

## Tests

- Added `TerminalPane.multi-screen-selection.test.ts` with 9 tests covering multi-screen selection scenarios (all passing).
- All 777 frontend tests pass.