### PR TITLE
feat: add whisper_start_sidecar command and microphone device config

### DIFF
--- a/src-tauri/src/commands/whisper.rs
+++ b/src-tauri/src/commands/whisper.rs
@@ -5,6 +5,49 @@ use tauri::State;
 use crate::whisper_state::{WhisperConfig, WhisperRecordingState, WhisperState, WhisperStatus};
 
 #[tauri::command]
+pub async fn whisper_start_sidecar(
+    app: tauri::AppHandle,
+    whisper: State<'_, Arc<WhisperState>>,
+) -> Result<String, String> {
+    // Check if already running
+    if whisper.get_status().sidecar_running {
+        return Ok("Sidecar already running".to_string());
+    }
+
+    let binary = crate::find_whisper_binary(&app).ok_or_else(|| {
+        "godly-whisper binary not found. Place godly-whisper.exe next to the app binary.".to_string()
+    })?;
+
+    let pipe_name = whisper.get_pipe_name();
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        const DETACHED_PROCESS: u32 = 0x00000008;
+
+        let child = std::process::Command::new(&binary)
+            .arg("--pipe")
+            .arg(&pipe_name)
+            .creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to start sidecar: {}", e))?;
+
+        let pid = child.id();
+        whisper.set_sidecar_running(true, Some(pid));
+        Ok(format!("Sidecar started (PID {})", pid))
+    }
+
+    #[cfg(not(windows))]
+    {
+        Err("Voice sidecar is only supported on Windows".to_string())
+    }
+}
+
+#[tauri::command]
 pub async fn whisper_get_status(
     whisper: State<'_, Arc<WhisperState>>,
 ) -> Result<WhisperStatus, String> {
@@ -48,6 +91,7 @@ pub async fn whisper_load_model(
         use_gpu,
         gpu_device,
         language,
+        microphone_device_id: None,
     };
     whisper.set_config(config);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -230,7 +230,7 @@ fn find_remote_binary(app_handle: &tauri::AppHandle) -> Option<std::path::PathBu
 }
 
 /// Find the godly-whisper binary: resource dir (installed) > exe dir > target/debug (dev).
-fn find_whisper_binary(app_handle: &tauri::AppHandle) -> Option<std::path::PathBuf> {
+pub(crate) fn find_whisper_binary(app_handle: &tauri::AppHandle) -> Option<std::path::PathBuf> {
     // 1. Resource dir (Tauri bundle)
     if let Ok(resource_dir) = app_handle.path().resource_dir() {
         let p = resource_dir.join("godly-whisper.exe");
@@ -642,6 +642,7 @@ pub fn run() {
             commands::whisper_list_models,
             commands::whisper_get_config,
             commands::whisper_set_config,
+            commands::whisper_start_sidecar,
             persistence::save_layout,
             persistence::load_layout,
             persistence::save_scrollback,

--- a/src-tauri/src/whisper_state.rs
+++ b/src-tauri/src/whisper_state.rs
@@ -29,6 +29,7 @@ pub struct WhisperConfig {
     pub language: String,
     pub use_gpu: bool,
     pub gpu_device: i32,
+    pub microphone_device_id: Option<String>,
 }
 
 impl Default for WhisperConfig {
@@ -38,6 +39,7 @@ impl Default for WhisperConfig {
             language: String::new(), // empty = auto-detect
             use_gpu: true,
             gpu_device: 0,
+            microphone_device_id: None,
         }
     }
 }

--- a/src/plugins/voice/whisper-service.ts
+++ b/src/plugins/voice/whisper-service.ts
@@ -14,6 +14,7 @@ export interface WhisperConfig {
   language: string;
   useGpu: boolean;
   gpuDevice: number;
+  microphoneDeviceId: string | null;
 }
 
 export async function whisperGetStatus(): Promise<WhisperStatus> {
@@ -39,6 +40,10 @@ export async function whisperLoadModel(
 
 export async function whisperListModels(): Promise<string[]> {
   return invoke<string[]>('whisper_list_models');
+}
+
+export async function whisperStartSidecar(): Promise<string> {
+  return invoke<string>('whisper_start_sidecar');
 }
 
 export async function whisperGetConfig(): Promise<WhisperConfig> {


### PR DESCRIPTION
## Summary

- Add `whisper_start_sidecar` Tauri command that spawns the `godly-whisper` binary as a detached process with `CREATE_NO_WINDOW | DETACHED_PROCESS` flags, passing the whisper pipe name via `--pipe` arg
- Add optional `microphone_device_id` field to `WhisperConfig` on both Rust and TypeScript sides
- Change `find_whisper_binary` visibility from `fn` to `pub(crate) fn` so it can be called from commands module

Fixes #365

## Files changed
- `src-tauri/src/commands/whisper.rs` — new `whisper_start_sidecar` command + updated `WhisperConfig` struct literal
- `src-tauri/src/whisper_state.rs` — added `microphone_device_id: Option<String>` to `WhisperConfig`
- `src-tauri/src/lib.rs` — `pub(crate) fn find_whisper_binary` + registered new command in handler
- `src/plugins/voice/whisper-service.ts` — added `microphoneDeviceId` to interface + `whisperStartSidecar()` function

## Test plan
- [x] `cargo check -p godly-terminal` passes with no new errors
- [ ] CI build passes