### PR TITLE
Fix canvas grid scroll shift mismatch

### DIFF
--- a/src/components/Canvas2DGridRenderer.ts
+++ b/src/components/Canvas2DGridRenderer.ts
@@ -94,6 +94,39 @@ export class Canvas2DGridRenderer {
   }
 
   /**
+   * Optimistic scroll: shift existing canvas content by deltaLines immediately.
+   * Gives instant visual feedback while the real snapshot IPC is in flight.
+   * Positive delta = scrolling up (into history), content moves down on screen.
+   */
+  shiftCanvas(deltaLines: number): void {
+    if (deltaLines === 0 || this.cellHeight === 0) return;
+
+    const ctx = this.ctx;
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+    const shiftPx = Math.round(deltaLines * this.cellHeight);
+
+    if (Math.abs(shiftPx) >= h) {
+      ctx.fillStyle = this.theme.background;
+      ctx.fillRect(0, 0, w, h);
+      return;
+    }
+
+    if (shiftPx > 0) {
+      // Scrolling up: content moves down, new rows appear at top
+      ctx.drawImage(this.canvas, 0, 0, w, h - shiftPx, 0, shiftPx, w, h - shiftPx);
+      ctx.fillStyle = this.theme.background;
+      ctx.fillRect(0, 0, w, shiftPx);
+    } else {
+      // Scrolling down: content moves up, new rows appear at bottom
+      const absShift = -shiftPx;
+      ctx.drawImage(this.canvas, 0, absShift, w, h - absShift, 0, 0, w, h - absShift);
+      ctx.fillStyle = this.theme.background;
+      ctx.fillRect(0, h - absShift, w, absShift);
+    }
+  }
+
+  /**
    * Render a terminal grid snapshot to the canvas.
    * This is synchronous and fast — no IPC, no async pipeline.
    */

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -569,8 +569,9 @@ export class TerminalPane {
     // Bug #242: adjust selection so it stays anchored to the same content
     this.renderer.adjustSelectionForScroll(actualDelta);
 
-    // Optimistic: shift canvas content immediately for instant feedback
+    // Optimistic: shift both canvases immediately for instant feedback
     this.renderer.shiftCanvas(actualDelta);
+    this.gridRenderer?.shiftCanvas(actualDelta);
 
     // Invalidate cache — next real snapshot overwrites the shifted view
     this.cachedSnapshot = null;
@@ -600,6 +601,7 @@ export class TerminalPane {
 
     // Optimistic canvas shift + coalesced IPC (same as handleScroll)
     this.renderer.shiftCanvas(actualDelta);
+    this.gridRenderer?.shiftCanvas(actualDelta);
     this.cachedSnapshot = null;
     ++this.scrollSeq;
 
@@ -676,6 +678,7 @@ export class TerminalPane {
     const delta = -this.scrollbackOffset;
     this.renderer.adjustSelectionForScroll(delta);
     this.renderer.shiftCanvas(delta);
+    this.gridRenderer?.shiftCanvas(delta);
     this.scrollbackOffset = 0;
     this.isUserScrolled = false;
     this.cachedSnapshot = null;


### PR DESCRIPTION
## Summary

- Add `shiftCanvas()` to Canvas2DGridRenderer for optimistic scroll
- Call it alongside overlay's `shiftCanvas()` in all 3 scroll paths (handleScroll, handleScrollTo, snapToBottom)

Without this, only the overlay canvas shifted during scroll — the grid canvas stayed put, creating a jarring visual mismatch for ~50-150ms until the snapshot IPC arrived.

## Test plan

- [x] TypeScript strict check passes
- [x] All 818 frontend tests pass
- [ ] Scroll up/down with mouse wheel — grid and overlay should move together smoothly
- [ ] Scrollbar drag — same smooth behavior
- [ ] Page Up/Down keys — no visual mismatch