### PR TITLE
feat: tmux-like split pane keyboard shortcuts

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -91,6 +91,10 @@ export class App {
   private pendingNotificationTerminalId: string | null = null;
   private pendingNotificationTimestamp: number = 0;
   private perfOverlay: PerfOverlay | null = null;
+  /** Tracks which pane is currently zoomed (null = no zoom active). */
+  private zoomedPaneId: string | null = null;
+  /** Stores the split ratio before zoom, so it can be restored on unzoom. */
+  private preZoomRatio: number | null = null;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -440,6 +444,121 @@ export class App {
         case 'split.unsplit': {
           e.preventDefault();
           this.handleUnsplitRequest();
+          break;
+        }
+
+        case 'split.focusLeft':
+        case 'split.focusRight':
+        case 'split.focusUp':
+        case 'split.focusDown': {
+          e.preventDefault();
+          if (state.activeWorkspaceId && state.activeTerminalId) {
+            const split = store.getSplitView(state.activeWorkspaceId);
+            if (split) {
+              // Determine which pane to focus based on direction and split orientation
+              const isHorizontal = split.direction === 'horizontal';
+              const isVertical = split.direction === 'vertical';
+              let targetId: string | null = null;
+
+              if (action === 'split.focusLeft' && isHorizontal) {
+                targetId = split.leftTerminalId;
+              } else if (action === 'split.focusRight' && isHorizontal) {
+                targetId = split.rightTerminalId;
+              } else if (action === 'split.focusUp' && isVertical) {
+                targetId = split.leftTerminalId; // "left" = top in vertical
+              } else if (action === 'split.focusDown' && isVertical) {
+                targetId = split.rightTerminalId; // "right" = bottom in vertical
+              }
+
+              if (targetId && targetId !== state.activeTerminalId) {
+                store.setActiveTerminal(targetId);
+              }
+            }
+          }
+          break;
+        }
+
+        case 'split.resizeLeft':
+        case 'split.resizeRight':
+        case 'split.resizeUp':
+        case 'split.resizeDown': {
+          e.preventDefault();
+          if (state.activeWorkspaceId) {
+            const split = store.getSplitView(state.activeWorkspaceId);
+            if (split) {
+              const isHorizontal = split.direction === 'horizontal';
+              const isVertical = split.direction === 'vertical';
+              const RESIZE_STEP = 0.05;
+              let delta = 0;
+
+              if (action === 'split.resizeLeft' && isHorizontal) delta = -RESIZE_STEP;
+              else if (action === 'split.resizeRight' && isHorizontal) delta = RESIZE_STEP;
+              else if (action === 'split.resizeUp' && isVertical) delta = -RESIZE_STEP;
+              else if (action === 'split.resizeDown' && isVertical) delta = RESIZE_STEP;
+
+              if (delta !== 0) {
+                const newRatio = Math.max(0.1, Math.min(0.9, split.ratio + delta));
+                store.updateSplitRatio(state.activeWorkspaceId, newRatio);
+              }
+            }
+          }
+          break;
+        }
+
+        case 'split.zoom': {
+          e.preventDefault();
+          if (state.activeWorkspaceId && state.activeTerminalId) {
+            const split = store.getSplitView(state.activeWorkspaceId);
+            if (split) {
+              if (this.zoomedPaneId) {
+                // Unzoom: restore split ratio
+                store.updateSplitRatio(state.activeWorkspaceId, this.preZoomRatio ?? 0.5);
+                this.zoomedPaneId = null;
+                this.preZoomRatio = null;
+              } else {
+                // Zoom: save ratio, then push active pane to near-full width
+                this.preZoomRatio = split.ratio;
+                this.zoomedPaneId = state.activeTerminalId;
+                const isLeft = state.activeTerminalId === split.leftTerminalId;
+                store.updateSplitRatio(state.activeWorkspaceId, isLeft ? 0.95 : 0.05);
+              }
+            }
+          }
+          break;
+        }
+
+        case 'split.swapPanes': {
+          e.preventDefault();
+          if (state.activeWorkspaceId) {
+            const split = store.getSplitView(state.activeWorkspaceId);
+            if (split) {
+              store.setSplitView(
+                state.activeWorkspaceId,
+                split.rightTerminalId,
+                split.leftTerminalId,
+                split.direction,
+                1 - split.ratio,
+              );
+            }
+          }
+          break;
+        }
+
+        case 'split.rotateSplit': {
+          e.preventDefault();
+          if (state.activeWorkspaceId) {
+            const split = store.getSplitView(state.activeWorkspaceId);
+            if (split) {
+              const newDirection = split.direction === 'horizontal' ? 'vertical' : 'horizontal';
+              store.setSplitView(
+                state.activeWorkspaceId,
+                split.leftTerminalId,
+                split.rightTerminalId,
+                newDirection,
+                split.ratio,
+              );
+            }
+          }
           break;
         }
 

--- a/src/components/TerminalPane.test.ts
+++ b/src/components/TerminalPane.test.ts
@@ -164,18 +164,18 @@ describe('custom keybinding integration', () => {
   });
 
   it('isTerminalControlKey respects custom bindings from the store', () => {
-    // Rebind terminal.interrupt from Ctrl+C to Ctrl+Shift+X
+    // Rebind terminal.interrupt from Ctrl+C to Ctrl+Shift+J
     keybindingStore.setBinding('terminal.interrupt', {
       ctrlKey: true,
       shiftKey: true,
       altKey: false,
-      key: 'x',
+      key: 'j',
     });
 
     // Old binding should no longer be a terminal control key
     expect(isTerminalControlKey(keydown('c', { ctrlKey: true }))).toBe(false);
     // New binding should be a terminal control key
-    expect(isTerminalControlKey(keydown('X', { ctrlKey: true, shiftKey: true }))).toBe(true);
+    expect(isTerminalControlKey(keydown('J', { ctrlKey: true, shiftKey: true }))).toBe(true);
   });
 
   it('Ctrl+, is always an app shortcut regardless of bindings', () => {

--- a/src/components/keyboard.ts
+++ b/src/components/keyboard.ts
@@ -11,12 +11,14 @@ import { keybindingStore } from '../state/keybinding-store';
  */
 export function isAppShortcut(event: { ctrlKey: boolean; shiftKey: boolean; altKey?: boolean; key: string; type: string }): boolean {
   if (event.type !== 'keydown') return false;
-  if (!event.ctrlKey) return false;
 
   // Hardcoded shortcuts that should always bubble (not customisable)
-  if (event.shiftKey && (event.key === 'S' || event.key === 'L')) return true;
+  if (event.ctrlKey && event.shiftKey && (event.key === 'S' || event.key === 'L')) return true;
   // Ctrl+, (open settings)
-  if (!event.shiftKey && event.key === ',') return true;
+  if (event.ctrlKey && !event.shiftKey && event.key === ',') return true;
+
+  // No modifier at all — not an app shortcut (let plain keys through to PTY)
+  if (!event.ctrlKey && !event.altKey) return false;
 
   return keybindingStore.isAppShortcut({
     ctrlKey: event.ctrlKey,

--- a/src/state/keybinding-store.split-shortcuts.test.ts
+++ b/src/state/keybinding-store.split-shortcuts.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  KeybindingStore,
+  chordToString,
+  formatChord,
+  DEFAULT_SHORTCUTS,
+  type ActionId,
+} from './keybinding-store';
+
+// Mock localStorage
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+});
+
+function keydown(
+  key: string,
+  opts: { ctrlKey?: boolean; shiftKey?: boolean; altKey?: boolean } = {}
+) {
+  return {
+    key,
+    type: 'keydown' as const,
+    ctrlKey: opts.ctrlKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    altKey: opts.altKey ?? false,
+  };
+}
+
+const SPLIT_ACTION_IDS: ActionId[] = [
+  'split.focusLeft',
+  'split.focusRight',
+  'split.focusUp',
+  'split.focusDown',
+  'split.resizeLeft',
+  'split.resizeRight',
+  'split.resizeUp',
+  'split.resizeDown',
+  'split.zoom',
+  'split.swapPanes',
+  'split.rotateSplit',
+];
+
+describe('Split shortcut registration', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it('all new split shortcuts are registered in DEFAULT_SHORTCUTS', () => {
+    const registeredIds = DEFAULT_SHORTCUTS.map(s => s.id);
+    for (const id of SPLIT_ACTION_IDS) {
+      expect(registeredIds).toContain(id);
+    }
+  });
+
+  it('all new split shortcuts are in the Split category', () => {
+    for (const id of SPLIT_ACTION_IDS) {
+      const def = DEFAULT_SHORTCUTS.find(s => s.id === id);
+      expect(def).toBeDefined();
+      expect(def!.category).toBe('Split');
+    }
+  });
+
+  it('all new split shortcuts have type app', () => {
+    for (const id of SPLIT_ACTION_IDS) {
+      const def = DEFAULT_SHORTCUTS.find(s => s.id === id);
+      expect(def).toBeDefined();
+      expect(def!.type).toBe('app');
+    }
+  });
+
+  it('no duplicate action IDs in DEFAULT_SHORTCUTS', () => {
+    const ids = DEFAULT_SHORTCUTS.map(s => s.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('no conflicting default chords in DEFAULT_SHORTCUTS', () => {
+    const chords = new Map<string, ActionId>();
+    for (const def of DEFAULT_SHORTCUTS) {
+      const str = chordToString(def.defaultChord);
+      const existing = chords.get(str);
+      expect(existing).toBeUndefined();
+      chords.set(str, def.id);
+    }
+  });
+});
+
+describe('Split shortcut matching', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it('matches Alt+ArrowLeft to split.focusLeft', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowLeft', { altKey: true }))).toBe('split.focusLeft');
+  });
+
+  it('matches Alt+ArrowRight to split.focusRight', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowRight', { altKey: true }))).toBe('split.focusRight');
+  });
+
+  it('matches Alt+ArrowUp to split.focusUp', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowUp', { altKey: true }))).toBe('split.focusUp');
+  });
+
+  it('matches Alt+ArrowDown to split.focusDown', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowDown', { altKey: true }))).toBe('split.focusDown');
+  });
+
+  it('matches Ctrl+Alt+ArrowLeft to split.resizeLeft', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowLeft', { ctrlKey: true, altKey: true }))).toBe('split.resizeLeft');
+  });
+
+  it('matches Ctrl+Alt+ArrowRight to split.resizeRight', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowRight', { ctrlKey: true, altKey: true }))).toBe('split.resizeRight');
+  });
+
+  it('matches Ctrl+Alt+ArrowUp to split.resizeUp', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowUp', { ctrlKey: true, altKey: true }))).toBe('split.resizeUp');
+  });
+
+  it('matches Ctrl+Alt+ArrowDown to split.resizeDown', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowDown', { ctrlKey: true, altKey: true }))).toBe('split.resizeDown');
+  });
+
+  it('matches Ctrl+Shift+Z to split.zoom', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('Z', { ctrlKey: true, shiftKey: true }))).toBe('split.zoom');
+  });
+
+  it('matches Ctrl+Shift+X to split.swapPanes', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('X', { ctrlKey: true, shiftKey: true }))).toBe('split.swapPanes');
+  });
+
+  it('matches Ctrl+Shift+R to split.rotateSplit', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('R', { ctrlKey: true, shiftKey: true }))).toBe('split.rotateSplit');
+  });
+});
+
+describe('Split shortcut non-conflicts', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it('Ctrl+Z (suspend) does not conflict with Ctrl+Shift+Z (zoom)', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('z', { ctrlKey: true }))).toBe('terminal.suspend');
+    expect(store.matchAction(keydown('Z', { ctrlKey: true, shiftKey: true }))).toBe('split.zoom');
+  });
+
+  it('Alt+Arrow focus shortcuts do not conflict with Ctrl+Alt+Arrow resize shortcuts', () => {
+    const store = new KeybindingStore();
+    expect(store.matchAction(keydown('ArrowLeft', { altKey: true }))).toBe('split.focusLeft');
+    expect(store.matchAction(keydown('ArrowLeft', { ctrlKey: true, altKey: true }))).toBe('split.resizeLeft');
+  });
+
+  it('all new split shortcuts are classified as app shortcuts', () => {
+    const store = new KeybindingStore();
+    for (const id of SPLIT_ACTION_IDS) {
+      expect(store.isAppShortcut(keydown('dummy'))).toBe(false); // sanity check
+    }
+
+    // Check each shortcut is classified correctly
+    expect(store.isAppShortcut(keydown('ArrowLeft', { altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowRight', { altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowUp', { altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowDown', { altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowLeft', { ctrlKey: true, altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowRight', { ctrlKey: true, altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowUp', { ctrlKey: true, altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('ArrowDown', { ctrlKey: true, altKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('Z', { ctrlKey: true, shiftKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('X', { ctrlKey: true, shiftKey: true }))).toBe(true);
+    expect(store.isAppShortcut(keydown('R', { ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+
+  it('none of the new shortcuts conflict with existing ones', () => {
+    const store = new KeybindingStore();
+    for (const id of SPLIT_ACTION_IDS) {
+      const def = DEFAULT_SHORTCUTS.find(s => s.id === id)!;
+      const conflict = store.findConflict(def.defaultChord, id);
+      expect(conflict).toBeNull();
+    }
+  });
+});
+
+describe('Split shortcut display formatting', () => {
+  it('formats arrow key shortcuts with arrow symbols', () => {
+    const leftDef = DEFAULT_SHORTCUTS.find(s => s.id === 'split.focusLeft')!;
+    expect(formatChord(leftDef.defaultChord)).toBe('Alt+\u2190');
+  });
+
+  it('formats resize shortcuts with Ctrl+Alt+arrow', () => {
+    const resizeDef = DEFAULT_SHORTCUTS.find(s => s.id === 'split.resizeRight')!;
+    expect(formatChord(resizeDef.defaultChord)).toBe('Ctrl+Alt+\u2192');
+  });
+
+  it('formats zoom shortcut as Ctrl+Shift+Z', () => {
+    const zoomDef = DEFAULT_SHORTCUTS.find(s => s.id === 'split.zoom')!;
+    expect(formatChord(zoomDef.defaultChord)).toBe('Ctrl+Shift+Z');
+  });
+
+  it('formats swap shortcut as Ctrl+Shift+X', () => {
+    const swapDef = DEFAULT_SHORTCUTS.find(s => s.id === 'split.swapPanes')!;
+    expect(formatChord(swapDef.defaultChord)).toBe('Ctrl+Shift+X');
+  });
+
+  it('formats rotate shortcut as Ctrl+Shift+R', () => {
+    const rotateDef = DEFAULT_SHORTCUTS.find(s => s.id === 'split.rotateSplit')!;
+    expect(formatChord(rotateDef.defaultChord)).toBe('Ctrl+Shift+R');
+  });
+});

--- a/src/state/keybinding-store.test.ts
+++ b/src/state/keybinding-store.test.ts
@@ -142,11 +142,11 @@ describe('KeybindingStore', () => {
   describe('setBinding', () => {
     it('changes the action binding and rebuilds the index', () => {
       const store = new KeybindingStore();
-      const newChord: KeyChord = { ctrlKey: true, shiftKey: true, altKey: false, key: 'x' };
+      const newChord: KeyChord = { ctrlKey: true, shiftKey: true, altKey: false, key: 'j' };
       store.setBinding('terminal.interrupt', newChord);
 
       expect(store.getBinding('terminal.interrupt')).toEqual(newChord);
-      expect(store.matchAction(keydown('X', { ctrlKey: true, shiftKey: true }))).toBe(
+      expect(store.matchAction(keydown('J', { ctrlKey: true, shiftKey: true }))).toBe(
         'terminal.interrupt'
       );
       // Old binding no longer matches
@@ -170,13 +170,13 @@ describe('KeybindingStore', () => {
         ctrlKey: true,
         shiftKey: true,
         altKey: false,
-        key: 'x',
+        key: 'j',
       });
       expect(storage.has('godly-custom-keybindings')).toBe(true);
 
       // A new store picks up the override
       const store2 = new KeybindingStore();
-      expect(chordToString(store2.getBinding('terminal.interrupt'))).toBe('Ctrl+Shift+x');
+      expect(chordToString(store2.getBinding('terminal.interrupt'))).toBe('Ctrl+Shift+j');
     });
   });
 
@@ -259,19 +259,19 @@ describe('KeybindingStore', () => {
     });
 
     it('type follows the action, not the binding', () => {
-      // Bug scenario: user rebinds SIGINT to Ctrl+Shift+X — it should still
+      // Bug scenario: user rebinds SIGINT to Ctrl+Shift+J — it should still
       // be classified as terminal-control so it gets preventDefault().
       const store = new KeybindingStore();
       store.setBinding('terminal.interrupt', {
         ctrlKey: true,
         shiftKey: true,
         altKey: false,
-        key: 'x',
+        key: 'j',
       });
-      expect(store.isTerminalControlKey(keydown('X', { ctrlKey: true, shiftKey: true }))).toBe(
+      expect(store.isTerminalControlKey(keydown('J', { ctrlKey: true, shiftKey: true }))).toBe(
         true
       );
-      expect(store.isAppShortcut(keydown('X', { ctrlKey: true, shiftKey: true }))).toBe(false);
+      expect(store.isAppShortcut(keydown('J', { ctrlKey: true, shiftKey: true }))).toBe(false);
     });
 
     it('returns false for keyup events', () => {

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -22,6 +22,17 @@ export type ActionId =
   | 'split.splitDown'
   | 'split.focusOtherPane'
   | 'split.unsplit'
+  | 'split.focusLeft'
+  | 'split.focusRight'
+  | 'split.focusUp'
+  | 'split.focusDown'
+  | 'split.resizeLeft'
+  | 'split.resizeRight'
+  | 'split.resizeUp'
+  | 'split.resizeDown'
+  | 'split.zoom'
+  | 'split.swapPanes'
+  | 'split.rotateSplit'
   | 'workspace.toggleWorktreeMode'
   | 'workspace.toggleClaudeCodeMode'
   | 'scroll.pageUp'
@@ -149,6 +160,83 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'Split',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: '\\' },
+  },
+  {
+    id: 'split.focusLeft',
+    label: 'Focus Pane Left',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: false, shiftKey: false, altKey: true, key: 'arrowleft' },
+  },
+  {
+    id: 'split.focusRight',
+    label: 'Focus Pane Right',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: false, shiftKey: false, altKey: true, key: 'arrowright' },
+  },
+  {
+    id: 'split.focusUp',
+    label: 'Focus Pane Up',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: false, shiftKey: false, altKey: true, key: 'arrowup' },
+  },
+  {
+    id: 'split.focusDown',
+    label: 'Focus Pane Down',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: false, shiftKey: false, altKey: true, key: 'arrowdown' },
+  },
+  {
+    id: 'split.resizeLeft',
+    label: 'Resize Pane Left',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: true, key: 'arrowleft' },
+  },
+  {
+    id: 'split.resizeRight',
+    label: 'Resize Pane Right',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: true, key: 'arrowright' },
+  },
+  {
+    id: 'split.resizeUp',
+    label: 'Resize Pane Up',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: true, key: 'arrowup' },
+  },
+  {
+    id: 'split.resizeDown',
+    label: 'Resize Pane Down',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: false, altKey: true, key: 'arrowdown' },
+  },
+  {
+    id: 'split.zoom',
+    label: 'Zoom/Unzoom Pane',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'z' },
+  },
+  {
+    id: 'split.swapPanes',
+    label: 'Swap Panes',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'x' },
+  },
+  {
+    id: 'split.rotateSplit',
+    label: 'Rotate Split Direction',
+    category: 'Split',
+    type: 'app',
+    defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'r' },
   },
   {
     id: 'workspace.toggleWorktreeMode',
@@ -289,6 +377,10 @@ export function formatChord(chord: KeyChord): string {
     home: 'Home',
     end: 'End',
     f2: 'F2',
+    arrowleft: '\u2190',
+    arrowright: '\u2192',
+    arrowup: '\u2191',
+    arrowdown: '\u2193',
   };
   const displayKey = keyDisplayMap[chord.key] ?? chord.key.toUpperCase();
   parts.push(displayKey);


### PR DESCRIPTION
## Summary

- Add 11 new keyboard shortcuts for split pane management: directional focus (Alt+Arrow), resize (Ctrl+Alt+Arrow), zoom (Ctrl+Shift+Z), swap (Ctrl+Shift+X), and rotate (Ctrl+Shift+R)
- Fix `isAppShortcut()` in `keyboard.ts` to allow Alt-only shortcuts to bubble from TerminalPane to App.ts (was blocked by early `ctrlKey` guard, which also broke the existing `Alt+\` focus-other-pane shortcut)
- Add arrow key Unicode symbols to `formatChord` display map for clean rendering in Settings dialog

refs #379

## Test plan

- [x] All 846 existing tests pass (no regressions)
- [x] 25 new tests in `keybinding-store.split-shortcuts.test.ts` covering registration, matching, conflicts, classification, and formatting
- [x] `npx tsc --noEmit` passes cleanly
- [ ] Manual verification with split panes in Godly Staging