### PR TITLE
feat: voice-to-text plugin TypeScript service layer

### DIFF
--- a/current_tasks/wt-feat-voice-plugin-ts.md
+++ b/current_tasks/wt-feat-voice-plugin-ts.md
@@ -1,0 +1,10 @@
+# Voice-to-Text Plugin TypeScript Layer
+
+## Branch: wt-feat-voice-plugin-ts
+## Scope: Frontend plugin + service layer for voice-to-text (#357)
+
+## Files owned:
+- src/plugins/voice/whisper-service.ts (new)
+- src/plugins/voice/model-presets.ts (new)
+- src/plugins/voice/index.ts (new)
+- src/plugins/index.ts (modified — registration)

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -2,6 +2,7 @@ import { PluginEventBus } from './event-bus';
 import { PluginRegistry } from './plugin-registry';
 import { PeonPingPlugin } from './peon-ping/index';
 import { SmolLM2Plugin } from './smollm2/index';
+import { VoiceToTextPlugin } from './voice/index';
 import { pluginStore } from './plugin-store';
 import { loadExternalPlugin } from './external-plugin-loader';
 import { invoke } from '@tauri-apps/api/core';
@@ -19,6 +20,7 @@ export async function initPlugins(): Promise<PluginRegistry> {
   registry.register(peonPing, { builtin: true });
 
   registry.register(new SmolLM2Plugin(), { builtin: true });
+  registry.register(new VoiceToTextPlugin(), { builtin: true });
 
   // Phase 2: Load installed external plugins
   const installed = pluginStore.getInstalledPlugins();

--- a/src/plugins/voice/index.ts
+++ b/src/plugins/voice/index.ts
@@ -1,0 +1,340 @@
+import type { GodlyPlugin, PluginContext } from '../types';
+import {
+  whisperGetStatus,
+  whisperGetConfig,
+  whisperSetConfig,
+  whisperLoadModel,
+  whisperListModels,
+  whisperStartRecording,
+  whisperStopRecording,
+  type WhisperStatus,
+} from './whisper-service';
+import { WHISPER_MODEL_PRESETS } from './model-presets';
+
+export class VoiceToTextPlugin implements GodlyPlugin {
+  id = 'voice-to-text';
+  name = 'Voice to Text';
+  description = 'Dictate text into the terminal using Whisper speech-to-text';
+  version = '1.0.0';
+
+  private ctx!: PluginContext;
+  private status: WhisperStatus | null = null;
+
+  async init(ctx: PluginContext): Promise<void> {
+    this.ctx = ctx;
+    try {
+      this.status = await whisperGetStatus();
+    } catch {
+      // Sidecar not running yet — that's ok
+      this.status = null;
+    }
+  }
+
+  async enable(): Promise<void> {
+    try {
+      this.status = await whisperGetStatus();
+    } catch {
+      // Will retry on first use
+    }
+  }
+
+  async disable(): Promise<void> {
+    if (this.status?.state === 'recording') {
+      try {
+        await whisperStopRecording();
+      } catch (e) {
+        console.warn('[VoiceToText] Failed to stop recording on disable:', e);
+      }
+    }
+  }
+
+  destroy(): void {
+    // Nothing to clean up
+  }
+
+  renderSettings(): HTMLElement {
+    const container = document.createElement('div');
+    container.className = 'voice-plugin-settings';
+
+    // ── Status indicator ──
+    const statusRow = this.createRow('Status');
+    const statusValue = document.createElement('span');
+    statusValue.className = 'shortcut-keys';
+    statusValue.textContent = 'Checking...';
+    statusRow.appendChild(statusValue);
+    container.appendChild(statusRow);
+
+    // ── Section A: Model ──
+    const modelSection = document.createElement('div');
+    modelSection.className = 'settings-section';
+    const modelTitle = document.createElement('div');
+    modelTitle.className = 'settings-section-title';
+    modelTitle.textContent = 'Model';
+    modelSection.appendChild(modelTitle);
+
+    // Model dropdown
+    const modelRow = this.createRow('Model');
+    const modelSelect = document.createElement('select');
+    modelSelect.className = 'dialog-input';
+    modelSelect.style.cssText = 'width: auto; font-size: 12px; padding: 4px 8px;';
+
+    for (const preset of WHISPER_MODEL_PRESETS) {
+      const option = document.createElement('option');
+      option.value = preset.fileName;
+      option.textContent = `${preset.name} (${preset.size})`;
+      if (preset.recommended) option.selected = true;
+      modelSelect.appendChild(option);
+    }
+    modelRow.appendChild(modelSelect);
+    modelSection.appendChild(modelRow);
+
+    // Model description hint
+    const descRow = document.createElement('div');
+    descRow.style.cssText = 'padding: 0 12px; font-size: 10px; color: var(--text-secondary);';
+    const updateDesc = () => {
+      const preset = WHISPER_MODEL_PRESETS.find(p => p.fileName === modelSelect.value);
+      descRow.textContent = preset ? preset.description : '';
+    };
+    modelSelect.addEventListener('change', updateDesc);
+    updateDesc();
+    modelSection.appendChild(descRow);
+
+    // Available models display
+    const availableRow = document.createElement('div');
+    availableRow.style.cssText = 'padding: 4px 12px; font-size: 10px; color: var(--text-secondary);';
+    modelSection.appendChild(availableRow);
+
+    // Load model button
+    const loadRow = this.createRow('');
+    const loadBtn = document.createElement('button');
+    loadBtn.className = 'dialog-btn dialog-btn-primary';
+    loadBtn.textContent = 'Load Model';
+    loadBtn.onclick = async () => {
+      loadBtn.disabled = true;
+      loadBtn.textContent = 'Loading...';
+      try {
+        const gpuCheckbox = container.querySelector('.voice-gpu-checkbox') as HTMLInputElement;
+        const gpuDeviceInput = container.querySelector('.voice-gpu-device-input') as HTMLInputElement;
+        const langSelect = container.querySelector('.voice-language-select') as HTMLSelectElement;
+        await whisperLoadModel(
+          modelSelect.value,
+          gpuCheckbox?.checked ?? true,
+          parseInt(gpuDeviceInput?.value ?? '0') || 0,
+          langSelect?.value ?? '',
+        );
+        this.status = await whisperGetStatus();
+        this.updateStatusDisplay(statusValue);
+        loadBtn.textContent = 'Loaded!';
+        setTimeout(() => { loadBtn.textContent = 'Load Model'; loadBtn.disabled = false; }, 2000);
+      } catch (e) {
+        loadBtn.textContent = 'Error';
+        console.warn('[VoiceToText] Load model failed:', e);
+        setTimeout(() => { loadBtn.textContent = 'Load Model'; loadBtn.disabled = false; }, 2000);
+      }
+    };
+    loadRow.appendChild(loadBtn);
+    modelSection.appendChild(loadRow);
+
+    container.appendChild(modelSection);
+
+    // ── Section B: GPU Acceleration ──
+    const gpuSection = document.createElement('div');
+    gpuSection.className = 'settings-section';
+    const gpuTitle = document.createElement('div');
+    gpuTitle.className = 'settings-section-title';
+    gpuTitle.textContent = 'GPU Acceleration';
+    gpuSection.appendChild(gpuTitle);
+
+    const gpuRow = this.createRow('Use GPU (CUDA)');
+    const gpuCheckbox = document.createElement('input');
+    gpuCheckbox.type = 'checkbox';
+    gpuCheckbox.className = 'notification-checkbox voice-gpu-checkbox';
+    gpuCheckbox.checked = true;
+    gpuRow.appendChild(gpuCheckbox);
+    gpuSection.appendChild(gpuRow);
+
+    const deviceRow = this.createRow('GPU Device');
+    const gpuDeviceInput = document.createElement('input');
+    gpuDeviceInput.type = 'number';
+    gpuDeviceInput.className = 'dialog-input voice-gpu-device-input';
+    gpuDeviceInput.style.cssText = 'width: 60px; font-size: 12px; padding: 4px 8px;';
+    gpuDeviceInput.value = '0';
+    gpuDeviceInput.min = '0';
+    gpuDeviceInput.max = '7';
+    deviceRow.appendChild(gpuDeviceInput);
+    gpuSection.appendChild(deviceRow);
+
+    container.appendChild(gpuSection);
+
+    // ── Section C: Language ──
+    const langSection = document.createElement('div');
+    langSection.className = 'settings-section';
+    const langTitle = document.createElement('div');
+    langTitle.className = 'settings-section-title';
+    langTitle.textContent = 'Language';
+    langSection.appendChild(langTitle);
+
+    const langRow = this.createRow('Language');
+    const langSelect = document.createElement('select');
+    langSelect.className = 'dialog-input voice-language-select';
+    langSelect.style.cssText = 'width: auto; font-size: 12px; padding: 4px 8px;';
+
+    for (const lang of [
+      { value: '', label: 'Auto-detect' },
+      { value: 'en', label: 'English' },
+      { value: 'es', label: 'Spanish' },
+      { value: 'fr', label: 'French' },
+      { value: 'de', label: 'German' },
+      { value: 'pt', label: 'Portuguese' },
+      { value: 'zh', label: 'Chinese' },
+      { value: 'ja', label: 'Japanese' },
+      { value: 'ko', label: 'Korean' },
+    ]) {
+      const option = document.createElement('option');
+      option.value = lang.value;
+      option.textContent = lang.label;
+      langSelect.appendChild(option);
+    }
+    langRow.appendChild(langSelect);
+    langSection.appendChild(langRow);
+
+    container.appendChild(langSection);
+
+    // Save config on GPU/language/model changes
+    const saveConfig = async () => {
+      try {
+        await whisperSetConfig({
+          modelName: modelSelect.value,
+          language: langSelect.value,
+          useGpu: gpuCheckbox.checked,
+          gpuDevice: parseInt(gpuDeviceInput.value) || 0,
+        });
+      } catch {
+        // Config save failed silently
+      }
+    };
+    gpuCheckbox.addEventListener('change', saveConfig);
+    gpuDeviceInput.addEventListener('change', saveConfig);
+    langSelect.addEventListener('change', saveConfig);
+
+    // ── Section D: Test Recording ──
+    const testSection = document.createElement('div');
+    testSection.className = 'settings-section';
+    const testTitle = document.createElement('div');
+    testTitle.className = 'settings-section-title';
+    testTitle.textContent = 'Test';
+    testSection.appendChild(testTitle);
+
+    const testRow = document.createElement('div');
+    testRow.className = 'shortcut-row';
+    testRow.style.flexDirection = 'column';
+    testRow.style.alignItems = 'stretch';
+    testRow.style.gap = '8px';
+
+    const testResultRow = document.createElement('div');
+    testResultRow.style.display = 'flex';
+    testResultRow.style.gap = '8px';
+    testResultRow.style.alignItems = 'center';
+
+    const testBtn = document.createElement('button');
+    testBtn.className = 'dialog-btn dialog-btn-secondary';
+    testBtn.textContent = 'Test Recording (3s)';
+    testBtn.style.fontSize = '11px';
+
+    const testResult = document.createElement('span');
+    testResult.style.cssText = 'font-family: monospace; font-size: 12px;';
+
+    testBtn.onclick = async () => {
+      testBtn.disabled = true;
+      testBtn.textContent = 'Recording...';
+      testResult.textContent = '';
+      testResult.style.color = '';
+      try {
+        await whisperStartRecording();
+        await new Promise(resolve => setTimeout(resolve, 3000));
+        testBtn.textContent = 'Transcribing...';
+        const text = await whisperStopRecording();
+        testResult.textContent = text ? `"${text}"` : '(no speech detected)';
+        testResult.style.color = 'var(--accent)';
+      } catch (e) {
+        testResult.textContent = `Error: ${e}`;
+        testResult.style.color = 'var(--error)';
+      } finally {
+        testBtn.disabled = false;
+        testBtn.textContent = 'Test Recording (3s)';
+      }
+    };
+
+    testResultRow.appendChild(testBtn);
+    testResultRow.appendChild(testResult);
+    testRow.appendChild(testResultRow);
+    testSection.appendChild(testRow);
+    container.appendChild(testSection);
+
+    // Load current state from sidecar
+    this.refreshSettingsState(container, statusValue, modelSelect, gpuCheckbox, gpuDeviceInput, langSelect, availableRow);
+
+    return container;
+  }
+
+  // ── Helper: create a shortcut-row with a label ──
+  private createRow(label: string): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'shortcut-row';
+    const lbl = document.createElement('span');
+    lbl.className = 'shortcut-label';
+    lbl.textContent = label;
+    row.appendChild(lbl);
+    return row;
+  }
+
+  private updateStatusDisplay(statusValue: HTMLElement): void {
+    if (!this.status) {
+      statusValue.textContent = 'Unable to connect';
+      return;
+    }
+    if (!this.status.sidecarRunning) {
+      statusValue.textContent = 'Sidecar not running';
+      return;
+    }
+    if (this.status.modelLoaded) {
+      statusValue.textContent = `Connected — ${this.status.modelName ?? 'model loaded'}`;
+    } else {
+      statusValue.textContent = 'Connected — no model loaded';
+    }
+  }
+
+  private async refreshSettingsState(
+    _container: HTMLElement,
+    statusValue: HTMLElement,
+    modelSelect: HTMLSelectElement,
+    gpuCheckbox: HTMLInputElement,
+    gpuDeviceInput: HTMLInputElement,
+    langSelect: HTMLSelectElement,
+    availableRow: HTMLElement,
+  ): Promise<void> {
+    try {
+      const [status, config, models] = await Promise.all([
+        whisperGetStatus(),
+        whisperGetConfig(),
+        whisperListModels(),
+      ]);
+
+      this.status = status;
+      this.updateStatusDisplay(statusValue);
+
+      // Update config fields
+      if (config.modelName) modelSelect.value = config.modelName;
+      gpuCheckbox.checked = config.useGpu;
+      gpuDeviceInput.value = String(config.gpuDevice);
+      langSelect.value = config.language;
+
+      // Show available models
+      if (models.length > 0) {
+        availableRow.textContent = `Downloaded: ${models.join(', ')}`;
+      }
+    } catch {
+      statusValue.textContent = 'Unable to connect';
+    }
+  }
+}

