### PR TITLE
feat: Tauri GPU renderer integration (Phase 2 of #330)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [features]
 leak-check = ["dhat"]
 staging = []
+gpu-renderer = ["godly-renderer"]
 
 [build-dependencies]
 tauri-build = { version = "2.0", features = [] }
@@ -58,6 +59,7 @@ tauri-plugin-notification = "2"
 base64 = "0.22"
 godly-protocol.workspace = true
 godly-llm = { path = "llm" }
+godly-renderer = { path = "renderer", optional = true }
 uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src-tauri/renderer/Cargo.toml
+++ b/src-tauri/renderer/Cargo.toml
@@ -3,6 +3,7 @@ name = "godly-renderer"
 version = "0.1.0"
 edition = "2021"
 license = "BUSL-1.1"
+description = "GPU-accelerated terminal renderer for Godly Terminal"
 
 [dependencies]
 godly-protocol = { path = "../protocol" }

--- a/src-tauri/src/commands/gpu_render.rs
+++ b/src-tauri/src/commands/gpu_render.rs
@@ -1,0 +1,63 @@
+//! Tauri commands for GPU-accelerated terminal rendering.
+//!
+//! These commands expose the `godly-renderer` GPU pipeline to the frontend.
+//! When the `gpu-renderer` feature is disabled, stub commands return errors
+//! indicating that GPU rendering is not available.
+
+use std::sync::Arc;
+use tauri::State;
+
+use crate::gpu_renderer::GpuRendererManager;
+
+/// Check if GPU rendering is available on this system.
+///
+/// Returns `true` if a GPU adapter was found and the renderer initialized
+/// successfully; `false` otherwise (or if the feature is disabled).
+#[tauri::command]
+pub fn gpu_renderer_available(
+    gpu: State<'_, Arc<GpuRendererManager>>,
+) -> bool {
+    gpu.is_available()
+}
+
+/// Render a terminal to PNG bytes using the GPU renderer.
+///
+/// Fetches the current grid snapshot from the daemon, renders it via the GPU
+/// pipeline, and returns the PNG image as a base64-encoded string.
+#[tauri::command]
+#[cfg(feature = "gpu-renderer")]
+pub fn render_terminal_gpu(
+    terminal_id: String,
+    daemon: State<'_, Arc<crate::daemon_client::DaemonClient>>,
+    gpu: State<'_, Arc<GpuRendererManager>>,
+) -> Result<String, String> {
+    use base64::Engine;
+    use godly_protocol::{Request, Response};
+
+    // Fetch grid snapshot from daemon
+    let request = Request::ReadRichGrid {
+        session_id: terminal_id,
+    };
+    let response = daemon.send_request(&request)?;
+
+    let grid = match response {
+        Response::RichGrid { grid } => grid,
+        Response::Error { message } => return Err(message),
+        _ => return Err("Unexpected response from daemon".to_string()),
+    };
+
+    // Render via GPU
+    let png_bytes = gpu.render_terminal_png(&grid)?;
+
+    // Return as base64
+    Ok(base64::engine::general_purpose::STANDARD.encode(&png_bytes))
+}
+
+/// Stub when the `gpu-renderer` feature is disabled.
+#[tauri::command]
+#[cfg(not(feature = "gpu-renderer"))]
+pub fn render_terminal_gpu(
+    _terminal_id: String,
+) -> Result<String, String> {
+    Err("GPU renderer not enabled. Build with --features gpu-renderer".to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod files;
+pub mod gpu_render;
 pub mod grid;
 pub mod llm;
 pub mod log;

--- a/src-tauri/src/gpu_renderer.rs
+++ b/src-tauri/src/gpu_renderer.rs
@@ -1,0 +1,102 @@
+//! GPU renderer state management for the Tauri app.
+//!
+//! Wraps `godly-renderer::GpuRenderer` behind a `Mutex` for thread-safe access
+//! from Tauri command handlers. The renderer is lazily initialized on first use
+//! so app startup isn't blocked by GPU adapter enumeration.
+//!
+//! When the `gpu-renderer` feature is disabled, a no-op stub is provided that
+//! always reports GPU rendering as unavailable.
+
+#[cfg(feature = "gpu-renderer")]
+use std::sync::Mutex;
+
+#[cfg(feature = "gpu-renderer")]
+use godly_renderer::GpuRenderer;
+
+#[cfg(feature = "gpu-renderer")]
+use godly_protocol::types::RichGridData;
+
+/// Manages a lazily-initialized GPU renderer instance.
+///
+/// The renderer is shared across all terminals. It is initialized on first
+/// render request and cached for subsequent calls. A `Mutex` serializes
+/// access since `GpuRenderer` holds GPU device state that is not `Sync`.
+#[cfg(feature = "gpu-renderer")]
+pub struct GpuRendererManager {
+    renderer: Mutex<Option<GpuRenderer>>,
+    font_family: String,
+    font_size: f32,
+}
+
+#[cfg(feature = "gpu-renderer")]
+impl GpuRendererManager {
+    pub fn new(font_family: &str, font_size: f32) -> Self {
+        Self {
+            renderer: Mutex::new(None),
+            font_family: font_family.to_string(),
+            font_size,
+        }
+    }
+
+    /// Ensure the GPU renderer is initialized, creating it if needed.
+    fn ensure_renderer(&self) -> Result<(), String> {
+        let mut renderer = self.renderer.lock().map_err(|e| e.to_string())?;
+        if renderer.is_none() {
+            *renderer = Some(
+                GpuRenderer::new(&self.font_family, self.font_size)
+                    .map_err(|e| format!("GPU renderer init failed: {e}"))?,
+            );
+        }
+        Ok(())
+    }
+
+    /// Render a terminal grid to raw RGBA pixels.
+    ///
+    /// Returns `(width, height, rgba_bytes)`.
+    pub fn render_terminal(
+        &self,
+        grid: &RichGridData,
+    ) -> Result<(u32, u32, Vec<u8>), String> {
+        self.ensure_renderer()?;
+        let mut renderer = self.renderer.lock().map_err(|e| e.to_string())?;
+        renderer
+            .as_mut()
+            .unwrap()
+            .render_to_pixels(grid)
+            .map_err(|e| format!("GPU render failed: {e}"))
+    }
+
+    /// Render a terminal grid to PNG-encoded bytes.
+    pub fn render_terminal_png(
+        &self,
+        grid: &RichGridData,
+    ) -> Result<Vec<u8>, String> {
+        self.ensure_renderer()?;
+        let mut renderer = self.renderer.lock().map_err(|e| e.to_string())?;
+        renderer
+            .as_mut()
+            .unwrap()
+            .render_to_png(grid)
+            .map_err(|e| format!("GPU render failed: {e}"))
+    }
+
+    /// Check whether GPU rendering is available (i.e. a renderer can be created).
+    pub fn is_available(&self) -> bool {
+        self.ensure_renderer().is_ok()
+    }
+}
+
+/// Stub when the `gpu-renderer` feature is disabled.
+#[cfg(not(feature = "gpu-renderer"))]
+pub struct GpuRendererManager;
+
+#[cfg(not(feature = "gpu-renderer"))]
+impl GpuRendererManager {
+    pub fn new(_font_family: &str, _font_size: f32) -> Self {
+        Self
+    }
+
+    pub fn is_available(&self) -> bool {
+        false
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod daemon_client;
+mod gpu_renderer;
 mod llm_state;
 mod mcp_server;
 mod persistence;
@@ -17,6 +18,7 @@ use tauri::{Emitter, Manager};
 
 use crate::daemon_client::bridge::OutputStreamRegistry;
 use crate::daemon_client::DaemonClient;
+use crate::gpu_renderer::GpuRendererManager;
 use crate::llm_state::LlmState;
 use crate::persistence::{save_on_exit, AutoSaveManager};
 use crate::pty::ProcessMonitor;
@@ -270,6 +272,107 @@ fn start_remote_http_server(app_handle: &tauri::AppHandle) {
     }
 }
 
+/// Handle a `gpuframe://` protocol request.
+///
+/// Expected URL: `gpuframe://render/{session_id}`
+///
+/// When the `gpu-renderer` feature is enabled, fetches the terminal grid from
+/// the daemon, renders it via the GPU pipeline, and returns a PNG response.
+/// When disabled, returns 501 Not Implemented.
+#[cfg(feature = "gpu-renderer")]
+fn handle_gpuframe_request(
+    path: &str,
+    gpu: &Arc<GpuRendererManager>,
+    daemon: &Arc<DaemonClient>,
+) -> tauri::http::Response<Vec<u8>> {
+    use godly_protocol::{Request, Response};
+
+    let session_id = match path.strip_prefix("/render/") {
+        Some(id) if !id.is_empty() => id,
+        _ => {
+            return tauri::http::Response::builder()
+                .status(400)
+                .header("Access-Control-Allow-Origin", "*")
+                .body(b"Bad request. Use /render/{session_id}".to_vec())
+                .unwrap();
+        }
+    };
+
+    if !gpu.is_available() {
+        return tauri::http::Response::builder()
+            .status(503)
+            .header("Access-Control-Allow-Origin", "*")
+            .body(b"GPU renderer not available".to_vec())
+            .unwrap();
+    }
+
+    // Fetch grid snapshot from daemon
+    let request = Request::ReadRichGrid {
+        session_id: session_id.to_string(),
+    };
+    let response = match daemon.send_request(&request) {
+        Ok(r) => r,
+        Err(e) => {
+            let msg = format!("Daemon error: {e}");
+            return tauri::http::Response::builder()
+                .status(502)
+                .header("Access-Control-Allow-Origin", "*")
+                .body(msg.into_bytes())
+                .unwrap();
+        }
+    };
+
+    let grid = match response {
+        Response::RichGrid { grid } => grid,
+        Response::Error { message } => {
+            return tauri::http::Response::builder()
+                .status(404)
+                .header("Access-Control-Allow-Origin", "*")
+                .body(message.into_bytes())
+                .unwrap();
+        }
+        _ => {
+            return tauri::http::Response::builder()
+                .status(500)
+                .header("Access-Control-Allow-Origin", "*")
+                .body(b"Unexpected daemon response".to_vec())
+                .unwrap();
+        }
+    };
+
+    // Render via GPU to PNG
+    match gpu.render_terminal_png(&grid) {
+        Ok(png_bytes) => tauri::http::Response::builder()
+            .status(200)
+            .header("Content-Type", "image/png")
+            .header("Access-Control-Allow-Origin", "*")
+            .body(png_bytes)
+            .unwrap(),
+        Err(e) => {
+            let msg = format!("GPU render failed: {e}");
+            tauri::http::Response::builder()
+                .status(500)
+                .header("Access-Control-Allow-Origin", "*")
+                .body(msg.into_bytes())
+                .unwrap()
+        }
+    }
+}
+
+/// Stub for when the `gpu-renderer` feature is disabled.
+#[cfg(not(feature = "gpu-renderer"))]
+fn handle_gpuframe_request(
+    _path: &str,
+    _gpu: &Arc<GpuRendererManager>,
+    _daemon: &Arc<DaemonClient>,
+) -> tauri::http::Response<Vec<u8>> {
+    tauri::http::Response::builder()
+        .status(501)
+        .header("Access-Control-Allow-Origin", "*")
+        .body(b"GPU renderer not enabled. Build with --features gpu-renderer".to_vec())
+        .unwrap()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(feature = "leak-check")]
@@ -339,6 +442,13 @@ pub fn run() {
     // Keep rx alive for the lifetime of the app (workers hold Arc clones)
     let _stream_rx_keepalive = stream_rx;
 
+    // GPU renderer manager — lazily initializes GPU on first render request.
+    let gpu_renderer_manager = Arc::new(GpuRendererManager::new("Cascadia Code", 14.0));
+
+    // Clones for the gpuframe:// custom protocol closure
+    let gpu_for_protocol = gpu_renderer_manager.clone();
+    let daemon_for_gpuframe = daemon_client.clone();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
@@ -378,10 +488,27 @@ pub fn run() {
                 responder.respond(response);
             }));
         })
+        // Register custom protocol for GPU-rendered terminal frames as PNG images.
+        // Frontend fetches: http://gpuframe.localhost/render/{session_id}
+        // Returns a PNG image of the terminal rendered by the GPU pipeline.
+        // When the gpu-renderer feature is disabled, always returns 501.
+        .register_asynchronous_uri_scheme_protocol("gpuframe", move |_ctx, request, responder| {
+            let gpu = gpu_for_protocol.clone();
+            let daemon = daemon_for_gpuframe.clone();
+            let path = request.uri().path().to_string();
+
+            // Offload to a background thread — GPU rendering can take a few ms
+            // and we must not block the WebView2 main thread.
+            std::thread::spawn(move || {
+                let response = handle_gpuframe_request(&path, &gpu, &daemon);
+                responder.respond(response);
+            });
+        })
         .manage(app_state.clone())
         .manage(auto_save.clone())
         .manage(daemon_client.clone())
         .manage(llm_state.clone())
+        .manage(gpu_renderer_manager)
         .manage(JsCallbackState {
             senders: Mutex::new(HashMap::new()),
         })
@@ -437,6 +564,8 @@ pub fn run() {
             commands::uninstall_plugin,
             commands::check_plugin_update,
             commands::fetch_plugin_registry,
+            commands::gpu_render::gpu_renderer_available,
+            commands::gpu_render::render_terminal_gpu,
             commands::get_grid_snapshot,
             commands::get_grid_snapshot_diff,
             commands::get_grid_dimensions,


### PR DESCRIPTION
## Summary

- Adds the Tauri-side integration for the GPU terminal renderer pipeline (Phase 2 of #330)
- Creates `godly-renderer` stub crate as a compilation target while the real GPU renderer is built in parallel (Phase 1)
- Introduces `gpu-renderer` Cargo feature flag that gates the entire GPU rendering dependency
- Adds `GpuRendererManager` state with lazy GPU initialization and `Mutex`-guarded access
- Registers `gpuframe://` custom protocol for serving GPU-rendered PNG frames to the frontend
- Adds `gpu_renderer_available` and `render_terminal_gpu` Tauri commands
- All GPU code is feature-gated: when disabled, stubs return "not available" / 501

## Architecture

The new rendering pipeline (when `gpu-renderer` feature is enabled):

```
Frontend fetch: http://gpuframe.localhost/render/{session_id}
  → handle_gpuframe_request()
    → DaemonClient.send_request(ReadRichGrid)
      → GpuRendererManager.render_terminal_png(grid)
        → PNG bytes response (image/png)
```

Or via Tauri command:
```
invoke("render_terminal_gpu", { terminalId })
  → fetch RichGridData from daemon
  → GPU render to PNG
  → base64-encoded PNG string
```

## Files changed

| File | Change |
|------|--------|
| `src-tauri/Cargo.toml` | Add `renderer` workspace member, `godly-renderer` optional dep, `gpu-renderer` feature |
| `src-tauri/renderer/` | Minimal stub crate with public API surface matching Phase 1 spec |
| `src-tauri/src/gpu_renderer.rs` | `GpuRendererManager` — lazy init, Mutex-guarded GPU state |
| `src-tauri/src/commands/gpu_render.rs` | Tauri commands: `gpu_renderer_available`, `render_terminal_gpu` |
| `src-tauri/src/commands/mod.rs` | Register `gpu_render` module |
| `src-tauri/src/lib.rs` | Wire up state, commands, and `gpuframe://` custom protocol |

## Test plan

- [ ] `cargo check -p godly-renderer` — stub crate compiles
- [ ] `cargo check -p godly-terminal` — default (no GPU) path compiles cleanly
- [ ] `cargo check -p godly-terminal --features gpu-renderer` — feature-gated path compiles
- [ ] No new warnings introduced (verified locally)
- [ ] CI passes (pre-existing DashMap error in `bridge.rs` is unrelated)

refs #330