### PR TITLE
perf: isolate stream:// protocol handler from IPC thread pool

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -287,6 +287,38 @@ pub fn run() {
     // Clone for the custom protocol closure (captured by move)
     let registry_for_protocol = output_registry.clone();
 
+    // Dedicated worker pool for stream:// protocol responses (2 threads).
+    // The WebView2 WebResourceRequested callback runs on the main thread, so
+    // the synchronous register_uri_scheme_protocol variant blocks the main
+    // thread until the response is built. Under load (rapid terminal creation
+    // saturating IPC), stream:// fetches time out ("Failed to fetch"), blanking
+    // all terminals. By using the async variant + a dedicated worker pool, the
+    // handler returns immediately and a pool thread calls responder.respond().
+    type StreamJob = Box<dyn FnOnce() + Send>;
+    let (stream_tx, stream_rx) = {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<StreamJob>(256);
+        let rx = Arc::new(std::sync::Mutex::new(rx));
+        for i in 0..2 {
+            let rx = rx.clone();
+            std::thread::Builder::new()
+                .name(format!("stream-proto-{}", i))
+                .spawn(move || loop {
+                    let job = {
+                        let guard = rx.lock().unwrap();
+                        guard.recv()
+                    };
+                    match job {
+                        Ok(f) => f(),
+                        Err(_) => break, // channel closed
+                    }
+                })
+                .expect("Failed to spawn stream protocol worker");
+        }
+        (tx, rx)
+    };
+    // Keep rx alive for the lifetime of the app (workers hold Arc clones)
+    let _stream_rx_keepalive = stream_rx;
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
@@ -295,31 +327,36 @@ pub fn run() {
         // Register custom protocol for streaming terminal output as raw bytes.
         // Frontend fetches: http://stream.localhost/terminal-output/{session_id}
         // Returns accumulated raw PTY bytes since last fetch (application/octet-stream).
-        .register_uri_scheme_protocol("stream", move |_ctx, request| {
-            let path = request.uri().path();
-            // Expected path: /terminal-output/{session_id}
-            if let Some(session_id) = path.strip_prefix("/terminal-output/") {
-                if session_id.is_empty() {
-                    return tauri::http::Response::builder()
-                        .status(400)
+        .register_asynchronous_uri_scheme_protocol("stream", move |_ctx, request, responder| {
+            let registry = registry_for_protocol.clone();
+            let path = request.uri().path().to_string();
+            let _ = stream_tx.try_send(Box::new(move || {
+                // Expected path: /terminal-output/{session_id}
+                let response = if let Some(session_id) = path.strip_prefix("/terminal-output/") {
+                    if session_id.is_empty() {
+                        tauri::http::Response::builder()
+                            .status(400)
+                            .header("Access-Control-Allow-Origin", "*")
+                            .body(b"Missing session_id".to_vec())
+                            .unwrap()
+                    } else {
+                        let bytes = registry.drain(session_id);
+                        tauri::http::Response::builder()
+                            .status(200)
+                            .header("Content-Type", "application/octet-stream")
+                            .header("Access-Control-Allow-Origin", "*")
+                            .body(bytes)
+                            .unwrap()
+                    }
+                } else {
+                    tauri::http::Response::builder()
+                        .status(404)
                         .header("Access-Control-Allow-Origin", "*")
-                        .body(b"Missing session_id".to_vec())
-                        .unwrap();
-                }
-                let bytes = registry_for_protocol.drain(session_id);
-                tauri::http::Response::builder()
-                    .status(200)
-                    .header("Content-Type", "application/octet-stream")
-                    .header("Access-Control-Allow-Origin", "*")
-                    .body(bytes)
-                    .unwrap()
-            } else {
-                tauri::http::Response::builder()
-                    .status(404)
-                    .header("Access-Control-Allow-Origin", "*")
-                    .body(b"Not found. Use /terminal-output/{session_id}".to_vec())
-                    .unwrap()
-            }
+                        .body(b"Not found. Use /terminal-output/{session_id}".to_vec())
+                        .unwrap()
+                };
+                responder.respond(response);
+            }));
         })
         .manage(app_state.clone())
         .manage(auto_save.clone())


### PR DESCRIPTION
## Problem

The `stream://` custom protocol handler and Tauri IPC commands both execute on the WebView2 main thread. Under load (rapid terminal creation saturating IPC), `stream://` fetches time out with "Failed to fetch", causing all terminal tabs to go blank simultaneously.

## Root Cause

`register_uri_scheme_protocol` (synchronous variant) blocks the WebView2 `WebResourceRequested` callback until the response is built. Since this callback runs on the main thread, it competes with IPC command dispatch. When IPC is saturated, stream fetches are starved.

## Fix

Switch to `register_asynchronous_uri_scheme_protocol` with a dedicated 2-thread worker pool:
- Handler returns immediately, freeing the main thread
- A bounded `sync_channel(256)` queues work items to 2 persistent worker threads
- Workers call `responder.respond()` off the main thread
- Zero new dependencies (uses `std::sync::mpsc` and `std::thread`)

The `drain()` call itself is sub-microsecond (just `mem::take`), so the workers complete near-instantly. The critical fix is *not blocking the main thread callback*.

## Test Plan

- `cargo check -p godly-terminal` passes
- Manual: rapidly create 10+ terminals while existing ones are producing output — stream fetches should no longer fail

fixes #319