### PR TITLE
feat: add voice-to-text plugin frontend UI

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -492,6 +492,12 @@ export class App {
           break;
         }
 
+        case 'voice.toggleRecording': {
+          e.preventDefault();
+          this.handleVoiceToggle();
+          break;
+        }
+
         case 'tabs.quickClaude': {
           e.preventDefault();
           if (!state.activeWorkspaceId) break;
@@ -530,6 +536,9 @@ export class App {
         }
       }
     });
+
+    // Listen for voice toggle events from the mic button in TabBar
+    document.addEventListener('voice-toggle-recording', () => this.handleVoiceToggle());
   }
 
   async init() {
@@ -921,6 +930,39 @@ export class App {
    * Create a new terminal in the active workspace. Returns the new terminal ID,
    * or null if creation was cancelled (e.g. worktree prompt dismissed).
    */
+  private async handleVoiceToggle(): Promise<void> {
+    try {
+      const { whisperGetStatus, whisperStartRecording, whisperStopRecording } = await import('../plugins/voice/whisper-service');
+      const status = await whisperGetStatus();
+
+      if (status.state === 'idle') {
+        await whisperStartRecording();
+        this.updateMicButtonState('recording');
+      } else if (status.state === 'recording') {
+        this.updateMicButtonState('transcribing');
+        const text = await whisperStopRecording();
+        this.updateMicButtonState('idle');
+        if (text && store.getState().activeTerminalId) {
+          await terminalService.writeToTerminal(store.getState().activeTerminalId!, text);
+        }
+      }
+    } catch (err) {
+      console.error('Voice toggle failed:', err);
+      this.updateMicButtonState('idle');
+    }
+  }
+
+  private updateMicButtonState(state: 'idle' | 'recording' | 'transcribing'): void {
+    const micBtn = document.querySelector('.mic-btn');
+    if (!micBtn) return;
+    micBtn.className = `mic-btn mic-${state}`;
+    micBtn.setAttribute('title',
+      state === 'idle' ? 'Voice input (Ctrl+Shift+M)' :
+      state === 'recording' ? 'Stop recording (Ctrl+Shift+M)' :
+      'Transcribing...'
+    );
+  }
+
   private async createNewTerminal(): Promise<string | null> {
     const state = store.getState();
     if (!state.activeWorkspaceId) return null;

--- a/src/components/SettingsDialog.ts
+++ b/src/components/SettingsDialog.ts
@@ -1130,7 +1130,7 @@ export function showSettingsDialog(): Promise<void> {
     function renderShortcuts() {
       shortcutsContainer.textContent = '';
 
-      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace', 'Scroll', 'Zoom', 'Debug'];
+      const categories: ShortcutCategory[] = ['Terminal', 'Clipboard', 'Tabs', 'Split', 'Workspace', 'Scroll', 'Zoom', 'Voice', 'Debug'];
 
       for (const category of categories) {
         const defs = DEFAULT_SHORTCUTS.filter((d) => {

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -44,6 +44,18 @@ export class TabBar {
       e.preventDefault();
     }, { passive: false });
 
+    // Create mic button for voice input
+    const micBtn = document.createElement('div');
+    micBtn.className = 'mic-btn mic-idle';
+    micBtn.title = 'Voice input (Ctrl+Shift+M)';
+    micBtn.setAttribute('role', 'button');
+    micBtn.setAttribute('aria-label', 'Toggle voice recording');
+    micBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>`;
+    micBtn.addEventListener('click', () => {
+      document.dispatchEvent(new CustomEvent('voice-toggle-recording'));
+    });
+    this.container.appendChild(micBtn);
+
     const addBtn = document.createElement('div');
     addBtn.className = 'add-tab-btn';
     addBtn.textContent = '+';

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -468,6 +468,37 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
     cancelBtn.textContent = 'Cancel';
     buttons.appendChild(cancelBtn);
 
+    // Voice input button for dictation
+    const voiceBtn = document.createElement('button');
+    voiceBtn.className = 'dialog-btn dialog-btn-secondary quick-claude-voice-btn';
+    voiceBtn.textContent = 'Voice';
+    voiceBtn.title = 'Dictate with voice';
+    voiceBtn.addEventListener('click', async () => {
+      try {
+        const { whisperGetStatus, whisperStartRecording, whisperStopRecording } = await import('../plugins/voice/whisper-service');
+        const status = await whisperGetStatus();
+        if (status.state === 'idle') {
+          await whisperStartRecording();
+          voiceBtn.textContent = 'Stop';
+          voiceBtn.classList.add('voice-recording');
+        } else if (status.state === 'recording') {
+          voiceBtn.textContent = '...';
+          voiceBtn.classList.remove('voice-recording');
+          const text = await whisperStopRecording();
+          voiceBtn.textContent = 'Voice';
+          if (text) {
+            promptArea.value += (promptArea.value ? ' ' : '') + text;
+            promptArea.dispatchEvent(new Event('input'));
+          }
+        }
+      } catch (err) {
+        voiceBtn.textContent = 'Voice';
+        voiceBtn.classList.remove('voice-recording');
+        console.error('Voice input failed:', err);
+      }
+    });
+    buttons.appendChild(voiceBtn);
+
     const okBtn = document.createElement('button');
     okBtn.className = 'dialog-btn dialog-btn-primary';
     okBtn.textContent = 'Launch';

--- a/src/plugins/voice/whisper-service.ts
+++ b/src/plugins/voice/whisper-service.ts
@@ -1,0 +1,41 @@
+/**
+ * Whisper voice-to-text service interface.
+ *
+ * This module provides the frontend API for voice recording and transcription
+ * via the Whisper model running in the daemon. The actual implementation
+ * will be wired up when the daemon-side voice support is ready.
+ */
+
+export interface WhisperStatus {
+  state: 'idle' | 'recording' | 'transcribing' | 'error';
+  model?: string;
+  error?: string;
+}
+
+/**
+ * Query the current status of the whisper service.
+ */
+export async function whisperGetStatus(): Promise<WhisperStatus> {
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return await invoke<WhisperStatus>('whisper_get_status');
+  } catch {
+    return { state: 'idle' };
+  }
+}
+
+/**
+ * Start recording audio from the microphone.
+ */
+export async function whisperStartRecording(): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('whisper_start_recording');
+}
+
+/**
+ * Stop recording and return the transcribed text.
+ */
+export async function whisperStopRecording(): Promise<string> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  return await invoke<string>('whisper_stop_recording');
+}

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -33,9 +33,10 @@ export type ActionId =
   | 'zoom.in'
   | 'zoom.out'
   | 'zoom.reset'
+  | 'voice.toggleRecording'
   | 'debug.togglePerfOverlay';
 
-export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll' | 'Zoom' | 'Debug';
+export type ShortcutCategory = 'Terminal' | 'Clipboard' | 'Tabs' | 'Split' | 'Workspace' | 'Scroll' | 'Zoom' | 'Voice' | 'Debug';
 
 /** Whether the shortcut is an app-level action or a terminal control key. */
 export type ShortcutType = 'app' | 'terminal-control';
@@ -225,6 +226,13 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Zoom',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: false, altKey: false, key: '0' },
+  },
+  {
+    id: 'voice.toggleRecording',
+    label: 'Toggle Voice Recording',
+    category: 'Voice',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'm' },
   },
   {
     id: 'debug.togglePerfOverlay',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1917,3 +1917,164 @@ body.dragging-active * {
   padding-top: 8px;
   border-top: 1px solid var(--border-color);
 }
+
+/* ── Voice Recording ───────────────────────────────────── */
+
+/* Mic button in tab bar */
+.mic-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: color 0.2s, background-color 0.2s;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.mic-btn:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-tertiary);
+}
+
+.mic-btn.mic-recording {
+  color: var(--danger);
+  animation: mic-pulse 1.5s ease-in-out infinite;
+}
+
+.mic-btn.mic-transcribing {
+  color: #ffaa00;
+  animation: mic-spin 1s linear infinite;
+}
+
+@keyframes mic-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes mic-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Voice plugin settings */
+.voice-plugin-settings .plugin-settings-section {
+  margin-bottom: 16px;
+}
+
+.voice-plugin-settings h4 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.voice-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.voice-status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #666;
+}
+
+.voice-status-indicator.voice-status-connected {
+  background: var(--success);
+}
+
+.voice-status-indicator.voice-status-disconnected {
+  background: var(--danger);
+}
+
+.voice-model-select {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.voice-model-dropdown {
+  flex: 1;
+  padding: 4px 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.voice-load-model-btn,
+.voice-test-btn {
+  padding: 4px 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.voice-load-model-btn:disabled,
+.voice-test-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.voice-model-description {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.voice-gpu-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.voice-gpu-device {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.voice-gpu-device-input {
+  width: 60px;
+  padding: 4px 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.voice-language-select {
+  width: 100%;
+  padding: 4px 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.voice-test-result {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+  font-style: italic;
+}
+
+/* Quick Claude dialog voice button */
+.quick-claude-voice-btn {
+  min-width: 60px;
+}
+
+.quick-claude-voice-btn.voice-recording {
+  background-color: var(--danger) !important;
+  color: #fff !important;
+  animation: mic-pulse 1.5s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary

- Add `Ctrl+Shift+M` keybinding to toggle voice recording (`voice.toggleRecording` action)
- Add microphone button in the TabBar (between tabs and the + button) with SVG icon
- Add Voice button in the Quick Claude dialog for voice dictation into the prompt
- Add `Voice` shortcut category in the Settings dialog keyboard shortcuts section
- Add CSS styles for mic button states (idle, recording, transcribing) with pulse/spin animations
- Add `whisper-service.ts` stub module with typed interface for future daemon-side Whisper integration

## Test plan

- [x] All 808 existing frontend tests pass (no regressions)
- [ ] Verify mic button renders in the tab bar next to the + button
- [ ] Verify `Ctrl+Shift+M` is shown in Settings > Shortcuts > Voice category
- [ ] Verify Voice button appears in Quick Claude dialog (between Cancel and Launch)
- [ ] Verify mic button click dispatches `voice-toggle-recording` custom event
- [ ] Verify CSS animations work for recording (red pulse) and transcribing (spin) states

refs #357