### PR TITLE
feat: GPU renderer Phase 3 — always-on + underline + raw RGBA (#330)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,6 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [features]
 leak-check = ["dhat"]
 staging = []
-gpu-renderer = ["godly-renderer"]
 
 [build-dependencies]
 tauri-build = { version = "2.0", features = [] }
@@ -59,7 +58,7 @@ tauri-plugin-notification = "2"
 base64 = "0.22"
 godly-protocol.workspace = true
 godly-llm = { path = "llm" }
-godly-renderer = { path = "renderer", optional = true }
+godly-renderer = { path = "renderer" }
 uuid.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src-tauri/renderer/src/renderer.rs
+++ b/src-tauri/renderer/src/renderer.rs
@@ -356,6 +356,23 @@ impl GpuRenderer {
                         bg_color: bg,
                     },
                 ]);
+
+                // Add underline quad if the cell is underlined.
+                if cell.underline {
+                    let underline_h = (cell_h * 0.06).max(1.0); // 1px minimum
+                    let uy0 = 1.0 - ((y + h - underline_h) / h_f) * 2.0;
+                    let uy1 = 1.0 - ((y + h) / h_f) * 2.0;
+                    let blank = self.atlas.get_or_insert(' ', false, false);
+                    // Solid fg-colored quad (blank glyph -> mix returns bg, so use fg as both)
+                    vertices.extend_from_slice(&[
+                        CellVertex { position: [x0, uy0], uv: [blank.u0, blank.v0], fg_color: fg, bg_color: fg },
+                        CellVertex { position: [x1, uy0], uv: [blank.u1, blank.v0], fg_color: fg, bg_color: fg },
+                        CellVertex { position: [x0, uy1], uv: [blank.u0, blank.v1], fg_color: fg, bg_color: fg },
+                        CellVertex { position: [x0, uy1], uv: [blank.u0, blank.v1], fg_color: fg, bg_color: fg },
+                        CellVertex { position: [x1, uy0], uv: [blank.u1, blank.v0], fg_color: fg, bg_color: fg },
+                        CellVertex { position: [x1, uy1], uv: [blank.u1, blank.v1], fg_color: fg, bg_color: fg },
+                    ]);
+                }
             }
         }
 

--- a/src-tauri/src/commands/gpu_render.rs
+++ b/src-tauri/src/commands/gpu_render.rs
@@ -1,8 +1,6 @@
 //! Tauri commands for GPU-accelerated terminal rendering.
 //!
 //! These commands expose the `godly-renderer` GPU pipeline to the frontend.
-//! When the `gpu-renderer` feature is disabled, stub commands return errors
-//! indicating that GPU rendering is not available.
 
 use std::sync::Arc;
 use tauri::State;
@@ -12,7 +10,7 @@ use crate::gpu_renderer::GpuRendererManager;
 /// Check if GPU rendering is available on this system.
 ///
 /// Returns `true` if a GPU adapter was found and the renderer initialized
