### PR TITLE
fix: use linear texture format for GPU renderer

### DIFF
--- a/src-tauri/renderer/src/atlas.rs
+++ b/src-tauri/renderer/src/atlas.rs
@@ -391,7 +391,7 @@ impl GlyphAtlas {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                format: wgpu::TextureFormat::Rgba8Unorm,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                 view_formats: &[],
             });

--- a/src-tauri/renderer/src/renderer.rs
+++ b/src-tauri/renderer/src/renderer.rs
@@ -19,7 +19,7 @@ pub struct GpuRenderer {
 }
 
 /// Output texture format used for offscreen rendering.
-const OUTPUT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+const OUTPUT_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
 
 impl GpuRenderer {
     /// Create a new GPU renderer with the given font family and size.


### PR DESCRIPTION
## Summary
- Atlas and output textures used `Rgba8UnormSrgb`, which applies gamma decoding to glyph coverage values — crushing antialiasing and producing blocky pixel-art text
- Changed both to `Rgba8Unorm` so coverage passes through linearly and colors reach `putImageData()` without double-encoding

## Test plan
- [ ] Run `npm run tauri dev` and verify text renders with smooth antialiased glyphs
- [ ] Check bold/italic text still renders correctly
- [ ] Verify terminal colors look correct (no washed-out or over-saturated tones)