### PR TITLE
perf: shard OutputStreamRegistry to per-session locks

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1.0", features = ["rt"] }
 parking_lot.workspace = true
+dashmap = "6"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 zip = "2"
 tempfile = "3"

--- a/src-tauri/src/daemon_client/bridge.rs
+++ b/src-tauri/src/daemon_client/bridge.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
@@ -25,16 +25,19 @@ const MAX_STREAM_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 ///
 /// Thread-safe: the bridge I/O thread pushes data, and the Tauri custom
 /// protocol handler (running on the Tauri thread pool) drains data.
-/// Critical sections are short (push a slice, swap a Vec), so contention
-/// is negligible.
+///
+/// Uses `DashMap` with per-session sharded locks so that push/drain
+/// operations for different sessions never block each other. With 20+
+/// concurrent terminals this eliminates the global-mutex serialization
+/// bottleneck.
 pub struct OutputStreamRegistry {
-    buffers: parking_lot::Mutex<HashMap<String, Vec<u8>>>,
+    buffers: dashmap::DashMap<String, Vec<u8>>,
 }
 
 impl OutputStreamRegistry {
     pub fn new() -> Self {
         Self {
-            buffers: parking_lot::Mutex::new(HashMap::new()),
+            buffers: dashmap::DashMap::new(),
         }
     }
 
@@ -47,8 +50,7 @@ impl OutputStreamRegistry {
         if data.is_empty() {
             return;
         }
-        let mut buffers = self.buffers.lock();
-        let buf = buffers.entry(session_id.to_string()).or_default();
+        let mut buf = self.buffers.entry(session_id.to_string()).or_default();
         if buf.len() + data.len() > MAX_STREAM_BUFFER_SIZE {
             // Drop oldest data to make room
             let overflow = (buf.len() + data.len()).saturating_sub(MAX_STREAM_BUFFER_SIZE);
@@ -69,22 +71,21 @@ impl OutputStreamRegistry {
     /// Drain all accumulated bytes for a session, returning them.
     /// The buffer is cleared after draining.
     pub fn drain(&self, session_id: &str) -> Vec<u8> {
-        let mut buffers = self.buffers.lock();
-        match buffers.get_mut(session_id) {
-            Some(buf) => std::mem::take(buf),
+        match self.buffers.get_mut(session_id) {
+            Some(mut buf) => std::mem::take(buf.value_mut()),
             None => Vec::new(),
         }
     }
 
     /// Remove a session's buffer entirely (on session close).
     pub fn remove(&self, session_id: &str) {
-        self.buffers.lock().remove(session_id);
+        self.buffers.remove(session_id);
     }
 
     /// Number of sessions with active buffers (for diagnostics).
     #[cfg(test)]
     pub fn session_count(&self) -> usize {
-        self.buffers.lock().len()
+        self.buffers.len()
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the single global `parking_lot::Mutex<HashMap>` in `OutputStreamRegistry` with `dashmap::DashMap` so that push/drain operations for different terminal sessions never block each other.

With 20+ concurrent terminals, the old global lock serialized all stream buffer access — every `stream://` fetch and every bridge output push contended on one mutex. This contributed to cascade blank-screen failures when multiple sessions produced heavy output simultaneously.

### Changes
- **`src-tauri/Cargo.toml`** — added `dashmap = "6"` dependency
- **`src-tauri/src/daemon_client/bridge.rs`** — replaced `parking_lot::Mutex<HashMap<String, Vec<u8>>>` with `dashmap::DashMap<String, Vec<u8>>`, removed unused `HashMap` import

### Behavior preserved
- 4MB per-session buffer cap unchanged
- Overflow drops oldest data (same logic)
- All 144 existing tests pass (including 9 OutputStreamRegistry-specific tests)

fixes #316