### PR TITLE
fix: scan .claude/commands/ in skill autocomplete

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -75,16 +75,20 @@ pub fn list_skills(project_path: String) -> Vec<SkillInfo> {
     let mut skills_map = std::collections::HashMap::new();
 
     if let Ok(home) = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")) {
-        let global_dir = PathBuf::from(home).join(".claude").join("skills");
-        for skill in scan_skills_dir(&global_dir, "global") {
+        let claude_dir = PathBuf::from(home).join(".claude");
+        for skill in scan_skills_dir(&claude_dir.join("skills"), "global") {
+            skills_map.insert(skill.name.clone(), skill);
+        }
+        for skill in scan_skills_dir(&claude_dir.join("commands"), "global") {
             skills_map.insert(skill.name.clone(), skill);
         }
     }
 
-    let project_dir = PathBuf::from(&project_path)
-        .join(".claude")
-        .join("skills");
-    for skill in scan_skills_dir(&project_dir, "project") {
+    let project_claude_dir = PathBuf::from(&project_path).join(".claude");
+    for skill in scan_skills_dir(&project_claude_dir.join("skills"), "project") {
+        skills_map.insert(skill.name.clone(), skill);
+    }
+    for skill in scan_skills_dir(&project_claude_dir.join("commands"), "project") {
         skills_map.insert(skill.name.clone(), skill);
     }
 
@@ -135,4 +139,175 @@ pub fn get_user_claude_md_path() -> Result<String, String> {
     path.to_str()
         .map(|s| s.to_string())
         .ok_or_else(|| "Invalid path encoding".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Helper: create a minimal skill .md file in the given directory.
+    fn write_skill_file(dir: &std::path::Path, name: &str, description: &str) {
+        fs::create_dir_all(dir).unwrap();
+        let content = format!(
+            "# {name}\n\n{description}\n\n## Usage\n\n```\n/{name} <args>\n```\n"
+        );
+        fs::write(dir.join(format!("{name}.md")), content).unwrap();
+    }
+
+    #[test]
+    fn list_skills_returns_skills_from_skills_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+
+        write_skill_file(
+            &project.join(".claude").join("skills"),
+            "deploy",
+            "Deploy to production",
+        );
+
+        let results = list_skills(project.to_string_lossy().to_string());
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"deploy"),
+            "Expected 'deploy' from .claude/skills/ but got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn list_skills_returns_commands_from_commands_dir() {
+        // Bug #292: skills in .claude/commands/ must also be scanned
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+
+        write_skill_file(
+            &project.join(".claude").join("commands"),
+            "create-reproducible-issue",
+            "Create a test that reproduces a bug",
+        );
+
+        let results = list_skills(project.to_string_lossy().to_string());
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"create-reproducible-issue"),
+            "Bug #292: Expected 'create-reproducible-issue' from .claude/commands/ but got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn list_skills_merges_skills_and_commands_dirs() {
+        // Bug #292: both .claude/skills/ and .claude/commands/ should be scanned
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+
+        write_skill_file(
+            &project.join(".claude").join("skills"),
+            "build",
+            "Build the project",
+        );
+        write_skill_file(
+            &project.join(".claude").join("commands"),
+            "release",
+            "Create a release",
+        );
+
+        let results = list_skills(project.to_string_lossy().to_string());
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"build"),
+            "Expected 'build' from .claude/skills/ but got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"release"),
+            "Bug #292: Expected 'release' from .claude/commands/ but got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn list_skills_commands_dir_has_project_source() {
+        // Bug #292: project .claude/commands/ entries should have source="project"
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+
+        write_skill_file(
+            &project.join(".claude").join("commands"),
+            "test-hygiene",
+            "Project-specific test hygiene",
+        );
+
+        let results = list_skills(project.to_string_lossy().to_string());
+        let found = results.iter().find(|s| s.name == "test-hygiene");
+
+        assert!(
+            found.is_some(),
+            "Bug #292: Expected 'test-hygiene' from .claude/commands/ but not found"
+        );
+        assert_eq!(
+            found.unwrap().source,
+            "project",
+            "Project-level command should have source='project'"
+        );
+    }
+
+    #[test]
+    fn list_skills_global_commands_dir_is_scanned() {
+        // Bug #292: global ~/.claude/commands/ should be scanned
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_home = tmp.path().join("fakehome");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+
+        write_skill_file(
+            &fake_home.join(".claude").join("commands"),
+            "global-command",
+            "A global command from commands dir",
+        );
+        write_skill_file(
+            &fake_home.join(".claude").join("skills"),
+            "global-skill",
+            "A global skill from skills dir",
+        );
+
+        // Temporarily override USERPROFILE
+        let old_profile = std::env::var("USERPROFILE").ok();
+        let old_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("USERPROFILE", fake_home.to_string_lossy().to_string());
+            std::env::remove_var("HOME");
+        }
+
+        let results = list_skills(project.to_string_lossy().to_string());
+
+        // Restore env
+        unsafe {
+            match old_profile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+            match old_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => {}
+            }
+        }
+
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"global-skill"),
+            "Expected 'global-skill' from ~/.claude/skills/ but got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"global-command"),
+            "Bug #292: Expected 'global-command' from ~/.claude/commands/ but got: {:?}",
+            names
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `list_skills()` only scanned `.claude/skills/` directories, ignoring `.claude/commands/` where Claude Code stores slash commands
- Added scanning of `.claude/commands/` at both global (`~/.claude/`) and project levels
- Added 5 unit tests covering skills dir, commands dir, merged results, source labels, and global commands

Fixes #292

## Test plan
- [ ] CI passes (`cargo nextest run -p godly-terminal`)
- [ ] Open Quick Claude, type `/` — verify commands from `.claude/commands/` appear
- [ ] Verify global commands (e.g. `/create-reproducible-issue`) show in autocomplete
- [ ] Verify project commands (e.g. `/release`) show in autocomplete