-/// successfully; `false` otherwise (or if the feature is disabled).
+/// successfully; `false` otherwise.
 #[tauri::command]
 pub fn gpu_renderer_available(
     gpu: State<'_, Arc<GpuRendererManager>>,
@@ -25,7 +23,6 @@ pub fn gpu_renderer_available(
 /// Fetches the current grid snapshot from the daemon, renders it via the GPU
 /// pipeline, and returns the PNG image as a base64-encoded string.
 #[tauri::command]
-#[cfg(feature = "gpu-renderer")]
 pub fn render_terminal_gpu(
     terminal_id: String,
     daemon: State<'_, Arc<crate::daemon_client::DaemonClient>>,
@@ -53,11 +50,11 @@ pub fn render_terminal_gpu(
     Ok(base64::engine::general_purpose::STANDARD.encode(&png_bytes))
 }
 
-/// Stub when the `gpu-renderer` feature is disabled.
+/// Get the cell size (width, height) in pixels from the GPU renderer.
+/// Returns CSS pixels (not device pixels).
 #[tauri::command]
-#[cfg(not(feature = "gpu-renderer"))]
-pub fn render_terminal_gpu(
-    _terminal_id: String,
-) -> Result<String, String> {
-    Err("GPU renderer not enabled. Build with --features gpu-renderer".to_string())
+pub fn get_gpu_cell_size(
+    gpu: State<'_, Arc<GpuRendererManager>>,
+) -> Result<(f64, f64), String> {
+    gpu.cell_size()
 }

--- a/src-tauri/src/gpu_renderer.rs
+++ b/src-tauri/src/gpu_renderer.rs
@@ -3,17 +3,10 @@
 //! Wraps `godly-renderer::GpuRenderer` behind a `Mutex` for thread-safe access
 //! from Tauri command handlers. The renderer is lazily initialized on first use
 //! so app startup isn't blocked by GPU adapter enumeration.
-//!
-//! When the `gpu-renderer` feature is disabled, a no-op stub is provided that
-//! always reports GPU rendering as unavailable.
 
-#[cfg(feature = "gpu-renderer")]
 use std::sync::Mutex;
 
-#[cfg(feature = "gpu-renderer")]
 use godly_renderer::GpuRenderer;
-
-#[cfg(feature = "gpu-renderer")]
 use godly_protocol::types::RichGridData;
 
 /// Manages a lazily-initialized GPU renderer instance.
@@ -21,14 +14,12 @@ use godly_protocol::types::RichGridData;
 /// The renderer is shared across all terminals. It is initialized on first
 /// render request and cached for subsequent calls. A `Mutex` serializes
 /// access since `GpuRenderer` holds GPU device state that is not `Sync`.
-#[cfg(feature = "gpu-renderer")]
 pub struct GpuRendererManager {
     renderer: Mutex<Option<GpuRenderer>>,
     font_family: String,
     font_size: f32,
 }
 
-#[cfg(feature = "gpu-renderer")]
 impl GpuRendererManager {
     pub fn new(font_family: &str, font_size: f32) -> Self {
         Self {
@@ -80,23 +71,38 @@ impl GpuRendererManager {
             .map_err(|e| format!("GPU render failed: {e}"))
     }
 
+    /// Render a terminal grid to raw RGBA bytes with a dimensions header.
+    ///
+    /// Format: `[width: u32 LE][height: u32 LE][rgba_pixels...]`
+    pub fn render_terminal_raw(
+        &self,
+        grid: &RichGridData,
+    ) -> Result<Vec<u8>, String> {
+        self.ensure_renderer()?;
+        let mut renderer = self.renderer.lock().map_err(|e| e.to_string())?;
+        let (width, height, pixels) = renderer
+            .as_mut()
+            .unwrap()
+            .render_to_pixels(grid)
+            .map_err(|e| format!("GPU render failed: {e}"))?;
+
+        let mut result = Vec::with_capacity(8 + pixels.len());
+        result.extend_from_slice(&width.to_le_bytes());
+        result.extend_from_slice(&height.to_le_bytes());
+        result.extend_from_slice(&pixels);
+        Ok(result)
+    }
+
+    /// Get the cell size (width, height) in pixels from the GPU renderer.
+    pub fn cell_size(&self) -> Result<(f64, f64), String> {
+        self.ensure_renderer()?;
+        let renderer = self.renderer.lock().map_err(|e| e.to_string())?;
+        let (w, h) = renderer.as_ref().unwrap().cell_size();
+        Ok((w as f64, h as f64))
+    }
+
     /// Check whether GPU rendering is available (i.e. a renderer can be created).
     pub fn is_available(&self) -> bool {
         self.ensure_renderer().is_ok()
-    }
-}
-
-/// Stub when the `gpu-renderer` feature is disabled.
-#[cfg(not(feature = "gpu-renderer"))]
-pub struct GpuRendererManager;
-
-#[cfg(not(feature = "gpu-renderer"))]
-impl GpuRendererManager {
-    pub fn new(_font_family: &str, _font_size: f32) -> Self {
-        Self
-    }
-
-    pub fn is_available(&self) -> bool {
-        false
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -274,18 +274,21 @@ fn start_remote_http_server(app_handle: &tauri::AppHandle) {
 
 /// Handle a `gpuframe://` protocol request.
 ///
-/// Expected URL: `gpuframe://render/{session_id}`
+/// Expected URLs:
+///   `gpuframe://render/{session_id}`             — returns PNG (backward compat)
+///   `gpuframe://render/{session_id}?format=raw`  — returns raw RGBA with 8-byte header
 ///
-/// When the `gpu-renderer` feature is enabled, fetches the terminal grid from
-/// the daemon, renders it via the GPU pipeline, and returns a PNG response.
-/// When disabled, returns 501 Not Implemented.
-#[cfg(feature = "gpu-renderer")]
+/// Fetches the terminal grid from the daemon and renders it via the GPU pipeline.
 fn handle_gpuframe_request(
-    path: &str,
+    uri: &str,
     gpu: &Arc<GpuRendererManager>,
     daemon: &Arc<DaemonClient>,
 ) -> tauri::http::Response<Vec<u8>> {
     use godly_protocol::{Request, Response};
+
+    // Parse path and query from the URI
+    let (path, query) = uri.split_once('?').unwrap_or((uri, ""));
+    let use_raw = query.contains("format=raw");
 
     let session_id = match path.strip_prefix("/render/") {
         Some(id) if !id.is_empty() => id,
@@ -340,37 +343,43 @@ fn handle_gpuframe_request(
         }
     };
 
-    // Render via GPU to PNG
-    match gpu.render_terminal_png(&grid) {
-        Ok(png_bytes) => tauri::http::Response::builder()
-            .status(200)
-            .header("Content-Type", "image/png")
-            .header("Access-Control-Allow-Origin", "*")
-            .body(png_bytes)
-            .unwrap(),
-        Err(e) => {
-            let msg = format!("GPU render failed: {e}");
-            tauri::http::Response::builder()
-                .status(500)
+    if use_raw {
+        // Raw RGBA format: [width: u32 LE][height: u32 LE][rgba_pixels...]
+        match gpu.render_terminal_raw(&grid) {
+            Ok(raw_bytes) => tauri::http::Response::builder()
+                .status(200)
+                .header("Content-Type", "application/octet-stream")
                 .header("Access-Control-Allow-Origin", "*")
-                .body(msg.into_bytes())
-                .unwrap()
+                .body(raw_bytes)
+                .unwrap(),
+            Err(e) => {
+                let msg = format!("GPU render failed: {e}");
+                tauri::http::Response::builder()
+                    .status(500)
+                    .header("Access-Control-Allow-Origin", "*")
+                    .body(msg.into_bytes())
+                    .unwrap()
+            }
+        }
+    } else {
+        // PNG format (backward compatible)
+        match gpu.render_terminal_png(&grid) {
+            Ok(png_bytes) => tauri::http::Response::builder()
+                .status(200)
+                .header("Content-Type", "image/png")
+                .header("Access-Control-Allow-Origin", "*")
+                .body(png_bytes)
+                .unwrap(),
+            Err(e) => {
+                let msg = format!("GPU render failed: {e}");
+                tauri::http::Response::builder()
+                    .status(500)
+                    .header("Access-Control-Allow-Origin", "*")
+                    .body(msg.into_bytes())
+                    .unwrap()
+            }
         }
     }
-}
-
-/// Stub for when the `gpu-renderer` feature is disabled.
-#[cfg(not(feature = "gpu-renderer"))]
-fn handle_gpuframe_request(
-    _path: &str,
-    _gpu: &Arc<GpuRendererManager>,
-    _daemon: &Arc<DaemonClient>,
-) -> tauri::http::Response<Vec<u8>> {
-    tauri::http::Response::builder()
-        .status(501)
-        .header("Access-Control-Allow-Origin", "*")
-        .body(b"GPU renderer not enabled. Build with --features gpu-renderer".to_vec())
-        .unwrap()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -495,12 +504,18 @@ pub fn run() {
         .register_asynchronous_uri_scheme_protocol("gpuframe", move |_ctx, request, responder| {
             let gpu = gpu_for_protocol.clone();
             let daemon = daemon_for_gpuframe.clone();
-            let path = request.uri().path().to_string();
+            // Capture full URI (path + query) so the handler can parse ?format=raw
+            let uri = request.uri();
+            let full_uri = if let Some(query) = uri.query() {
+                format!("{}?{}", uri.path(), query)
+            } else {
+                uri.path().to_string()
+            };
 
             // Offload to a background thread — GPU rendering can take a few ms
             // and we must not block the WebView2 main thread.
             std::thread::spawn(move || {
-                let response = handle_gpuframe_request(&path, &gpu, &daemon);
+                let response = handle_gpuframe_request(&full_uri, &gpu, &daemon);
                 responder.respond(response);
             });
         })
@@ -566,6 +581,7 @@ pub fn run() {
             commands::fetch_plugin_registry,
             commands::gpu_render::gpu_renderer_available,
             commands::gpu_render::render_terminal_gpu,
+            commands::gpu_render::get_gpu_cell_size,
             commands::get_grid_snapshot,
             commands::get_grid_snapshot_diff,
             commands::get_grid_dimensions,


### PR DESCRIPTION
## Summary

- **Remove `gpu-renderer` feature flag** — `godly-renderer` is now always compiled as a non-optional dependency. All `#[cfg(feature = "gpu-renderer")]` guards and stub implementations removed from `gpu_renderer.rs`, `commands/gpu_render.rs`, and `lib.rs`
- **Add underline rendering** — `build_vertices()` now emits a thin horizontal quad at the bottom of underlined cells, using the foreground color
- **Add raw RGBA streaming** — New `render_terminal_raw()` method returns `[width: u32 LE][height: u32 LE][rgba_pixels...]`, exposed via `gpuframe://render/{session_id}?format=raw` (avoids ~10-30ms PNG encode overhead)
- **Add `get_gpu_cell_size` command** — Returns cell dimensions in CSS pixels for the frontend interaction overlay

refs #330

## Test plan

- [x] `cargo check -p godly-renderer` passes
- [x] `cargo nextest run -p godly-renderer` — all 32 tests pass
- [x] `cargo check -p godly-terminal` — only fails on pre-existing `godly-pty-shim.exe` build.rs requirement, no Rust code errors
- [ ] CI full build validates cross-crate compilation
- [ ] Frontend integration (Phase 3 frontend PR) will test raw RGBA streaming end-to-end