--- a/src/plugins/voice/model-presets.ts
+++ b/src/plugins/voice/model-presets.ts
@@ -1,0 +1,45 @@
+export interface WhisperModelPreset {
+  name: string;
+  fileName: string;
+  size: string;
+  description: string;
+  recommended: boolean;
+}
+
+export const WHISPER_MODEL_PRESETS: WhisperModelPreset[] = [
+  {
+    name: 'Tiny',
+    fileName: 'ggml-tiny.bin',
+    size: '75 MB',
+    description: 'Fastest, lowest accuracy. Good for quick commands.',
+    recommended: false,
+  },
+  {
+    name: 'Base',
+    fileName: 'ggml-base.bin',
+    size: '142 MB',
+    description: 'Good balance of speed and accuracy. Recommended for most users.',
+    recommended: true,
+  },
+  {
+    name: 'Small',
+    fileName: 'ggml-small.bin',
+    size: '466 MB',
+    description: 'Higher accuracy, slower. Good for longer dictation.',
+    recommended: false,
+  },
+  {
+    name: 'Medium',
+    fileName: 'ggml-medium.bin',
+    size: '1.5 GB',
+    description: 'High accuracy, requires more RAM/VRAM.',
+    recommended: false,
+  },
+  {
+    name: 'Large v3 Turbo',
+    fileName: 'ggml-large-v3-turbo.bin',
+    size: '1.5 GB',
+    description: 'Best accuracy with optimized speed. Requires GPU.',
+    recommended: false,
+  },
+];

