### PR TITLE
feat: GPU terminal renderer crate (Phase 1 of #330)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "protocol", "daemon", "mcp", "notify", "godly-vt", "remote", "llm", "pty-shim"]
+members = [".", "protocol", "daemon", "mcp", "notify", "godly-vt", "remote", "llm", "pty-shim", "renderer"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/src-tauri/renderer/Cargo.toml
+++ b/src-tauri/renderer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "godly-renderer"
+version = "0.1.0"
+edition = "2021"
+license = "BUSL-1.1"
+
+[dependencies]
+godly-protocol = { path = "../protocol" }
+wgpu = { version = "24", features = [] }
+cosmic-text = "0.12"
+image = { version = "0.25", default-features = false, features = ["png"] }
+bytemuck = { version = "1", features = ["derive"] }
+log = "0.4"
+pollster = "0.4"
+
+[dev-dependencies]
+env_logger = "0.11"

--- a/src-tauri/renderer/src/atlas.rs
+++ b/src-tauri/renderer/src/atlas.rs
@@ -1,0 +1,508 @@
+use std::collections::HashMap;
+
+use cosmic_text::{
+    Attrs, Buffer, Family, FontSystem, Metrics, Shaping, Style, SwashCache, Weight,
+};
+
+/// Key for looking up a rasterized glyph in the atlas.
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+struct GlyphKey {
+    ch: char,
+    bold: bool,
+    italic: bool,
+}
+
+/// Location and metrics of a rasterized glyph within the atlas texture.
+#[derive(Clone, Copy, Debug)]
+pub struct AtlasEntry {
+    /// Top-left U coordinate (normalized 0..1).
+    pub u0: f32,
+    /// Top-left V coordinate (normalized 0..1).
+    pub v0: f32,
+    /// Bottom-right U coordinate (normalized 0..1).
+    pub u1: f32,
+    /// Bottom-right V coordinate (normalized 0..1).
+    pub v1: f32,
+    /// Glyph pixel width.
+    pub width: u32,
+    /// Glyph pixel height.
+    pub height: u32,
+    /// Horizontal bearing offset (pixels from cell left edge).
+    pub offset_x: i32,
+    /// Vertical bearing offset (pixels from cell top edge).
+    pub offset_y: i32,
+}
+
+/// A glyph atlas that rasterizes characters into a single texture.
+///
+/// Glyphs are packed row-by-row into an RGBA texture. The RED channel
+/// stores the glyph coverage/alpha value; G, B, A are zero. The shader
+/// samples `.r` to use as the blend factor between background and foreground.
+///
+/// When the current row runs out of horizontal space, a new row starts.
+/// When vertical space runs out, the atlas is resized (doubled in height).
+pub struct GlyphAtlas {
+    font_system: FontSystem,
+    swash_cache: SwashCache,
+    /// Raw RGBA pixel data (R = glyph alpha, GBA = 0).
+    atlas_data: Vec<u8>,
+    atlas_width: u32,
+    atlas_height: u32,
+    entries: HashMap<GlyphKey, AtlasEntry>,
+    /// X position for next glyph insertion.
+    cursor_x: u32,
+    /// Y position for current row.
+    cursor_y: u32,
+    /// Maximum height of any glyph in the current row.
+    row_height: u32,
+    /// Monospace cell width in pixels.
+    cell_width: f32,
+    /// Monospace cell height in pixels.
+    cell_height: f32,
+    /// GPU texture handle (created lazily on first use).
+    texture: Option<wgpu::Texture>,
+    /// Whether atlas_data has changed since last GPU upload.
+    dirty: bool,
+    /// The font size used for rendering.
+    font_size: f32,
+    /// The font family name.
+    font_family: String,
+}
+
+/// Font families to try in order. The first one found on the system wins.
+const FONT_FALLBACKS: &[&str] = &[
+    "Cascadia Code",
+    "Cascadia Mono",
+    "Consolas",
+    "Courier New",
+    "monospace",
+];
+
+impl GlyphAtlas {
+    /// Create a new glyph atlas with the given font and size.
+    ///
+    /// Attempts `font_family` first, then falls back through common monospace
+    /// fonts. Pre-rasterizes printable ASCII (32..=126) for fast startup.
+    pub fn new(font_family: &str, font_size: f32) -> Self {
+        let mut font_system = FontSystem::new();
+        let swash_cache = SwashCache::new();
+
+        // Determine cell metrics using a reference character.
+        // We shape "M" to get the advance width, and use font metrics for height.
+        let line_height = (font_size * 1.2).ceil();
+        let metrics = Metrics::new(font_size, line_height);
+        let mut buffer = Buffer::new(&mut font_system, metrics);
+        buffer.set_size(&mut font_system, Some(font_size * 10.0), Some(line_height * 2.0));
+
+        // Try the requested family first, then fallbacks.
+        let families: Vec<&str> = std::iter::once(font_family)
+            .chain(FONT_FALLBACKS.iter().copied())
+            .collect();
+
+        let mut cell_width = font_size * 0.6; // Conservative default
+        let mut cell_height = line_height;
+        let mut resolved_family = font_family.to_string();
+
+        for &family in &families {
+            let attrs = Attrs::new().family(Family::Name(family));
+            buffer.set_text(&mut font_system, "M", attrs, Shaping::Advanced);
+            buffer.shape_until_scroll(&mut font_system, false);
+
+            // Try to get cell width from layout runs
+            let mut found = false;
+            for run in buffer.layout_runs() {
+                for glyph in run.glyphs.iter() {
+                    cell_width = glyph.w;
+                    cell_height = line_height;
+                    resolved_family = family.to_string();
+                    found = true;
+                    break;
+                }
+                if found {
+                    break;
+                }
+            }
+            if found {
+                break;
+            }
+        }
+
+        log::info!(
+            "GlyphAtlas: font='{}', size={}, cell={}x{}",
+            resolved_family,
+            font_size,
+            cell_width,
+            cell_height
+        );
+
+        // Initial atlas: 512x512 is enough for ASCII + common chars.
+        let atlas_width = 512u32;
+        let atlas_height = 512u32;
+        let atlas_data = vec![0u8; (atlas_width * atlas_height * 4) as usize];
+
+        let mut atlas = Self {
+            font_system,
+            swash_cache,
+            atlas_data,
+            atlas_width,
+            atlas_height,
+            entries: HashMap::new(),
+            cursor_x: 1, // Leave a 1px border for the "blank" region at (0,0)
+            cursor_y: 0,
+            row_height: 0,
+            cell_width,
+            cell_height,
+            texture: None,
+            dirty: true,
+            font_size,
+            font_family: resolved_family,
+        };
+
+        // Reserve a 1x1 transparent region at (0,0) for space/empty cells.
+        // This way, spaces map to UV coords that sample zero alpha.
+        atlas.entries.insert(
+            GlyphKey { ch: ' ', bold: false, italic: false },
+            AtlasEntry {
+                u0: 0.0,
+                v0: 0.0,
+                u1: 0.5 / atlas_width as f32,
+                v1: 0.5 / atlas_height as f32,
+                width: 0,
+                height: 0,
+                offset_x: 0,
+                offset_y: 0,
+            },
+        );
+
+        // Pre-rasterize printable ASCII for fast startup.
+        for ch in ' '..='~' {
+            for bold in [false, true] {
+                atlas.get_or_insert(ch, bold, false);
+            }
+        }
+
+        atlas
+    }
+
+    /// Get a cached glyph entry or rasterize it into the atlas.
+    pub fn get_or_insert(&mut self, ch: char, bold: bool, italic: bool) -> AtlasEntry {
+        let key = GlyphKey { ch, bold, italic };
+
+        if let Some(entry) = self.entries.get(&key) {
+            return *entry;
+        }
+
+        // For space or control chars, return the blank region.
+        if ch.is_control() || ch == ' ' {
+            let blank_key = GlyphKey { ch: ' ', bold: false, italic: false };
+            let entry = *self.entries.get(&blank_key).unwrap();
+            self.entries.insert(key, entry);
+            return entry;
+        }
+
+        // Rasterize the glyph using cosmic-text.
+        let entry = self.rasterize_glyph(ch, bold, italic);
+        self.entries.insert(key, entry);
+        entry
+    }
+
+    /// Rasterize a single glyph and pack it into the atlas.
+    fn rasterize_glyph(&mut self, ch: char, bold: bool, italic: bool) -> AtlasEntry {
+        let line_height = self.cell_height;
+        let metrics = Metrics::new(self.font_size, line_height);
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+        buffer.set_size(
+            &mut self.font_system,
+            Some(self.cell_width * 4.0),
+            Some(line_height * 2.0),
+        );
+
+        let weight = if bold { Weight::BOLD } else { Weight::NORMAL };
+        let style = if italic { Style::Italic } else { Style::Normal };
+        let attrs = Attrs::new()
+            .family(Family::Name(&self.font_family))
+            .weight(weight)
+            .style(style);
+
+        let text = ch.to_string();
+        buffer.set_text(&mut self.font_system, &text, attrs, Shaping::Advanced);
+        buffer.shape_until_scroll(&mut self.font_system, false);
+
+        // Collect glyph image data from cosmic-text SwashCache.
+        let mut glyph_pixels: Vec<u8> = Vec::new();
+        let mut glyph_w: u32 = 0;
+        let mut glyph_h: u32 = 0;
+        let mut offset_x: i32 = 0;
+        let mut offset_y: i32 = 0;
+
+        for run in buffer.layout_runs() {
+            for layout_glyph in run.glyphs.iter() {
+                let physical = layout_glyph.physical((0.0, 0.0), 1.0);
+                if let Some(image) = self
+                    .swash_cache
+                    .get_image(&mut self.font_system, physical.cache_key)
+                {
+                    let w = image.placement.width;
+                    let h = image.placement.height;
+                    if w == 0 || h == 0 {
+                        continue;
+                    }
+
+                    glyph_w = w;
+                    glyph_h = h;
+                    offset_x = image.placement.left;
+                    offset_y = image.placement.top;
+
+                    // Convert image data to single-channel alpha.
+                    // cosmic-text may return different formats.
+                    match image.content {
+                        cosmic_text::SwashContent::Mask => {
+                            // 1 byte per pixel: direct alpha/coverage
+                            glyph_pixels = image.data.clone();
+                        }
+                        cosmic_text::SwashContent::Color => {
+                            // 4 bytes per pixel (RGBA): extract alpha
+                            glyph_pixels = image
+                                .data
+                                .chunks_exact(4)
+                                .map(|px| px[3])
+                                .collect();
+                        }
+                        cosmic_text::SwashContent::SubpixelMask => {
+                            // 3 bytes per pixel (RGB subpixel): average as coverage
+                            glyph_pixels = image
+                                .data
+                                .chunks_exact(3)
+                                .map(|px| {
+                                    ((px[0] as u16 + px[1] as u16 + px[2] as u16) / 3) as u8
+                                })
+                                .collect();
+                        }
+                    }
+                    break; // Only need the first glyph
+                }
+            }
+            break; // Only need the first layout run
+        }
+
+        // If rasterization produced nothing, return the blank entry.
+        if glyph_w == 0 || glyph_h == 0 || glyph_pixels.is_empty() {
+            let blank_key = GlyphKey { ch: ' ', bold: false, italic: false };
+            return *self.entries.get(&blank_key).unwrap();
+        }
+
+        // Check if we need to wrap to a new row.
+        if self.cursor_x + glyph_w >= self.atlas_width {
+            self.cursor_y += self.row_height + 1; // +1 for padding
+            self.cursor_x = 0;
+            self.row_height = 0;
+        }
+
+        // Check if we need to grow the atlas vertically.
+        while self.cursor_y + glyph_h >= self.atlas_height {
+            self.grow_atlas();
+        }
+
+        // Blit glyph pixels into the atlas (RED channel only).
+        let x0 = self.cursor_x;
+        let y0 = self.cursor_y;
+        for row in 0..glyph_h {
+            for col in 0..glyph_w {
+                let src_idx = (row * glyph_w + col) as usize;
+                let dst_x = x0 + col;
+                let dst_y = y0 + row;
+                let dst_idx = ((dst_y * self.atlas_width + dst_x) * 4) as usize;
+                if src_idx < glyph_pixels.len() && dst_idx + 3 < self.atlas_data.len() {
+                    self.atlas_data[dst_idx] = glyph_pixels[src_idx]; // R = alpha
+                    self.atlas_data[dst_idx + 1] = 0;
+                    self.atlas_data[dst_idx + 2] = 0;
+                    self.atlas_data[dst_idx + 3] = 255; // Texture alpha = opaque
+                }
+            }
+        }
+
+        let entry = AtlasEntry {
+            u0: x0 as f32 / self.atlas_width as f32,
+            v0: y0 as f32 / self.atlas_height as f32,
+            u1: (x0 + glyph_w) as f32 / self.atlas_width as f32,
+            v1: (y0 + glyph_h) as f32 / self.atlas_height as f32,
+            width: glyph_w,
+            height: glyph_h,
+            offset_x,
+            offset_y,
+        };
+
+        // Advance cursor.
+        self.cursor_x += glyph_w + 1; // +1 for padding between glyphs
+        if glyph_h > self.row_height {
+            self.row_height = glyph_h;
+        }
+        self.dirty = true;
+
+        entry
+    }
+
+    /// Double the atlas height and copy existing data.
+    fn grow_atlas(&mut self) {
+        let new_height = self.atlas_height * 2;
+        log::info!(
+            "GlyphAtlas: growing from {}x{} to {}x{}",
+            self.atlas_width,
+            self.atlas_height,
+            self.atlas_width,
+            new_height
+        );
+
+        let mut new_data = vec![0u8; (self.atlas_width * new_height * 4) as usize];
+        new_data[..self.atlas_data.len()].copy_from_slice(&self.atlas_data);
+        self.atlas_data = new_data;
+
+        // Recalculate UV coordinates for existing entries.
+        let height_ratio = self.atlas_height as f32 / new_height as f32;
+        for entry in self.entries.values_mut() {
+            entry.v0 *= height_ratio;
+            entry.v1 *= height_ratio;
+        }
+
+        self.atlas_height = new_height;
+        self.texture = None; // Force re-creation of GPU texture
+        self.dirty = true;
+    }
+
+    /// Ensure the GPU texture exists and is up to date with atlas_data.
+    ///
+    /// Creates the texture on first call, then re-uploads data whenever `dirty`.
+    /// Returns a reference to the GPU texture.
+    pub fn ensure_gpu_texture(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> &wgpu::Texture {
+        let needs_create = self.texture.is_none();
+
+        if needs_create {
+            let texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("glyph_atlas"),
+                size: wgpu::Extent3d {
+                    width: self.atlas_width,
+                    height: self.atlas_height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+            self.texture = Some(texture);
+            self.dirty = true; // Force upload after creation
+        }
+
+        if self.dirty {
+            if let Some(ref texture) = self.texture {
+                queue.write_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    &self.atlas_data,
+                    wgpu::TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(self.atlas_width * 4),
+                        rows_per_image: Some(self.atlas_height),
+                    },
+                    wgpu::Extent3d {
+                        width: self.atlas_width,
+                        height: self.atlas_height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                self.dirty = false;
+            }
+        }
+
+        self.texture.as_ref().unwrap()
+    }
+
+    /// Returns (cell_width, cell_height) in pixels.
+    pub fn cell_size(&self) -> (f32, f32) {
+        (self.cell_width, self.cell_height)
+    }
+
+    /// Returns the current atlas dimensions (width, height).
+    pub fn atlas_dimensions(&self) -> (u32, u32) {
+        (self.atlas_width, self.atlas_height)
+    }
+
+    /// Returns the number of cached glyph entries.
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atlas_creation_succeeds() {
+        let atlas = GlyphAtlas::new("Cascadia Code", 14.0);
+        let (cw, ch) = atlas.cell_size();
+        assert!(cw > 0.0, "cell width must be positive");
+        assert!(ch > 0.0, "cell height must be positive");
+    }
+
+    #[test]
+    fn atlas_has_preloaded_ascii() {
+        let atlas = GlyphAtlas::new("Consolas", 14.0);
+        // ASCII printable range is 95 chars (32..=126).
+        // We pre-rasterize normal + bold = 190 entries + 1 space base entry.
+        // Some chars map to the blank entry (like space variants), but entries >= 95.
+        assert!(
+            atlas.entry_count() >= 95,
+            "Expected at least 95 entries, got {}",
+            atlas.entry_count()
+        );
+    }
+
+    #[test]
+    fn get_or_insert_returns_same_entry() {
+        let mut atlas = GlyphAtlas::new("Consolas", 14.0);
+        let e1 = atlas.get_or_insert('A', false, false);
+        let e2 = atlas.get_or_insert('A', false, false);
+        assert!((e1.u0 - e2.u0).abs() < f32::EPSILON);
+        assert!((e1.v0 - e2.v0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn bold_and_normal_are_different_entries() {
+        let mut atlas = GlyphAtlas::new("Consolas", 14.0);
+        let normal = atlas.get_or_insert('A', false, false);
+        let bold = atlas.get_or_insert('A', true, false);
+        // They should be separate atlas entries (different UV regions),
+        // unless the font happens to render them identically.
+        // At minimum, both should be valid.
+        assert!(normal.u1 > normal.u0 || normal.width == 0);
+        assert!(bold.u1 > bold.u0 || bold.width == 0);
+    }
+
+    #[test]
+    fn space_returns_blank_entry() {
+        let mut atlas = GlyphAtlas::new("Consolas", 14.0);
+        let entry = atlas.get_or_insert(' ', false, false);
+        assert_eq!(entry.width, 0);
+        assert_eq!(entry.height, 0);
+    }
+
+    #[test]
+    fn unicode_glyph_can_be_inserted() {
+        let mut atlas = GlyphAtlas::new("Consolas", 14.0);
+        // This may fall back to blank if the font doesn't have it,
+        // but it should not panic.
+        let _entry = atlas.get_or_insert('\u{2588}', false, false); // Full block
+        let _entry = atlas.get_or_insert('\u{00e9}', false, false); // e-acute
+    }
+}

--- a/src-tauri/renderer/src/color.rs
+++ b/src-tauri/renderer/src/color.rs
@@ -1,0 +1,132 @@
+/// Parse a hex color string like "#cd3131" into normalized [f32; 4] RGBA.
+/// Returns None if the string is not a valid 6-digit hex color with '#' prefix.
+pub fn parse_hex_color(hex: &str) -> Option<[f32; 4]> {
+    let hex = hex.strip_prefix('#')?;
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some([
+        r as f32 / 255.0,
+        g as f32 / 255.0,
+        b as f32 / 255.0,
+        1.0,
+    ])
+}
+
+/// Resolve foreground and background colors for a cell, applying defaults and inverse.
+///
+/// Colors from RichGridData are either hex strings like "#cd3131" or "default".
+/// When a color is "default", the theme default is used.
+/// When `inverse` is true, foreground and background are swapped after resolution.
+pub fn resolve_cell_colors(
+    fg: &str,
+    bg: &str,
+    inverse: bool,
+    default_fg: [f32; 4],
+    default_bg: [f32; 4],
+) -> ([f32; 4], [f32; 4]) {
+    let fg_color = if fg == "default" {
+        default_fg
+    } else {
+        parse_hex_color(fg).unwrap_or(default_fg)
+    };
+
+    let bg_color = if bg == "default" {
+        default_bg
+    } else {
+        parse_hex_color(bg).unwrap_or(default_bg)
+    };
+
+    if inverse {
+        (bg_color, fg_color)
+    } else {
+        (fg_color, bg_color)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_red() {
+        let c = parse_hex_color("#ff0000").unwrap();
+        assert!((c[0] - 1.0).abs() < 0.01);
+        assert!(c[1].abs() < 0.01);
+        assert!(c[2].abs() < 0.01);
+        assert!((c[3] - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_green() {
+        let c = parse_hex_color("#00ff00").unwrap();
+        assert!(c[0].abs() < 0.01);
+        assert!((c[1] - 1.0).abs() < 0.01);
+        assert!(c[2].abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_blue() {
+        let c = parse_hex_color("#0000ff").unwrap();
+        assert!(c[0].abs() < 0.01);
+        assert!(c[1].abs() < 0.01);
+        assert!((c[2] - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_mixed_color() {
+        let c = parse_hex_color("#cd3131").unwrap();
+        assert!((c[0] - 0xcd as f32 / 255.0).abs() < 0.01);
+        assert!((c[1] - 0x31 as f32 / 255.0).abs() < 0.01);
+        assert!((c[2] - 0x31 as f32 / 255.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_invalid_returns_none() {
+        assert!(parse_hex_color("default").is_none());
+        assert!(parse_hex_color("").is_none());
+        assert!(parse_hex_color("#fff").is_none());
+        assert!(parse_hex_color("#zzzzzz").is_none());
+        assert!(parse_hex_color("ff0000").is_none());
+    }
+
+    #[test]
+    fn resolve_defaults() {
+        let dfg = [1.0, 1.0, 1.0, 1.0];
+        let dbg = [0.0, 0.0, 0.0, 1.0];
+        let (fg, bg) = resolve_cell_colors("default", "default", false, dfg, dbg);
+        assert_eq!(fg, dfg);
+        assert_eq!(bg, dbg);
+    }
+
+    #[test]
+    fn resolve_explicit_colors() {
+        let dfg = [1.0, 1.0, 1.0, 1.0];
+        let dbg = [0.0, 0.0, 0.0, 1.0];
+        let (fg, bg) = resolve_cell_colors("#ff0000", "#00ff00", false, dfg, dbg);
+        assert!((fg[0] - 1.0).abs() < 0.01);
+        assert!((bg[1] - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn resolve_inverse_swaps() {
+        let dfg = [1.0, 1.0, 1.0, 1.0];
+        let dbg = [0.0, 0.0, 0.0, 1.0];
+        let (fg, bg) = resolve_cell_colors("default", "default", true, dfg, dbg);
+        // Inverse: fg gets default_bg, bg gets default_fg
+        assert_eq!(fg, dbg);
+        assert_eq!(bg, dfg);
+    }
+
+    #[test]
+    fn resolve_invalid_hex_uses_default() {
+        let dfg = [0.8, 0.8, 0.8, 1.0];
+        let dbg = [0.1, 0.1, 0.1, 1.0];
+        let (fg, bg) = resolve_cell_colors("not-a-color", "also-bad", false, dfg, dbg);
+        assert_eq!(fg, dfg);
+        assert_eq!(bg, dbg);
+    }
+}

--- a/src-tauri/renderer/src/device.rs
+++ b/src-tauri/renderer/src/device.rs
@@ -1,0 +1,58 @@
+use crate::GpuError;
+
+/// Shared GPU device and queue for headless (offscreen) rendering.
+///
+/// The device can be shared across multiple `GpuRenderer` instances
+/// if needed, but each renderer typically owns its own `GpuDevice`.
+pub struct GpuDevice {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+}
+
+impl GpuDevice {
+    /// Create a new GPU device for headless rendering.
+    ///
+    /// Uses `pollster::block_on` for synchronous initialization.
+    /// Requests a low-power adapter since terminal rendering is background work.
+    /// No surface is needed -- all rendering is to offscreen textures.
+    pub fn new() -> Result<Self, GpuError> {
+        pollster::block_on(Self::new_async())
+    }
+
+    async fn new_async() -> Result<Self, GpuError> {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::LowPower,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .ok_or(GpuError::NoAdapter)?;
+
+        log::info!(
+            "GPU adapter: {:?} ({:?})",
+            adapter.get_info().name,
+            adapter.get_info().backend
+        );
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("godly-renderer"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::downlevel_defaults(),
+                    memory_hints: wgpu::MemoryHints::MemoryUsage,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| GpuError::DeviceError(e.to_string()))?;
+
+        Ok(Self { device, queue })
+    }
+}

--- a/src-tauri/renderer/src/lib.rs
+++ b/src-tauri/renderer/src/lib.rs
@@ -1,0 +1,65 @@
+//! GPU-accelerated terminal renderer for Godly Terminal.
+//!
+//! This crate renders `RichGridData` terminal snapshots (from `godly-protocol`)
+//! to raw RGBA pixel buffers or PNG images using wgpu. It is designed for
+//! headless/offscreen rendering -- no window or surface is needed.
+//!
+//! # Architecture
+//!
+//! - **GpuDevice** — wgpu adapter/device/queue initialization (headless).
+//! - **GlyphAtlas** — Font loading (cosmic-text), glyph rasterization, texture atlas management.
+//! - **RenderPipeline** — wgpu render pipeline with WGSL shaders for textured cell quads.
+//! - **GpuRenderer** — Main API: `RichGridData` → pixel buffer or PNG.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use godly_renderer::{GpuRenderer, TerminalTheme};
+//! use godly_protocol::types::RichGridData;
+//!
+//! let mut renderer = GpuRenderer::new("Cascadia Code", 14.0).unwrap();
+//! renderer.set_theme(TerminalTheme::default());
+//!
+//! // Given a RichGridData from the daemon:
+//! // let (width, height, pixels) = renderer.render_to_pixels(&grid).unwrap();
+//! // let png_bytes = renderer.render_to_png(&grid).unwrap();
+//! ```
+
+pub mod atlas;
+pub mod color;
+pub mod device;
+pub mod pipeline;
+pub mod renderer;
+pub mod theme;
+
+pub use color::{parse_hex_color, resolve_cell_colors};
+pub use renderer::GpuRenderer;
+pub use theme::TerminalTheme;
+
+use std::fmt;
+
+/// Errors that can occur during GPU rendering.
+#[derive(Debug)]
+pub enum GpuError {
+    /// No suitable GPU adapter was found on the system.
+    NoAdapter,
+    /// Failed to create the GPU device.
+    DeviceError(String),
+    /// An error occurred during rendering.
+    RenderError(String),
+    /// Image encoding/decoding failed.
+    ImageError,
+}
+
+impl fmt::Display for GpuError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GpuError::NoAdapter => write!(f, "No suitable GPU adapter found"),
+            GpuError::DeviceError(msg) => write!(f, "Failed to create GPU device: {}", msg),
+            GpuError::RenderError(msg) => write!(f, "Render error: {}", msg),
+            GpuError::ImageError => write!(f, "Image encoding error"),
+        }
+    }
+}
+
+impl std::error::Error for GpuError {}

--- a/src-tauri/renderer/src/pipeline.rs
+++ b/src-tauri/renderer/src/pipeline.rs
@@ -1,0 +1,145 @@
+/// Vertex data for a single corner of a cell quad.
+///
+/// Each cell is drawn as two triangles (6 vertices). The vertex carries
+/// its clip-space position, atlas UV coordinates, and foreground/background
+/// colors so the fragment shader can composite the glyph.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CellVertex {
+    /// Clip-space position (x, y) in range [-1, 1].
+    pub position: [f32; 2],
+    /// Texture UV coordinate into the glyph atlas.
+    pub uv: [f32; 2],
+    /// Foreground color (RGBA, normalized).
+    pub fg_color: [f32; 4],
+    /// Background color (RGBA, normalized).
+    pub bg_color: [f32; 4],
+}
+
+impl CellVertex {
+    /// Vertex buffer layout descriptor for wgpu.
+    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
+        const ATTRS: &[wgpu::VertexAttribute] = &[
+            // position: location 0
+            wgpu::VertexAttribute {
+                offset: 0,
+                shader_location: 0,
+                format: wgpu::VertexFormat::Float32x2,
+            },
+            // uv: location 1
+            wgpu::VertexAttribute {
+                offset: std::mem::size_of::<[f32; 2]>() as u64,
+                shader_location: 1,
+                format: wgpu::VertexFormat::Float32x2,
+            },
+            // fg_color: location 2
+            wgpu::VertexAttribute {
+                offset: std::mem::size_of::<[f32; 4]>() as u64,
+                shader_location: 2,
+                format: wgpu::VertexFormat::Float32x4,
+            },
+            // bg_color: location 3
+            wgpu::VertexAttribute {
+                offset: std::mem::size_of::<[f32; 8]>() as u64,
+                shader_location: 3,
+                format: wgpu::VertexFormat::Float32x4,
+            },
+        ];
+
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<CellVertex>() as u64,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: ATTRS,
+        }
+    }
+}
+
+/// Compiled render pipeline and bind group layout for terminal cell rendering.
+pub struct RenderPipeline {
+    pub pipeline: wgpu::RenderPipeline,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl RenderPipeline {
+    /// Create the render pipeline for the given output texture format.
+    ///
+    /// Loads the WGSL shader from the embedded `shaders/terminal.wgsl`,
+    /// sets up the bind group layout for the glyph atlas texture + sampler,
+    /// and creates the pipeline with alpha blending.
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let shader_source = include_str!("shaders/terminal.wgsl");
+        let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("terminal_shader"),
+            source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("atlas_bind_group_layout"),
+            entries: &[
+                // @binding(0): atlas texture
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                // @binding(1): sampler
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("terminal_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("terminal_render_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader_module,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[CellVertex::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader_module,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None, // No culling for 2D quads
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            bind_group_layout,
+        }
+    }
+}

--- a/src-tauri/renderer/src/renderer.rs
+++ b/src-tauri/renderer/src/renderer.rs
@@ -1,0 +1,423 @@
+use godly_protocol::types::RichGridData;
+
+use crate::atlas::GlyphAtlas;
+use crate::color::resolve_cell_colors;
+use crate::device::GpuDevice;
+use crate::pipeline::{CellVertex, RenderPipeline};
+use crate::theme::TerminalTheme;
+use crate::GpuError;
+
+/// GPU-accelerated terminal renderer.
+///
+/// Takes `RichGridData` snapshots from the daemon and renders them to
+/// raw RGBA pixel buffers or PNG images using wgpu.
+pub struct GpuRenderer {
+    device: GpuDevice,
+    atlas: GlyphAtlas,
+    pipeline: RenderPipeline,
+    theme: TerminalTheme,
+}
+
+/// Output texture format used for offscreen rendering.
+const OUTPUT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+
+impl GpuRenderer {
+    /// Create a new GPU renderer with the given font family and size.
+    ///
+    /// Initializes the GPU device, glyph atlas, and render pipeline.
+    /// Returns `GpuError::NoAdapter` if no GPU is available.
+    pub fn new(font_family: &str, font_size: f32) -> Result<Self, GpuError> {
+        let device = GpuDevice::new()?;
+        let atlas = GlyphAtlas::new(font_family, font_size);
+        let pipeline = RenderPipeline::new(&device.device, OUTPUT_FORMAT);
+        let theme = TerminalTheme::default();
+
+        Ok(Self {
+            device,
+            atlas,
+            pipeline,
+            theme,
+        })
+    }
+
+    /// Set the terminal color theme.
+    pub fn set_theme(&mut self, theme: TerminalTheme) {
+        self.theme = theme;
+    }
+
+    /// Returns the current cell size (width, height) in pixels.
+    pub fn cell_size(&self) -> (f32, f32) {
+        self.atlas.cell_size()
+    }
+
+    /// Render a `RichGridData` snapshot to raw RGBA pixels.
+    ///
+    /// Returns `(width, height, rgba_pixels)` where `rgba_pixels` has
+    /// length `width * height * 4`.
+    pub fn render_to_pixels(
+        &mut self,
+        grid: &RichGridData,
+    ) -> Result<(u32, u32, Vec<u8>), GpuError> {
+        let (cell_w, cell_h) = self.atlas.cell_size();
+        let width = (grid.dimensions.cols as f32 * cell_w).ceil() as u32;
+        let height = (grid.dimensions.rows as f32 * cell_h).ceil() as u32;
+
+        if width == 0 || height == 0 {
+            return Ok((width, height, Vec::new()));
+        }
+
+        // 1. Build vertex data for all cells.
+        let vertices = self.build_vertices(grid, width, height);
+
+        if vertices.is_empty() {
+            // No visible content -- return a solid background.
+            let bg = self.theme.background;
+            let r = (bg[0] * 255.0) as u8;
+            let g = (bg[1] * 255.0) as u8;
+            let b = (bg[2] * 255.0) as u8;
+            let a = (bg[3] * 255.0) as u8;
+            let mut pixels = vec![0u8; (width * height * 4) as usize];
+            for pixel in pixels.chunks_exact_mut(4) {
+                pixel[0] = r;
+                pixel[1] = g;
+                pixel[2] = b;
+                pixel[3] = a;
+            }
+            return Ok((width, height, pixels));
+        }
+
+        let dev = &self.device.device;
+        let queue = &self.device.queue;
+
+        // 2. Upload vertex buffer.
+        let vertex_data = bytemuck::cast_slice(&vertices);
+        let vertex_buffer = dev.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("vertex_buffer"),
+            size: vertex_data.len() as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&vertex_buffer, 0, vertex_data);
+
+        // 3. Ensure glyph atlas texture is uploaded.
+        let atlas_texture = self.atlas.ensure_gpu_texture(dev, queue);
+        let atlas_view = atlas_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let atlas_sampler = dev.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("atlas_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let bind_group = dev.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("atlas_bind_group"),
+            layout: &self.pipeline.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&atlas_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&atlas_sampler),
+                },
+            ],
+        });
+
+        // 4. Create output texture.
+        let output_texture = dev.create_texture(&wgpu::TextureDescriptor {
+            label: Some("output_texture"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: OUTPUT_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let output_view = output_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // 5. Record and submit render pass.
+        let mut encoder = dev.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("render_encoder"),
+        });
+
+        // Convert theme background to wgpu::Color (needs f64).
+        let bg = self.theme.background;
+        let clear_color = wgpu::Color {
+            r: bg[0] as f64,
+            g: bg[1] as f64,
+            b: bg[2] as f64,
+            a: bg[3] as f64,
+        };
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("terminal_render_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &output_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(clear_color),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            pass.set_pipeline(&self.pipeline.pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+            pass.draw(0..vertices.len() as u32, 0..1);
+        }
+
+        // 6. Copy output texture to staging buffer for CPU readback.
+        // Row alignment: wgpu requires rows to be aligned to 256 bytes.
+        let bytes_per_row = width * 4;
+        let aligned_bytes_per_row = (bytes_per_row + 255) & !255;
+        let staging_size = (aligned_bytes_per_row * height) as u64;
+
+        let staging_buffer = dev.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("staging_buffer"),
+            size: staging_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &output_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(aligned_bytes_per_row),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        queue.submit(std::iter::once(encoder.finish()));
+
+        // 7. Map staging buffer and read pixels.
+        let buffer_slice = staging_buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+        self.device.device.poll(wgpu::Maintain::Wait);
+
+        rx.recv()
+            .map_err(|e| GpuError::RenderError(format!("Buffer map channel error: {}", e)))?
+            .map_err(|e| GpuError::RenderError(format!("Buffer map failed: {}", e)))?;
+
+        let mapped = buffer_slice.get_mapped_range();
+
+        // Remove row alignment padding.
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for row in 0..height {
+            let start = (row * aligned_bytes_per_row) as usize;
+            let end = start + bytes_per_row as usize;
+            pixels.extend_from_slice(&mapped[start..end]);
+        }
+
+        drop(mapped);
+        staging_buffer.unmap();
+
+        Ok((width, height, pixels))
+    }
+
+    /// Render a `RichGridData` snapshot to PNG bytes.
+    pub fn render_to_png(&mut self, grid: &RichGridData) -> Result<Vec<u8>, GpuError> {
+        let (width, height, pixels) = self.render_to_pixels(grid)?;
+        if width == 0 || height == 0 {
+            return Err(GpuError::RenderError("Empty grid".to_string()));
+        }
+
+        let img = image::RgbaImage::from_raw(width, height, pixels)
+            .ok_or(GpuError::ImageError)?;
+        let mut png_bytes = Vec::new();
+        img.write_to(
+            &mut std::io::Cursor::new(&mut png_bytes),
+            image::ImageFormat::Png,
+        )
+        .map_err(|e| GpuError::RenderError(format!("PNG encode error: {}", e)))?;
+        Ok(png_bytes)
+    }
+
+    /// Build vertex data for all cells in the grid.
+    ///
+    /// Each non-continuation cell produces 6 vertices (2 triangles).
+    /// Positions are in clip space (-1..1). UVs reference the glyph atlas.
+    fn build_vertices(
+        &mut self,
+        grid: &RichGridData,
+        width: u32,
+        height: u32,
+    ) -> Vec<CellVertex> {
+        let (cell_w, cell_h) = self.atlas.cell_size();
+        let capacity = grid.dimensions.rows as usize * grid.dimensions.cols as usize * 6;
+        let mut vertices = Vec::with_capacity(capacity);
+        let w_f = width as f32;
+        let h_f = height as f32;
+
+        for (row_idx, row) in grid.rows.iter().enumerate() {
+            for (col_idx, cell) in row.cells.iter().enumerate() {
+                // Skip wide continuation cells (drawn by the wide-start cell).
+                if cell.wide_continuation {
+                    continue;
+                }
+
+                // Pixel position of cell top-left corner.
+                let x = col_idx as f32 * cell_w;
+                let y = row_idx as f32 * cell_h;
+                let w = if cell.wide { cell_w * 2.0 } else { cell_w };
+                let h = cell_h;
+
+                // Resolve foreground/background colors.
+                let (mut fg, bg) = resolve_cell_colors(
+                    &cell.fg,
+                    &cell.bg,
+                    cell.inverse,
+                    self.theme.foreground,
+                    self.theme.background,
+                );
+
+                // Apply dim attribute: halve foreground brightness.
+                if cell.dim {
+                    fg = [fg[0] * 0.5, fg[1] * 0.5, fg[2] * 0.5, fg[3]];
+                }
+
+                // Get glyph atlas entry.
+                let ch = cell.content.chars().next().unwrap_or(' ');
+                let entry = self.atlas.get_or_insert(ch, cell.bold, cell.italic);
+
+                // Convert pixel coords to clip space: x: -1..1, y: 1..-1 (top to bottom).
+                let x0 = (x / w_f) * 2.0 - 1.0;
+                let y0 = 1.0 - (y / h_f) * 2.0;
+                let x1 = ((x + w) / w_f) * 2.0 - 1.0;
+                let y1 = 1.0 - ((y + h) / h_f) * 2.0;
+
+                // Two triangles per cell (6 vertices).
+                // Triangle 1: top-left, top-right, bottom-left
+                // Triangle 2: bottom-left, top-right, bottom-right
+                vertices.extend_from_slice(&[
+                    CellVertex {
+                        position: [x0, y0],
+                        uv: [entry.u0, entry.v0],
+                        fg_color: fg,
+                        bg_color: bg,
+                    },
+                    CellVertex {
+                        position: [x1, y0],
+                        uv: [entry.u1, entry.v0],
+                        fg_color: fg,
+                        bg_color: bg,
+                    },
+                    CellVertex {
+                        position: [x0, y1],
+                        uv: [entry.u0, entry.v1],
+                        fg_color: fg,
+                        bg_color: bg,
+                    },
+                    CellVertex {
+                        position: [x0, y1],
+                        uv: [entry.u0, entry.v1],
+                        fg_color: fg,
+                        bg_color: bg,
+                    },
+                    CellVertex {
+                        position: [x1, y0],
+                        uv: [entry.u1, entry.v0],
+                        fg_color: fg,
+                        bg_color: bg,
+                    },
+                    CellVertex {
+                        position: [x1, y1],
+                        uv: [entry.u1, entry.v1],
+                        fg_color: fg,
+                        bg_color: bg,
+                    },
+                ]);
+            }
+        }
+
+        // Add cursor overlay if visible.
+        if !grid.cursor_hidden {
+            let cursor_row = grid.cursor.row as usize;
+            let cursor_col = grid.cursor.col as usize;
+
+            let x = cursor_col as f32 * cell_w;
+            let y = cursor_row as f32 * cell_h;
+
+            let x0 = (x / w_f) * 2.0 - 1.0;
+            let y0 = 1.0 - (y / h_f) * 2.0;
+            let x1 = ((x + cell_w) / w_f) * 2.0 - 1.0;
+            let y1 = 1.0 - ((y + cell_h) / h_f) * 2.0;
+
+            let cursor_fg = self.theme.cursor_color;
+            // Use cursor color as bg so it shows as a solid block.
+            // The glyph UV points to blank (space) so alpha=0, meaning
+            // mix() returns bg_color = cursor_color.
+            let blank = self.atlas.get_or_insert(' ', false, false);
+
+            vertices.extend_from_slice(&[
+                CellVertex {
+                    position: [x0, y0],
+                    uv: [blank.u0, blank.v0],
+                    fg_color: cursor_fg,
+                    bg_color: cursor_fg,
+                },
+                CellVertex {
+                    position: [x1, y0],
+                    uv: [blank.u1, blank.v0],
+                    fg_color: cursor_fg,
+                    bg_color: cursor_fg,
+                },
+                CellVertex {
+                    position: [x0, y1],
+                    uv: [blank.u0, blank.v1],
+                    fg_color: cursor_fg,
+                    bg_color: cursor_fg,
+                },
+                CellVertex {
+                    position: [x0, y1],
+                    uv: [blank.u0, blank.v1],
+                    fg_color: cursor_fg,
+                    bg_color: cursor_fg,
+                },
+                CellVertex {
+                    position: [x1, y0],
+                    uv: [blank.u1, blank.v0],
+                    fg_color: cursor_fg,
+                    bg_color: cursor_fg,
+                },
+                CellVertex {
+                    position: [x1, y1],
+                    uv: [blank.u1, blank.v1],
+                    fg_color: cursor_fg,
+                    bg_color: cursor_fg,
+                },
+            ]);
+        }
+
+        vertices
+    }
+}

--- a/src-tauri/renderer/src/shaders/terminal.wgsl
+++ b/src-tauri/renderer/src/shaders/terminal.wgsl
@@ -1,0 +1,35 @@
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) fg_color: vec4<f32>,
+    @location(3) bg_color: vec4<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) fg_color: vec4<f32>,
+    @location(2) bg_color: vec4<f32>,
+};
+
+@group(0) @binding(0)
+var atlas_texture: texture_2d<f32>;
+@group(0) @binding(1)
+var atlas_sampler: sampler;
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+    output.position = vec4<f32>(input.position, 0.0, 1.0);
+    output.uv = input.uv;
+    output.fg_color = input.fg_color;
+    output.bg_color = input.bg_color;
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let glyph_alpha = textureSample(atlas_texture, atlas_sampler, input.uv).r;
+    // Blend: background where no glyph, foreground where glyph is present
+    return mix(input.bg_color, input.fg_color, glyph_alpha);
+}

--- a/src-tauri/renderer/src/theme.rs
+++ b/src-tauri/renderer/src/theme.rs
@@ -1,0 +1,48 @@
+/// Terminal color theme for GPU rendering.
+///
+/// All colors are normalized RGBA in the range [0.0, 1.0].
+#[derive(Debug, Clone)]
+pub struct TerminalTheme {
+    /// Default text foreground color.
+    pub foreground: [f32; 4],
+    /// Default background color.
+    pub background: [f32; 4],
+    /// Cursor block color.
+    pub cursor_color: [f32; 4],
+    /// Selection highlight background color.
+    pub selection_bg: [f32; 4],
+}
+
+impl Default for TerminalTheme {
+    fn default() -> Self {
+        // Dark theme: light gray text on dark background
+        Self {
+            foreground: [0.8, 0.8, 0.8, 1.0],
+            background: [0.12, 0.12, 0.12, 1.0],
+            cursor_color: [0.8, 0.8, 0.8, 0.8],
+            selection_bg: [0.3, 0.4, 0.6, 0.5],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_theme_has_valid_colors() {
+        let theme = TerminalTheme::default();
+        for color in &[theme.foreground, theme.background, theme.cursor_color, theme.selection_bg] {
+            for component in color {
+                assert!(*component >= 0.0 && *component <= 1.0);
+            }
+        }
+    }
+
+    #[test]
+    fn default_theme_foreground_is_light() {
+        let theme = TerminalTheme::default();
+        // Foreground should be lighter than background (dark theme)
+        assert!(theme.foreground[0] > theme.background[0]);
+    }
+}

--- a/src-tauri/renderer/tests/render_test.rs
+++ b/src-tauri/renderer/tests/render_test.rs
@@ -1,0 +1,351 @@
+use godly_protocol::types::*;
+use godly_renderer::{parse_hex_color, resolve_cell_colors, GpuRenderer, TerminalTheme};
+
+/// Helper: create a RichGridCell with given content and defaults.
+fn make_cell(content: &str) -> RichGridCell {
+    RichGridCell {
+        content: content.to_string(),
+        fg: "default".to_string(),
+        bg: "default".to_string(),
+        bold: false,
+        dim: false,
+        italic: false,
+        underline: false,
+        inverse: false,
+        wide: false,
+        wide_continuation: false,
+    }
+}
+
+/// Helper: create a colored cell.
+fn make_colored_cell(content: &str, fg: &str, bg: &str) -> RichGridCell {
+    RichGridCell {
+        content: content.to_string(),
+        fg: fg.to_string(),
+        bg: bg.to_string(),
+        bold: false,
+        dim: false,
+        italic: false,
+        underline: false,
+        inverse: false,
+        wide: false,
+        wide_continuation: false,
+    }
+}
+
+/// Helper: create a styled cell.
+fn make_styled_cell(content: &str, bold: bool, italic: bool, dim: bool) -> RichGridCell {
+    RichGridCell {
+        content: content.to_string(),
+        fg: "#ffffff".to_string(),
+        bg: "default".to_string(),
+        bold,
+        dim,
+        italic,
+        underline: false,
+        inverse: false,
+        wide: false,
+        wide_continuation: false,
+    }
+}
+
+/// Helper: pad a row of cells to the desired column count with spaces.
+fn pad_row(mut cells: Vec<RichGridCell>, cols: usize) -> Vec<RichGridCell> {
+    while cells.len() < cols {
+        cells.push(make_cell(" "));
+    }
+    cells.truncate(cols);
+    cells
+}
+
+/// Build a small 3-row x 10-col test grid with mixed content.
+fn make_test_grid() -> RichGridData {
+    let cols = 10usize;
+
+    // Row 0: "Hello Wrld" in default colors
+    let row0_text = "HelloWorld";
+    let cells0: Vec<RichGridCell> = row0_text.chars().map(|ch| make_cell(&ch.to_string())).collect();
+
+    // Row 1: colored text
+    let cells1: Vec<RichGridCell> = "Red Green!".chars().enumerate().map(|(i, ch)| {
+        if i < 3 {
+            make_colored_cell(&ch.to_string(), "#ff0000", "default")
+        } else if i < 9 {
+            make_colored_cell(&ch.to_string(), "#00ff00", "#1e1e1e")
+        } else {
+            make_cell(&ch.to_string())
+        }
+    }).collect();
+
+    // Row 2: bold + italic
+    let cells2: Vec<RichGridCell> = "BoldItalic".chars().enumerate().map(|(i, ch)| {
+        if i < 4 {
+            make_styled_cell(&ch.to_string(), true, false, false)
+        } else {
+            make_styled_cell(&ch.to_string(), false, true, false)
+        }
+    }).collect();
+
+    RichGridData {
+        rows: vec![
+            RichGridRow { cells: pad_row(cells0, cols), wrapped: false },
+            RichGridRow { cells: pad_row(cells1, cols), wrapped: false },
+            RichGridRow { cells: pad_row(cells2, cols), wrapped: false },
+        ],
+        cursor: CursorState { row: 0, col: 0 },
+        dimensions: GridDimensions { rows: 3, cols: cols as u16 },
+        alternate_screen: false,
+        cursor_hidden: false,
+        title: String::new(),
+        scrollback_offset: 0,
+        total_scrollback: 0,
+    }
+}
+
+/// Build an empty grid (all spaces).
+fn make_empty_grid() -> RichGridData {
+    let cols = 5usize;
+    let rows = 2usize;
+    let cell_row: Vec<RichGridCell> = (0..cols).map(|_| make_cell(" ")).collect();
+    RichGridData {
+        rows: (0..rows)
+            .map(|_| RichGridRow {
+                cells: cell_row.clone(),
+                wrapped: false,
+            })
+            .collect(),
+        cursor: CursorState { row: 0, col: 0 },
+        dimensions: GridDimensions {
+            rows: rows as u16,
+            cols: cols as u16,
+        },
+        alternate_screen: false,
+        cursor_hidden: true,
+        title: String::new(),
+        scrollback_offset: 0,
+        total_scrollback: 0,
+    }
+}
+
+// ---- Color parsing tests ----
+
+#[test]
+fn test_color_parsing_red() {
+    let c = parse_hex_color("#ff0000").unwrap();
+    assert!((c[0] - 1.0).abs() < 0.01);
+    assert!(c[1].abs() < 0.01);
+    assert!(c[2].abs() < 0.01);
+    assert!((c[3] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn test_color_parsing_green() {
+    let c = parse_hex_color("#00ff00").unwrap();
+    assert!(c[0].abs() < 0.01);
+    assert!((c[1] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn test_color_parsing_blue() {
+    let c = parse_hex_color("#0000ff").unwrap();
+    assert!(c[0].abs() < 0.01);
+    assert!(c[1].abs() < 0.01);
+    assert!((c[2] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn test_color_parsing_white() {
+    let c = parse_hex_color("#ffffff").unwrap();
+    assert!((c[0] - 1.0).abs() < 0.01);
+    assert!((c[1] - 1.0).abs() < 0.01);
+    assert!((c[2] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn test_color_parsing_black() {
+    let c = parse_hex_color("#000000").unwrap();
+    assert!(c[0].abs() < 0.01);
+    assert!(c[1].abs() < 0.01);
+    assert!(c[2].abs() < 0.01);
+}
+
+#[test]
+fn test_color_parsing_invalid() {
+    assert!(parse_hex_color("default").is_none());
+    assert!(parse_hex_color("").is_none());
+    assert!(parse_hex_color("#fff").is_none());
+    assert!(parse_hex_color("not-a-color").is_none());
+}
+
+#[test]
+fn test_resolve_cell_colors_defaults() {
+    let dfg = [1.0, 1.0, 1.0, 1.0];
+    let dbg = [0.0, 0.0, 0.0, 1.0];
+    let (fg, bg) = resolve_cell_colors("default", "default", false, dfg, dbg);
+    assert_eq!(fg, dfg);
+    assert_eq!(bg, dbg);
+}
+
+#[test]
+fn test_resolve_cell_colors_inverse() {
+    let dfg = [1.0, 1.0, 1.0, 1.0];
+    let dbg = [0.0, 0.0, 0.0, 1.0];
+    let (fg, bg) = resolve_cell_colors("default", "default", true, dfg, dbg);
+    assert_eq!(fg, dbg);
+    assert_eq!(bg, dfg);
+}
+
+// ---- GPU renderer tests ----
+// These tests require a GPU adapter. They will fail in headless CI without one.
+
+#[test]
+fn test_render_basic_grid() {
+    let grid = make_test_grid();
+    let mut renderer = match GpuRenderer::new("Cascadia Code", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    let (width, height, pixels) = renderer.render_to_pixels(&grid).expect("render failed");
+    assert!(width > 0, "width should be positive");
+    assert!(height > 0, "height should be positive");
+    assert_eq!(
+        pixels.len(),
+        (width * height * 4) as usize,
+        "pixel buffer size mismatch"
+    );
+    // Verify non-zero pixels (something was rendered).
+    assert!(
+        pixels.iter().any(|&b| b != 0),
+        "pixels should not all be zero"
+    );
+}
+
+#[test]
+fn test_render_to_png() {
+    let grid = make_test_grid();
+    let mut renderer = match GpuRenderer::new("Cascadia Code", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    let png = renderer.render_to_png(&grid).expect("PNG render failed");
+    assert!(png.len() > 100, "Valid PNG should be at least 100 bytes");
+    // PNG magic bytes: 0x89 P N G
+    assert_eq!(
+        &png[..4],
+        &[0x89, 0x50, 0x4E, 0x47],
+        "PNG magic bytes mismatch"
+    );
+}
+
+#[test]
+fn test_render_empty_grid() {
+    let grid = make_empty_grid();
+    let mut renderer = match GpuRenderer::new("Consolas", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    let (width, height, pixels) = renderer.render_to_pixels(&grid).expect("render failed");
+    assert!(width > 0);
+    assert!(height > 0);
+    assert_eq!(pixels.len(), (width * height * 4) as usize);
+}
+
+#[test]
+fn test_render_with_custom_theme() {
+    let grid = make_test_grid();
+    let mut renderer = match GpuRenderer::new("Consolas", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    // Set a light theme.
+    renderer.set_theme(TerminalTheme {
+        foreground: [0.0, 0.0, 0.0, 1.0],
+        background: [1.0, 1.0, 1.0, 1.0],
+        cursor_color: [0.0, 0.0, 0.0, 1.0],
+        selection_bg: [0.6, 0.8, 1.0, 0.5],
+    });
+
+    let (width, height, pixels) = renderer.render_to_pixels(&grid).expect("render failed");
+    assert!(width > 0);
+    assert!(height > 0);
+    // With a white background, most pixels should be bright.
+    let bright_pixels = pixels.chunks_exact(4).filter(|px| px[0] > 200).count();
+    let total_pixels = (width * height) as usize;
+    assert!(
+        bright_pixels > total_pixels / 2,
+        "Light theme should have mostly bright pixels"
+    );
+}
+
+#[test]
+fn test_render_dimensions_match_grid() {
+    let grid = make_test_grid();
+    let mut renderer = match GpuRenderer::new("Consolas", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    let (cell_w, cell_h) = renderer.cell_size();
+    let expected_w = (grid.dimensions.cols as f32 * cell_w).ceil() as u32;
+    let expected_h = (grid.dimensions.rows as f32 * cell_h).ceil() as u32;
+
+    let (width, height, _pixels) = renderer.render_to_pixels(&grid).expect("render failed");
+    assert_eq!(width, expected_w, "output width should match grid cols * cell_w");
+    assert_eq!(height, expected_h, "output height should match grid rows * cell_h");
+}
+
+#[test]
+fn test_render_cursor_hidden() {
+    // When cursor is hidden, no cursor overlay should be drawn.
+    let mut grid = make_test_grid();
+    grid.cursor_hidden = true;
+
+    let mut renderer = match GpuRenderer::new("Consolas", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    // Should succeed without crash.
+    let result = renderer.render_to_pixels(&grid);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_multiple_renders_reuse_renderer() {
+    // Verify that the renderer can render multiple grids without issues.
+    let grid = make_test_grid();
+    let mut renderer = match GpuRenderer::new("Consolas", 14.0) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping GPU test (no adapter): {}", e);
+            return;
+        }
+    };
+
+    for _ in 0..3 {
+        let result = renderer.render_to_pixels(&grid);
+        assert!(result.is_ok(), "repeated render should succeed");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `godly-renderer` crate at `src-tauri/renderer/` that renders `RichGridData` terminal snapshots to RGBA pixel buffers and PNG images using wgpu
- Uses cosmic-text for font loading/shaping/rasterization with a packed glyph texture atlas
- Supports headless (offscreen) GPU rendering with no window or surface required
- Includes full color resolution (hex parsing, defaults, inverse, dim), a WGSL shader pipeline, and a configurable terminal theme

refs #330

## Test plan

- [x] `cargo check -p godly-renderer` passes
- [x] `cargo test -p godly-renderer` passes: 17 unit tests + 15 integration tests + 1 doc test (33 total)
- [x] Integration tests validate render-to-pixels dimensions, PNG output magic bytes, custom themes, cursor visibility, and repeated renders
- [ ] CI runs full workspace build to verify no cross-crate breakage