--- a/src/plugins/voice/whisper-service.ts
+++ b/src/plugins/voice/whisper-service.ts
@@ -1,0 +1,50 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface WhisperStatus {
+  state: 'idle' | 'recording' | 'transcribing';
+  modelLoaded: boolean;
+  modelName: string | null;
+  gpuAvailable: boolean;
+  gpuInUse: boolean;
+  sidecarRunning: boolean;
+}
+
+export interface WhisperConfig {
+  modelName: string;
+  language: string;
+  useGpu: boolean;
+  gpuDevice: number;
+}
+
+export async function whisperGetStatus(): Promise<WhisperStatus> {
+  return invoke<WhisperStatus>('whisper_get_status');
+}
+
+export async function whisperStartRecording(): Promise<void> {
+  return invoke<void>('whisper_start_recording');
+}
+
+export async function whisperStopRecording(): Promise<string> {
+  return invoke<string>('whisper_stop_recording');
+}
+
+export async function whisperLoadModel(
+  modelName: string,
+  useGpu: boolean,
+  gpuDevice: number,
+  language: string,
+): Promise<void> {
+  return invoke<void>('whisper_load_model', { modelName, useGpu, gpuDevice, language });
+}
+
+export async function whisperListModels(): Promise<string[]> {
+  return invoke<string[]>('whisper_list_models');
+}
+
+export async function whisperGetConfig(): Promise<WhisperConfig> {
+  return invoke<WhisperConfig>('whisper_get_config');
+}
+
+export async function whisperSetConfig(config: WhisperConfig): Promise<void> {
+  return invoke<void>('whisper_set_config', { config });
+}


### PR DESCRIPTION
## Summary

- Add `VoiceToTextPlugin` class implementing `GodlyPlugin` with full settings UI (model selection, GPU config, language, test recording)
- Add `whisper-service.ts` with `invoke()` wrappers for all whisper sidecar IPC commands (status, recording, model loading, config)
- Add `model-presets.ts` with 5 Whisper model presets (Tiny through Large v3 Turbo)
- Register plugin as built-in in `plugins/index.ts`

Refs #357

## Test plan

- [x] All 808 frontend tests pass (`npm test`)
- [ ] TypeScript strict check (`npx tsc --noEmit`) — may have expected errors from missing Rust backend commands
- [ ] Plugin appears in Settings dialog under Plugins section
- [ ] Settings UI renders correctly (model dropdown, GPU toggle, language select, test button)
- [ ] Verify IPC commands connect to whisper sidecar when backend is available