### PR TITLE
feat: recursive layout tree state for split panes

### DIFF
--- a/src/state/split-types.test.ts
+++ b/src/state/split-types.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LayoutNode,
+  terminalIds,
+  replaceLeaf,
+  removeLeaf,
+  containsTerminal,
+  updateRatioAtPath,
+  swapTerminals,
+  findAdjacentTerminal,
+  getNodeAtPath,
+} from './split-types';
+
+const leaf = (id: string): LayoutNode => ({ type: 'leaf', terminal_id: id });
+const split = (
+  dir: 'horizontal' | 'vertical',
+  ratio: number,
+  first: LayoutNode,
+  second: LayoutNode,
+): LayoutNode => ({ type: 'split', direction: dir, ratio, first, second });
+
+describe('split-types tree utilities', () => {
+  describe('terminalIds', () => {
+    it('should return single id for leaf', () => {
+      expect(terminalIds(leaf('t1'))).toEqual(['t1']);
+    });
+
+    it('should return DFS order for nested tree', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      expect(terminalIds(tree)).toEqual(['t1', 't2', 't3']);
+    });
+
+    it('should handle deeply nested tree', () => {
+      const tree = split('horizontal', 0.5,
+        split('vertical', 0.5, leaf('t1'), leaf('t2')),
+        split('vertical', 0.5, leaf('t3'), leaf('t4')),
+      );
+      expect(terminalIds(tree)).toEqual(['t1', 't2', 't3', 't4']);
+    });
+  });
+
+  describe('containsTerminal', () => {
+    it('should find terminal in leaf', () => {
+      expect(containsTerminal(leaf('t1'), 't1')).toBe(true);
+      expect(containsTerminal(leaf('t1'), 't2')).toBe(false);
+    });
+
+    it('should find terminal in nested tree', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      expect(containsTerminal(tree, 't3')).toBe(true);
+      expect(containsTerminal(tree, 't4')).toBe(false);
+    });
+  });
+
+  describe('replaceLeaf', () => {
+    it('should replace a leaf at root', () => {
+      const result = replaceLeaf(leaf('t1'), 't1', leaf('t2'));
+      expect(result).toEqual(leaf('t2'));
+    });
+
+    it('should return null if leaf not found', () => {
+      const result = replaceLeaf(leaf('t1'), 't3', leaf('t2'));
+      expect(result).toBeNull();
+    });
+
+    it('should replace a leaf in nested tree', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      const replacement = split('horizontal', 0.5, leaf('t2'), leaf('t4'));
+      const result = replaceLeaf(tree, 't2', replacement);
+
+      expect(result).not.toBeNull();
+      expect(terminalIds(result!)).toEqual(['t1', 't2', 't4', 't3']);
+    });
+  });
+
+  describe('removeLeaf', () => {
+    it('should remove leaf from 2-pane split, returning sibling', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      const { result, found } = removeLeaf(tree, 't1');
+      expect(found).toBe(true);
+      expect(result).toEqual(leaf('t2'));
+    });
+
+    it('should remove leaf from nested tree, collapsing parent split', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      const { result, found } = removeLeaf(tree, 't3');
+      expect(found).toBe(true);
+      // Should collapse to: t1 | t2
+      expect(result).toEqual(split('horizontal', 0.5, leaf('t1'), leaf('t2')));
+    });
+
+    it('should not find non-existent terminal', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      const { result, found } = removeLeaf(tree, 't3');
+      expect(found).toBe(false);
+      expect(result).toEqual(tree);
+    });
+
+    it('should return null when removing only terminal', () => {
+      const { result, found } = removeLeaf(leaf('t1'), 't1');
+      expect(found).toBe(true);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getNodeAtPath', () => {
+    it('should return root at empty path', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(getNodeAtPath(tree, [])).toEqual(tree);
+    });
+
+    it('should return first child at [0]', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(getNodeAtPath(tree, [0])).toEqual(leaf('t1'));
+    });
+
+    it('should return second child at [1]', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(getNodeAtPath(tree, [1])).toEqual(leaf('t2'));
+    });
+
+    it('should navigate nested path', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.7, leaf('t2'), leaf('t3')),
+      );
+      const node = getNodeAtPath(tree, [1, 0]);
+      expect(node).toEqual(leaf('t2'));
+    });
+
+    it('should return null for invalid path', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(getNodeAtPath(tree, [0, 0])).toBeNull(); // [0] is a leaf, can't go deeper
+      expect(getNodeAtPath(tree, [2])).toBeNull(); // no third child
+    });
+  });
+
+  describe('updateRatioAtPath', () => {
+    it('should update root ratio', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      const result = updateRatioAtPath(tree, [], 0.7);
+      expect(result).not.toBeNull();
+      if (result!.type === 'split') {
+        expect(result!.ratio).toBe(0.7);
+      }
+    });
+
+    it('should update nested ratio', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      const result = updateRatioAtPath(tree, [1], 0.3);
+      expect(result).not.toBeNull();
+      if (result!.type === 'split' && result!.second.type === 'split') {
+        expect(result!.second.ratio).toBe(0.3);
+        expect(result!.ratio).toBe(0.5); // root unchanged
+      }
+    });
+
+    it('should return null for path pointing to leaf', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(updateRatioAtPath(tree, [0], 0.3)).toBeNull();
+    });
+  });
+
+  describe('swapTerminals', () => {
+    it('should swap two terminals', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      const result = swapTerminals(tree, 't1', 't2');
+      expect(result).not.toBeNull();
+      expect(terminalIds(result!)).toEqual(['t2', 't1']);
+    });
+
+    it('should swap in nested tree', () => {
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      const result = swapTerminals(tree, 't1', 't3');
+      expect(result).not.toBeNull();
+      expect(terminalIds(result!)).toEqual(['t3', 't2', 't1']);
+    });
+
+    it('should return null if terminal not found', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(swapTerminals(tree, 't1', 't4')).toBeNull();
+    });
+  });
+
+  describe('findAdjacentTerminal', () => {
+    it('should find right neighbor in horizontal split', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(findAdjacentTerminal(tree, 't1', 'horizontal', true)).toBe('t2');
+    });
+
+    it('should find left neighbor in horizontal split', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(findAdjacentTerminal(tree, 't2', 'horizontal', false)).toBe('t1');
+    });
+
+    it('should return null for wrong direction', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(findAdjacentTerminal(tree, 't1', 'vertical', true)).toBeNull();
+    });
+
+    it('should navigate across nested splits', () => {
+      // t1 | (t2 / t3)
+      const tree = split('horizontal', 0.5,
+        leaf('t1'),
+        split('vertical', 0.5, leaf('t2'), leaf('t3')),
+      );
+      // From t1, going right should reach t2 (first leaf of right subtree)
+      expect(findAdjacentTerminal(tree, 't1', 'horizontal', true)).toBe('t2');
+      // From t3, going left should reach... nothing (t3 is in a vertical split)
+      // The vertical split is the second child of horizontal. Going left from t3
+      // means we need to find a horizontal split ancestor where t3 is in the second child.
+      // t3 is in tree.second (horizontal split), so going left = tree.first = t1's last leaf = t1
+      expect(findAdjacentTerminal(tree, 't3', 'horizontal', false)).toBe('t1');
+    });
+
+    it('should return null for terminal not in tree', () => {
+      const tree = split('horizontal', 0.5, leaf('t1'), leaf('t2'));
+      expect(findAdjacentTerminal(tree, 't3', 'horizontal', true)).toBeNull();
+    });
+
+    it('should return null for leaf node', () => {
+      expect(findAdjacentTerminal(leaf('t1'), 't1', 'horizontal', true)).toBeNull();
+    });
+  });
+});

--- a/src/state/split-types.ts
+++ b/src/state/split-types.ts
@@ -1,0 +1,224 @@
+/**
+ * Recursive layout tree types for split pane management.
+ *
+ * A layout is either a single terminal (LeafNode) or a binary split
+ * (SplitNode) whose children are themselves layout nodes. This allows
+ * arbitrary nesting of horizontal and vertical splits.
+ */
+
+export interface LeafNode {
+  type: 'leaf';
+  terminal_id: string;
+}
+
+export interface SplitNode {
+  type: 'split';
+  direction: 'horizontal' | 'vertical';
+  ratio: number;
+  first: LayoutNode;
+  second: LayoutNode;
+}
+
+export type LayoutNode = LeafNode | SplitNode;
+
+// ---------------------------------------------------------------------------
+// Tree utility functions
+// ---------------------------------------------------------------------------
+
+/** Collect all terminal IDs from the tree via depth-first traversal. */
+export function terminalIds(node: LayoutNode): string[] {
+  if (node.type === 'leaf') return [node.terminal_id];
+  return [...terminalIds(node.first), ...terminalIds(node.second)];
+}
+
+/** Find the leaf containing `terminalId` and replace it with `replacement`. */
+export function replaceLeaf(
+  node: LayoutNode,
+  terminalId: string,
+  replacement: LayoutNode,
+): LayoutNode | null {
+  if (node.type === 'leaf') {
+    return node.terminal_id === terminalId ? replacement : null;
+  }
+  const firstResult = replaceLeaf(node.first, terminalId, replacement);
+  if (firstResult) {
+    return { ...node, first: firstResult };
+  }
+  const secondResult = replaceLeaf(node.second, terminalId, replacement);
+  if (secondResult) {
+    return { ...node, second: secondResult };
+  }
+  return null;
+}
+
+/**
+ * Remove a terminal from the tree.
+ * Returns the collapsed tree (the sibling subtree), or null if the terminal
+ * was not found.
+ */
+export function removeLeaf(
+  node: LayoutNode,
+  terminalId: string,
+): { result: LayoutNode | null; found: boolean } {
+  if (node.type === 'leaf') {
+    if (node.terminal_id === terminalId) {
+      return { result: null, found: true };
+    }
+    return { result: node, found: false };
+  }
+
+  // Check first child
+  if (node.first.type === 'leaf' && node.first.terminal_id === terminalId) {
+    return { result: node.second, found: true };
+  }
+  if (node.second.type === 'leaf' && node.second.terminal_id === terminalId) {
+    return { result: node.first, found: true };
+  }
+
+  // Recurse into first
+  const firstResult = removeLeaf(node.first, terminalId);
+  if (firstResult.found) {
+    if (firstResult.result === null) {
+      return { result: node.second, found: true };
+    }
+    return { result: { ...node, first: firstResult.result }, found: true };
+  }
+
+  // Recurse into second
+  const secondResult = removeLeaf(node.second, terminalId);
+  if (secondResult.found) {
+    if (secondResult.result === null) {
+      return { result: node.first, found: true };
+    }
+    return { result: { ...node, second: secondResult.result }, found: true };
+  }
+
+  return { result: node, found: false };
+}
+
+/** Check whether a terminal exists in the tree. */
+export function containsTerminal(node: LayoutNode, terminalId: string): boolean {
+  if (node.type === 'leaf') return node.terminal_id === terminalId;
+  return containsTerminal(node.first, terminalId) || containsTerminal(node.second, terminalId);
+}
+
+/**
+ * Get the node at a given path (array of 0=first, 1=second indices).
+ * Returns the node or null if the path is invalid.
+ */
+export function getNodeAtPath(node: LayoutNode, path: number[]): LayoutNode | null {
+  if (path.length === 0) return node;
+  if (node.type === 'leaf') return null;
+  const [head, ...rest] = path;
+  if (head === 0) return getNodeAtPath(node.first, rest);
+  if (head === 1) return getNodeAtPath(node.second, rest);
+  return null;
+}
+
+/**
+ * Update the ratio of the split node at the given path.
+ * Returns the updated tree, or null if the path doesn't point to a split node.
+ */
+export function updateRatioAtPath(
+  node: LayoutNode,
+  path: number[],
+  ratio: number,
+): LayoutNode | null {
+  if (path.length === 0) {
+    if (node.type !== 'split') return null;
+    return { ...node, ratio };
+  }
+  if (node.type === 'leaf') return null;
+  const [head, ...rest] = path;
+  if (head === 0) {
+    const updated = updateRatioAtPath(node.first, rest, ratio);
+    if (!updated) return null;
+    return { ...node, first: updated };
+  }
+  if (head === 1) {
+    const updated = updateRatioAtPath(node.second, rest, ratio);
+    if (!updated) return null;
+    return { ...node, second: updated };
+  }
+  return null;
+}
+
+/**
+ * Swap two terminal IDs in the tree. Both must exist as leaves.
+ */
+export function swapTerminals(
+  node: LayoutNode,
+  idA: string,
+  idB: string,
+): LayoutNode | null {
+  if (!containsTerminal(node, idA) || !containsTerminal(node, idB)) return null;
+  return mapLeaves(node, (leaf) => {
+    if (leaf.terminal_id === idA) return { type: 'leaf', terminal_id: idB };
+    if (leaf.terminal_id === idB) return { type: 'leaf', terminal_id: idA };
+    return leaf;
+  });
+}
+
+/** Map over every leaf in the tree. */
+function mapLeaves(node: LayoutNode, fn: (leaf: LeafNode) => LeafNode): LayoutNode {
+  if (node.type === 'leaf') return fn(node);
+  return {
+    ...node,
+    first: mapLeaves(node.first, fn),
+    second: mapLeaves(node.second, fn),
+  };
+}
+
+/**
+ * Walk the tree to find the nearest terminal in the given direction.
+ *
+ * The algorithm finds the deepest split whose direction matches, where
+ * `terminalId` is on one side and we want to move to the other side.
+ * `goSecond` = true means move toward the "second" child (right/down),
+ * false means toward the "first" child (left/up).
+ *
+ * Returns the terminal ID of the nearest leaf in that direction, or null.
+ */
+export function findAdjacentTerminal(
+  node: LayoutNode,
+  terminalId: string,
+  direction: 'horizontal' | 'vertical',
+  goSecond: boolean,
+): string | null {
+  if (node.type === 'leaf') return null;
+
+  const inFirst = containsTerminal(node.first, terminalId);
+  const inSecond = containsTerminal(node.second, terminalId);
+
+  if (!inFirst && !inSecond) return null;
+
+  // If this split's direction matches what we're looking for
+  if (node.direction === direction) {
+    if (inFirst && goSecond) {
+      // Moving from first to second — return the nearest leaf in second
+      return firstLeaf(node.second);
+    }
+    if (inSecond && !goSecond) {
+      // Moving from second to first — return the last leaf in first
+      return lastLeaf(node.first);
+    }
+  }
+
+  // Recurse into the child that contains the terminal
+  if (inFirst) {
+    return findAdjacentTerminal(node.first, terminalId, direction, goSecond);
+  }
+  return findAdjacentTerminal(node.second, terminalId, direction, goSecond);
+}
+
+/** Get the first (leftmost/topmost) leaf terminal. */
+function firstLeaf(node: LayoutNode): string {
+  if (node.type === 'leaf') return node.terminal_id;
+  return firstLeaf(node.first);
+}
+
+/** Get the last (rightmost/bottommost) leaf terminal. */
+function lastLeaf(node: LayoutNode): string {
+  if (node.type === 'leaf') return node.terminal_id;
+  return lastLeaf(node.second);
+}

--- a/src/state/store.layout-tree.test.ts
+++ b/src/state/store.layout-tree.test.ts
@@ -1,0 +1,739 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { store, Workspace } from './store';
+import { terminalIds } from './split-types';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+const ws: Workspace = {
+  id: 'ws-1', name: 'WS', folderPath: 'C:\\ws', tabOrder: [],
+  shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+};
+
+function addTerminals(ids: string[]) {
+  for (let i = 0; i < ids.length; i++) {
+    store.addTerminal({
+      id: ids[i], workspaceId: 'ws-1', name: `Tab ${i + 1}`,
+      processName: 'cmd', order: i,
+    });
+  }
+}
+
+describe('layout tree state management', () => {
+  beforeEach(() => {
+    store.reset();
+    store.addWorkspace(ws);
+  });
+
+  // -------------------------------------------------------------------------
+  // Creating trees from splitTerminalAt
+  // -------------------------------------------------------------------------
+
+  describe('splitTerminalAt', () => {
+    it('should create a tree from an empty workspace', () => {
+      addTerminals(['t1', 't2']);
+      store.setActiveWorkspace('ws-1');
+
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(tree!.type).toBe('split');
+      if (tree!.type === 'split') {
+        expect(tree!.direction).toBe('horizontal');
+        expect(tree!.ratio).toBe(0.5);
+        expect(tree!.first).toEqual({ type: 'leaf', terminal_id: 't1' });
+        expect(tree!.second).toEqual({ type: 'leaf', terminal_id: 't2' });
+      }
+    });
+
+    it('should create a tree with custom ratio', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'vertical', 0.3);
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      if (tree!.type === 'split') {
+        expect(tree!.direction).toBe('vertical');
+        expect(tree!.ratio).toBe(0.3);
+      }
+    });
+
+    it('should nest a split within an existing tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      // Now split t2 vertically with t3
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(tree!.type).toBe('split');
+      if (tree!.type === 'split') {
+        expect(tree!.first).toEqual({ type: 'leaf', terminal_id: 't1' });
+        expect(tree!.second.type).toBe('split');
+        if (tree!.second.type === 'split') {
+          expect(tree!.second.direction).toBe('vertical');
+          expect(tree!.second.first).toEqual({ type: 'leaf', terminal_id: 't2' });
+          expect(tree!.second.second).toEqual({ type: 'leaf', terminal_id: 't3' });
+        }
+      }
+    });
+
+    it('should collect all terminal IDs from nested tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(terminalIds(tree!)).toEqual(['t1', 't2', 't3']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Removing terminals from trees
+  // -------------------------------------------------------------------------
+
+  describe('unsplitTerminal', () => {
+    it('should collapse a 2-pane tree to nothing', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.unsplitTerminal('ws-1', 't2');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+    });
+
+    it('should collapse a 3-pane tree to a 2-pane tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      // Remove t3 — the nested split should collapse
+      store.unsplitTerminal('ws-1', 't3');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(tree!.type).toBe('split');
+      if (tree!.type === 'split') {
+        expect(tree!.first).toEqual({ type: 'leaf', terminal_id: 't1' });
+        expect(tree!.second).toEqual({ type: 'leaf', terminal_id: 't2' });
+      }
+    });
+
+    it('should clear tree when removing all but one terminal', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      store.unsplitTerminal('ws-1', 't3');
+      store.unsplitTerminal('ws-1', 't2');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+    });
+
+    it('should no-op for terminal not in tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.unsplitTerminal('ws-1', 't3');
+
+      // Tree should be unchanged
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(terminalIds(tree!)).toEqual(['t1', 't2']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removeTerminal integration
+  // -------------------------------------------------------------------------
+
+  describe('removeTerminal with layout tree', () => {
+    it('should clear tree when removing a terminal from a 2-pane split', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t1');
+
+      store.removeTerminal('t1');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+      expect(store.getState().activeTerminalId).toBe('t2');
+    });
+
+    it('should collapse tree when removing from a 3-pane split', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+      store.setActiveTerminal('t3');
+
+      store.removeTerminal('t3');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      if (tree) {
+        expect(terminalIds(tree)).toEqual(['t1', 't2']);
+      }
+    });
+
+    it('should set remaining terminal as active when tree collapses', () => {
+      addTerminals(['t1', 't2']);
+      store.setActiveWorkspace('ws-1');
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t2');
+
+      store.removeTerminal('t2');
+
+      expect(store.getState().activeTerminalId).toBe('t1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Zoom
+  // -------------------------------------------------------------------------
+
+  describe('zoom', () => {
+    it('should set zoomed pane', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.setZoomedPane('ws-1', 't1');
+
+      expect(store.getZoomedPane('ws-1')).toBe('t1');
+    });
+
+    it('should unzoom with null', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setZoomedPane('ws-1', 't1');
+
+      store.setZoomedPane('ws-1', null);
+
+      expect(store.getZoomedPane('ws-1')).toBeNull();
+    });
+
+    it('should preserve tree when zoomed', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setZoomedPane('ws-1', 't1');
+
+      // Tree should still exist
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(terminalIds(tree!)).toEqual(['t1', 't2']);
+    });
+
+    it('should restore tree layout on unzoom', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal', 0.7);
+      store.setZoomedPane('ws-1', 't1');
+      store.setZoomedPane('ws-1', null);
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      if (tree!.type === 'split') {
+        expect(tree!.ratio).toBe(0.7);
+      }
+    });
+
+    it('should clear zoom when removing zoomed terminal', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+      store.setZoomedPane('ws-1', 't2');
+
+      store.removeTerminal('t2');
+
+      expect(store.getZoomedPane('ws-1')).toBeNull();
+    });
+
+    it('should clear zoom when clearing tree', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setZoomedPane('ws-1', 't1');
+
+      store.clearLayoutTree('ws-1');
+
+      expect(store.getZoomedPane('ws-1')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Swap panes
+  // -------------------------------------------------------------------------
+
+  describe('swapPanes', () => {
+    it('should swap two terminals in a 2-pane tree', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.swapPanes('ws-1', 't1', 't2');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      if (tree!.type === 'split') {
+        expect(tree!.first).toEqual({ type: 'leaf', terminal_id: 't2' });
+        expect(tree!.second).toEqual({ type: 'leaf', terminal_id: 't1' });
+      }
+    });
+
+    it('should swap terminals in a nested tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      store.swapPanes('ws-1', 't1', 't3');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(terminalIds(tree!)).toEqual(['t3', 't2', 't1']);
+    });
+
+    it('should no-op when swapping non-existent terminal', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.swapPanes('ws-1', 't1', 'nonexistent');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(terminalIds(tree!)).toEqual(['t1', 't2']);
+    });
+
+    it('should no-op when no tree exists', () => {
+      addTerminals(['t1', 't2']);
+      store.swapPanes('ws-1', 't1', 't2');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAdjacentPane
+  // -------------------------------------------------------------------------
+
+  describe('getAdjacentPane', () => {
+    it('should find adjacent pane in horizontal split', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      expect(store.getAdjacentPane('ws-1', 't1', 'horizontal', true)).toBe('t2');
+      expect(store.getAdjacentPane('ws-1', 't2', 'horizontal', false)).toBe('t1');
+    });
+
+    it('should find adjacent pane in vertical split', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'vertical');
+
+      expect(store.getAdjacentPane('ws-1', 't1', 'vertical', true)).toBe('t2');
+      expect(store.getAdjacentPane('ws-1', 't2', 'vertical', false)).toBe('t1');
+    });
+
+    it('should return null when no adjacent in that direction', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      // Looking vertically in a horizontal split should find nothing
+      expect(store.getAdjacentPane('ws-1', 't1', 'vertical', true)).toBeNull();
+    });
+
+    it('should navigate nested splits correctly', () => {
+      addTerminals(['t1', 't2', 't3']);
+      // Structure: t1 | (t2 / t3) — horizontal at root, vertical in second child
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      // From t1, go right → should reach t2 (first leaf of the right subtree)
+      expect(store.getAdjacentPane('ws-1', 't1', 'horizontal', true)).toBe('t2');
+      // From t2, go down → should reach t3
+      expect(store.getAdjacentPane('ws-1', 't2', 'vertical', true)).toBe('t3');
+      // From t3, go up → should reach t2
+      expect(store.getAdjacentPane('ws-1', 't3', 'vertical', false)).toBe('t2');
+      // From t2, go left → should reach t1
+      expect(store.getAdjacentPane('ws-1', 't2', 'horizontal', false)).toBe('t1');
+    });
+
+    it('should return null when no tree', () => {
+      addTerminals(['t1']);
+      expect(store.getAdjacentPane('ws-1', 't1', 'horizontal', true)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // updateTreeRatio
+  // -------------------------------------------------------------------------
+
+  describe('updateTreeRatio', () => {
+    it('should update root ratio', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.updateTreeRatio('ws-1', [], 0.3);
+
+      const tree = store.getLayoutTree('ws-1');
+      if (tree!.type === 'split') {
+        expect(tree!.ratio).toBe(0.3);
+      }
+    });
+
+    it('should clamp ratio to minimum 0.15', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.updateTreeRatio('ws-1', [], 0.05);
+
+      const tree = store.getLayoutTree('ws-1');
+      if (tree!.type === 'split') {
+        expect(tree!.ratio).toBe(0.15);
+      }
+    });
+
+    it('should clamp ratio to maximum 0.85', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.updateTreeRatio('ws-1', [], 0.95);
+
+      const tree = store.getLayoutTree('ws-1');
+      if (tree!.type === 'split') {
+        expect(tree!.ratio).toBe(0.85);
+      }
+    });
+
+    it('should update nested split ratio via path', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      // Path [1] → second child of root (the nested vertical split)
+      store.updateTreeRatio('ws-1', [1], 0.7);
+
+      const tree = store.getLayoutTree('ws-1');
+      if (tree!.type === 'split' && tree!.second.type === 'split') {
+        expect(tree!.second.ratio).toBe(0.7);
+        // Root ratio should be unchanged
+        expect(tree!.ratio).toBe(0.5);
+      }
+    });
+
+    it('should no-op for invalid path', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal', 0.5);
+
+      store.updateTreeRatio('ws-1', [0], 0.3); // path [0] points to a leaf
+
+      const tree = store.getLayoutTree('ws-1');
+      if (tree!.type === 'split') {
+        expect(tree!.ratio).toBe(0.5); // unchanged
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getFocusedPaneId
+  // -------------------------------------------------------------------------
+
+  describe('getFocusedPaneId', () => {
+    it('should return active terminal if in tree', () => {
+      addTerminals(['t1', 't2']);
+      store.setActiveWorkspace('ws-1');
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t1');
+
+      expect(store.getFocusedPaneId('ws-1')).toBe('t1');
+    });
+
+    it('should return null if active terminal not in tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.setActiveWorkspace('ws-1');
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      // setActiveTerminal('t3') will replace the active pane in the tree,
+      // so t3 will be in the tree after this call. Set it via setState instead.
+      store.setState({ activeTerminalId: 't3' });
+
+      expect(store.getFocusedPaneId('ws-1')).toBeNull();
+    });
+
+    it('should return null when no tree', () => {
+      addTerminals(['t1']);
+      store.setActiveWorkspace('ws-1');
+      store.setActiveTerminal('t1');
+
+      expect(store.getFocusedPaneId('ws-1')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // syncSessionPauseState with tree
+  // -------------------------------------------------------------------------
+
+  describe('syncSessionPauseState with layout tree', () => {
+    it('should resume all tree terminals and pause non-tree terminals', async () => {
+      const { invoke } = await import('@tauri-apps/api/core') as { invoke: ReturnType<typeof vi.fn> };
+
+      addTerminals(['t1', 't2', 't3', 't4']);
+      store.setActiveWorkspace('ws-1');
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+      store.setActiveTerminal('t1');
+
+      // After setup, clear mocks and trigger a fresh sync
+      invoke.mockClear();
+
+      // Force t4 into the resumed set by simulating it was previously resumed
+      // Then sync should pause it since it's not visible
+      invoke('resume_session', { sessionId: 't4' });
+      invoke.mockClear();
+
+      store.syncSessionPauseState();
+
+      // After sync: t1, t2, t3 are in tree so already resumed (no new calls).
+      // The important check: no resume call for t4 (it's not in tree or active)
+      const resumeCalls = invoke.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'resume_session'
+      );
+      const resumedIds = resumeCalls.map(
+        (c: unknown[]) => (c[1] as { sessionId: string }).sessionId
+      );
+      expect(resumedIds).not.toContain('t4');
+    });
+
+    it('should include all tree terminals as visible', () => {
+      addTerminals(['t1', 't2', 't3', 't4']);
+      store.setActiveWorkspace('ws-1');
+
+      // Create a 3-pane tree
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+      store.setActiveTerminal('t1');
+
+      // All tree terminals should be visible (in the layout tree)
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(terminalIds(tree!)).toEqual(['t1', 't2', 't3']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tab adjacency with layout tree
+  // -------------------------------------------------------------------------
+
+  describe('tab adjacency with layout tree', () => {
+    it('should order tabs to match depth-first tree traversal', () => {
+      addTerminals(['t1', 't2', 't3', 't4']);
+      store.setActiveWorkspace('ws-1');
+
+      // Create tree: t1 | (t3 / t2) — t3 and t2 are not adjacent initially
+      store.splitTerminalAt('ws-1', 't1', 't3', 'horizontal');
+      store.splitTerminalAt('ws-1', 't3', 't2', 'vertical');
+
+      const terminals = store.getWorkspaceTerminals('ws-1');
+      const ids = terminals.map(t => t.id);
+      const t1Idx = ids.indexOf('t1');
+      const t3Idx = ids.indexOf('t3');
+      const t2Idx = ids.indexOf('t2');
+
+      // DFS order: t1, t3, t2 — they should be adjacent
+      expect(t3Idx).toBe(t1Idx + 1);
+      expect(t2Idx).toBe(t3Idx + 1);
+    });
+
+    it('should reorder tabs when split is created with non-adjacent terminals', () => {
+      addTerminals(['t1', 't2', 't3', 't4']);
+      store.setActiveWorkspace('ws-1');
+
+      // Split t1 with t4 (non-adjacent in original order)
+      store.splitTerminalAt('ws-1', 't1', 't4', 'horizontal');
+
+      const terminals = store.getWorkspaceTerminals('ws-1');
+      const ids = terminals.map(t => t.id);
+      const t1Idx = ids.indexOf('t1');
+      const t4Idx = ids.indexOf('t4');
+
+      expect(Math.abs(t1Idx - t4Idx)).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Legacy getSplitView wrapper
+  // -------------------------------------------------------------------------
+
+  describe('legacy getSplitView wrapper', () => {
+    it('should return correct data for 2-pane trees', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal', 0.6);
+
+      const split = store.getSplitView('ws-1');
+      expect(split).not.toBeNull();
+      expect(split!.leftTerminalId).toBe('t1');
+      expect(split!.rightTerminalId).toBe('t2');
+      expect(split!.direction).toBe('horizontal');
+      expect(split!.ratio).toBe(0.6);
+    });
+
+    it('should return null for 3+ pane trees', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.splitTerminalAt('ws-1', 't2', 't3', 'vertical');
+
+      expect(store.getSplitView('ws-1')).toBeNull();
+    });
+
+    it('should return null when no tree exists', () => {
+      addTerminals(['t1']);
+      expect(store.getSplitView('ws-1')).toBeNull();
+    });
+
+    it('should work with setSplitView creating a tree', () => {
+      addTerminals(['t1', 't2']);
+      store.setSplitView('ws-1', 't1', 't2', 'vertical', 0.7);
+
+      // Both tree and legacy API should work
+      expect(store.getLayoutTree('ws-1')).not.toBeNull();
+      const split = store.getSplitView('ws-1');
+      expect(split).not.toBeNull();
+      expect(split!.direction).toBe('vertical');
+      expect(split!.ratio).toBe(0.7);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setActiveTerminal with tree
+  // -------------------------------------------------------------------------
+
+  describe('setActiveTerminal with layout tree', () => {
+    it('should not clear tree when clicking a terminal in the tree', () => {
+      addTerminals(['t1', 't2']);
+      store.setActiveWorkspace('ws-1');
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t1');
+
+      store.setActiveTerminal('t2');
+
+      expect(store.getLayoutTree('ws-1')).not.toBeNull();
+      expect(store.getState().activeTerminalId).toBe('t2');
+    });
+
+    it('should replace active pane when clicking a terminal outside the tree', () => {
+      addTerminals(['t1', 't2', 't3']);
+      store.setActiveWorkspace('ws-1');
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setActiveTerminal('t1');
+
+      // Click t3 (not in tree) — should replace t1 (active) in the tree
+      store.setActiveTerminal('t3');
+
+      const tree = store.getLayoutTree('ws-1');
+      expect(tree).not.toBeNull();
+      expect(terminalIds(tree!)).toContain('t3');
+      expect(terminalIds(tree!)).toContain('t2');
+      expect(terminalIds(tree!)).not.toContain('t1');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // clearLayoutTree
+  // -------------------------------------------------------------------------
+
+  describe('clearLayoutTree', () => {
+    it('should clear tree and splitViews', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.clearLayoutTree('ws-1');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+      expect(store.getSplitView('ws-1')).toBeNull();
+    });
+
+    it('should clear zoom when clearing tree', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setZoomedPane('ws-1', 't1');
+
+      store.clearLayoutTree('ws-1');
+
+      expect(store.getZoomedPane('ws-1')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setLayoutTree and getLayoutTree
+  // -------------------------------------------------------------------------
+
+  describe('setLayoutTree / getLayoutTree', () => {
+    it('should store and retrieve tree', () => {
+      addTerminals(['t1', 't2']);
+
+      const tree = {
+        type: 'split' as const,
+        direction: 'horizontal' as const,
+        ratio: 0.4,
+        first: { type: 'leaf' as const, terminal_id: 't1' },
+        second: { type: 'leaf' as const, terminal_id: 't2' },
+      };
+      store.setLayoutTree('ws-1', tree);
+
+      const retrieved = store.getLayoutTree('ws-1');
+      expect(retrieved).toEqual(tree);
+    });
+
+    it('should return null for workspace without tree', () => {
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reset clears all tree state
+  // -------------------------------------------------------------------------
+
+  describe('reset', () => {
+    it('should clear layoutTrees and zoomedPanes on reset', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setZoomedPane('ws-1', 't1');
+
+      store.reset();
+
+      expect(store.getState().layoutTrees).toEqual({});
+      expect(store.getState().zoomedPanes).toEqual({});
+      expect(store.getState().splitViews).toEqual({});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removeWorkspace clears tree state
+  // -------------------------------------------------------------------------
+
+  describe('removeWorkspace', () => {
+    it('should clean up tree state when removing workspace', () => {
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+      store.setZoomedPane('ws-1', 't1');
+
+      store.removeWorkspace('ws-1');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+      expect(store.getZoomedPane('ws-1')).toBeNull();
+      expect(store.getSplitView('ws-1')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // moveTerminalToWorkspace with tree
+  // -------------------------------------------------------------------------
+
+  describe('moveTerminalToWorkspace with tree', () => {
+    it('should clear tree when moving a terminal from a 2-pane split', () => {
+      store.addWorkspace({
+        id: 'ws-2', name: 'WS 2', folderPath: 'C:\\ws2', tabOrder: [],
+        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+      });
+      addTerminals(['t1', 't2']);
+      store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');
+
+      store.moveTerminalToWorkspace('t1', 'ws-2');
+
+      expect(store.getLayoutTree('ws-1')).toBeNull();
+    });
+  });
+});

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,16 @@
 import { invoke } from '@tauri-apps/api/core';
+import {
+  LayoutNode,
+  terminalIds,
+  replaceLeaf,
+  removeLeaf,
+  containsTerminal,
+  updateRatioAtPath,
+  swapTerminals,
+  findAdjacentTerminal,
+} from './split-types';
+
+export type { LayoutNode } from './split-types';
 
 export type PaneType = 'terminal' | 'figma';
 
@@ -33,6 +45,7 @@ export interface Workspace {
   claudeCodeMode: boolean;
 }
 
+/** Legacy flat split view — kept for backward compatibility. */
 export interface SplitView {
   leftTerminalId: string;   // or "top" in vertical
   rightTerminalId: string;  // or "bottom" in vertical
@@ -45,7 +58,12 @@ export interface AppState {
   terminals: Terminal[];
   activeWorkspaceId: string | null;
   activeTerminalId: string | null;
-  splitViews: Record<string, SplitView>;  // keyed by workspaceId
+  /** @deprecated Use layoutTrees instead — kept for backward compatibility. */
+  splitViews: Record<string, SplitView>;
+  /** Recursive layout trees, keyed by workspaceId. */
+  layoutTrees: Record<string, LayoutNode>;
+  /** Zoomed pane per workspace — when set, this pane fills the entire area. */
+  zoomedPanes: Record<string, string>;
 }
 
 type Listener = () => void;
@@ -58,6 +76,8 @@ class Store {
     activeWorkspaceId: null,
     activeTerminalId: null,
     splitViews: {},
+    layoutTrees: {},
+    zoomedPanes: {},
   };
 
   private listeners: Set<Listener> = new Set();
@@ -83,8 +103,11 @@ class Store {
       activeWorkspaceId: null,
       activeTerminalId: null,
       splitViews: {},
+      layoutTrees: {},
+      zoomedPanes: {},
     };
     this.lastActiveTerminalByWorkspace.clear();
+    this.resumedSessions.clear();
     this.notify();
   }
 
@@ -109,7 +132,10 @@ class Store {
     }
   }
 
+  // ---------------------------------------------------------------------------
   // Workspace operations
+  // ---------------------------------------------------------------------------
+
   addWorkspace(workspace: Workspace) {
     this.setState({
       workspaces: [...this.state.workspaces, workspace],
@@ -126,7 +152,9 @@ class Store {
 
   removeWorkspace(id: string) {
     this.lastActiveTerminalByWorkspace.delete(id);
-    const { [id]: _, ...remainingSplitViews } = this.state.splitViews;
+    const { [id]: _s, ...remainingSplitViews } = this.state.splitViews;
+    const { [id]: _t, ...remainingTrees } = this.state.layoutTrees;
+    const { [id]: _z, ...remainingZoomed } = this.state.zoomedPanes;
     this.setState({
       workspaces: this.state.workspaces.filter(w => w.id !== id),
       terminals: this.state.terminals.filter(t => t.workspaceId !== id),
@@ -134,6 +162,8 @@ class Store {
         ? (this.state.workspaces[0]?.id ?? null)
         : this.state.activeWorkspaceId,
       splitViews: remainingSplitViews,
+      layoutTrees: remainingTrees,
+      zoomedPanes: remainingZoomed,
     });
   }
 
@@ -157,7 +187,10 @@ class Store {
     this.syncSessionPauseState();
   }
 
+  // ---------------------------------------------------------------------------
   // Terminal operations
+  // ---------------------------------------------------------------------------
+
   addTerminal(terminal: Terminal, opts?: { background?: boolean }) {
     const workspaceTerminals = this.state.terminals.filter(
       t => t.workspaceId === terminal.workspaceId
@@ -207,28 +240,66 @@ class Store {
       newActiveId = sameWorkspace[0]?.id ?? null;
     }
 
-    // Clear split (active or suspended) if removed terminal was part of one
+    let layoutTrees = this.state.layoutTrees;
     let splitViews = this.state.splitViews;
+    let zoomedPanes = this.state.zoomedPanes;
+
     if (terminal) {
-      const split = splitViews[terminal.workspaceId];
-      if (split && (split.leftTerminalId === id || split.rightTerminalId === id)) {
-        const { [terminal.workspaceId]: _, ...rest } = splitViews;
-        splitViews = rest;
-        // Set remaining split terminal as active
-        const remainingId = split.leftTerminalId === id
-          ? split.rightTerminalId
-          : split.leftTerminalId;
-        if (remainingTerminals.some(t => t.id === remainingId)) {
-          newActiveId = remainingId;
+      const wsId = terminal.workspaceId;
+      const tree = layoutTrees[wsId];
+
+      if (tree && containsTerminal(tree, id)) {
+        // Clear zoom if the zoomed pane is being removed
+        if (zoomedPanes[wsId] === id) {
+          const { [wsId]: _, ...rest } = zoomedPanes;
+          zoomedPanes = rest;
+        }
+
+        const { result } = removeLeaf(tree, id);
+        if (!result || result.type === 'leaf') {
+          // Tree collapsed to a single leaf or empty — clear layout tree
+          const { [wsId]: _t, ...restTrees } = layoutTrees;
+          const { [wsId]: _s, ...restSplits } = splitViews;
+          layoutTrees = restTrees;
+          splitViews = restSplits;
+          // Set the remaining terminal as active
+          if (result && result.type === 'leaf') {
+            if (remainingTerminals.some(t => t.id === result.terminal_id)) {
+              newActiveId = result.terminal_id;
+            }
+          }
+        } else {
+          // Tree still has multiple panes — update it
+          layoutTrees = { ...layoutTrees, [wsId]: result };
+          splitViews = { ...splitViews, ...this.treeToSplitViews(wsId, result) };
+          // Pick a remaining terminal from the tree as active
+          const remaining = terminalIds(result);
+          if (remaining.length > 0 && (newActiveId === id || !remaining.includes(newActiveId ?? ''))) {
+            newActiveId = remaining[0];
+          }
+        }
+      } else {
+        // Not in tree — check legacy splitViews directly (defensive)
+        const split = splitViews[wsId];
+        if (split && (split.leftTerminalId === id || split.rightTerminalId === id)) {
+          const { [wsId]: _, ...rest } = splitViews;
+          splitViews = rest;
+          const remainingId = split.leftTerminalId === id
+            ? split.rightTerminalId
+            : split.leftTerminalId;
+          if (remainingTerminals.some(t => t.id === remainingId)) {
+            newActiveId = remainingId;
+          }
         }
       }
-
     }
 
     this.setState({
       terminals: remainingTerminals,
       activeTerminalId: newActiveId,
       splitViews,
+      layoutTrees,
+      zoomedPanes,
     });
     this.resumedSessions.delete(id);
     this.syncSessionPauseState();
@@ -238,9 +309,72 @@ class Store {
     if (id && this.state.activeWorkspaceId) {
       this.lastActiveTerminalByWorkspace.set(this.state.activeWorkspaceId, id);
       const wsId = this.state.activeWorkspaceId;
+      const tree = this.state.layoutTrees[wsId];
 
-      // If navigating to a terminal outside the current split → update the split
-      // by replacing the currently-active pane with the new terminal
+      if (tree) {
+        // Check if terminal is in the layout tree
+        if (containsTerminal(tree, id)) {
+          // Terminal is IN the tree — just update focus, don't clear anything
+          // Clear zoom if we're focusing a different pane than the zoomed one
+          let zoomedPanes = this.state.zoomedPanes;
+          if (zoomedPanes[wsId] && zoomedPanes[wsId] !== id) {
+            const { [wsId]: _, ...rest } = zoomedPanes;
+            zoomedPanes = rest;
+          }
+          this.setState({ activeTerminalId: id, zoomedPanes });
+          invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+          this.syncSessionPauseState();
+          return;
+        }
+
+        // Terminal is NOT in the tree — replace the active pane in the tree
+        const activeId = this.state.activeTerminalId;
+        if (activeId && containsTerminal(tree, activeId)) {
+          const newTree = replaceLeaf(tree, activeId, { type: 'leaf', terminal_id: id });
+          if (newTree) {
+            const zoomedPanes = { ...this.state.zoomedPanes };
+            if (zoomedPanes[wsId]) {
+              delete zoomedPanes[wsId];
+            }
+            this.setState({
+              activeTerminalId: id,
+              layoutTrees: { ...this.state.layoutTrees, [wsId]: newTree },
+              splitViews: { ...this.state.splitViews, ...this.treeToSplitViews(wsId, newTree) },
+              zoomedPanes,
+            });
+            invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+            this.enforceSplitAdjacency(wsId);
+            this.syncSessionPauseState();
+            return;
+          }
+        }
+
+        // Active terminal isn't in the tree either — replace second child's first leaf
+        const ids = terminalIds(tree);
+        if (ids.length > 0) {
+          // Replace the last leaf (rightmost/bottommost)
+          const lastId = ids[ids.length - 1];
+          const newTree = replaceLeaf(tree, lastId, { type: 'leaf', terminal_id: id });
+          if (newTree) {
+            const zoomedPanes = { ...this.state.zoomedPanes };
+            if (zoomedPanes[wsId]) {
+              delete zoomedPanes[wsId];
+            }
+            this.setState({
+              activeTerminalId: id,
+              layoutTrees: { ...this.state.layoutTrees, [wsId]: newTree },
+              splitViews: { ...this.state.splitViews, ...this.treeToSplitViews(wsId, newTree) },
+              zoomedPanes,
+            });
+            invoke('sync_active_terminal', { terminalId: id }).catch(() => {});
+            this.enforceSplitAdjacency(wsId);
+            this.syncSessionPauseState();
+            return;
+          }
+        }
+      }
+
+      // Legacy: handle splitViews without a layout tree (shouldn't happen normally)
       const split = this.state.splitViews[wsId];
       if (split && id !== split.leftTerminalId && id !== split.rightTerminalId) {
         const activeId = this.state.activeTerminalId;
@@ -252,7 +386,6 @@ class Store {
         } else if (activeId === split.rightTerminalId) {
           newRight = id;
         } else {
-          // Active terminal isn't in the split — replace the right pane
           newRight = id;
         }
 
@@ -282,13 +415,37 @@ class Store {
   moveTerminalToWorkspace(terminalId: string, workspaceId: string) {
     const terminal = this.state.terminals.find(t => t.id === terminalId);
     let splitViews = this.state.splitViews;
+    let layoutTrees = this.state.layoutTrees;
+    let zoomedPanes = this.state.zoomedPanes;
 
-    // Clear split (active or suspended) on source workspace if moved terminal was in it
     if (terminal) {
-      const split = splitViews[terminal.workspaceId];
-      if (split && (split.leftTerminalId === terminalId || split.rightTerminalId === terminalId)) {
-        const { [terminal.workspaceId]: _, ...rest } = splitViews;
-        splitViews = rest;
+      const srcWs = terminal.workspaceId;
+      const tree = layoutTrees[srcWs];
+
+      if (tree && containsTerminal(tree, terminalId)) {
+        // Remove from tree
+        if (zoomedPanes[srcWs] === terminalId) {
+          const { [srcWs]: _, ...rest } = zoomedPanes;
+          zoomedPanes = rest;
+        }
+
+        const { result } = removeLeaf(tree, terminalId);
+        if (!result || result.type === 'leaf') {
+          const { [srcWs]: _t, ...restTrees } = layoutTrees;
+          const { [srcWs]: _s, ...restSplits } = splitViews;
+          layoutTrees = restTrees;
+          splitViews = restSplits;
+        } else {
+          layoutTrees = { ...layoutTrees, [srcWs]: result };
+          splitViews = { ...splitViews, ...this.treeToSplitViews(srcWs, result) };
+        }
+      } else {
+        // Legacy fallback
+        const split = splitViews[srcWs];
+        if (split && (split.leftTerminalId === terminalId || split.rightTerminalId === terminalId)) {
+          const { [srcWs]: _, ...rest } = splitViews;
+          splitViews = rest;
+        }
       }
     }
 
@@ -297,6 +454,8 @@ class Store {
         t.id === terminalId ? { ...t, workspaceId } : t
       ),
       splitViews,
+      layoutTrees,
+      zoomedPanes,
     });
   }
 
@@ -319,7 +478,196 @@ class Store {
     this.enforceSplitAdjacency(workspaceId);
   }
 
-  // Split view operations
+  // ---------------------------------------------------------------------------
+  // Layout tree operations
+  // ---------------------------------------------------------------------------
+
+  /** Get the layout tree for a workspace. */
+  getLayoutTree(workspaceId: string): LayoutNode | null {
+    return this.state.layoutTrees[workspaceId] ?? null;
+  }
+
+  /** Set the layout tree for a workspace. Also syncs the legacy splitViews. */
+  setLayoutTree(workspaceId: string, tree: LayoutNode): void {
+    this.setState({
+      layoutTrees: { ...this.state.layoutTrees, [workspaceId]: tree },
+      splitViews: { ...this.state.splitViews, ...this.treeToSplitViews(workspaceId, tree) },
+    });
+    this.enforceSplitAdjacency(workspaceId);
+  }
+
+  /** Clear the layout tree for a workspace. */
+  clearLayoutTree(workspaceId: string): void {
+    const { [workspaceId]: _t, ...restTrees } = this.state.layoutTrees;
+    const { [workspaceId]: _s, ...restSplits } = this.state.splitViews;
+    const { [workspaceId]: _z, ...restZoomed } = this.state.zoomedPanes;
+    this.setState({
+      layoutTrees: restTrees,
+      splitViews: restSplits,
+      zoomedPanes: restZoomed,
+    });
+  }
+
+  /**
+   * Split a terminal at a target leaf, creating a new pane.
+   * If no tree exists, creates one with the target as the first leaf.
+   */
+  splitTerminalAt(
+    workspaceId: string,
+    targetTerminalId: string,
+    newTerminalId: string,
+    direction: 'horizontal' | 'vertical',
+    ratio = 0.5,
+  ): void {
+    const tree = this.state.layoutTrees[workspaceId];
+    const newSplit: LayoutNode = {
+      type: 'split',
+      direction,
+      ratio,
+      first: { type: 'leaf', terminal_id: targetTerminalId },
+      second: { type: 'leaf', terminal_id: newTerminalId },
+    };
+
+    if (!tree) {
+      // No tree yet — create one
+      this.setLayoutTree(workspaceId, newSplit);
+    } else {
+      // Replace the target leaf with a split node
+      const newTree = replaceLeaf(tree, targetTerminalId, newSplit);
+      if (newTree) {
+        this.setLayoutTree(workspaceId, newTree);
+      }
+    }
+  }
+
+  /**
+   * Remove a terminal from the layout tree, collapsing the split.
+   * If the tree collapses to a single leaf, clears the tree entirely.
+   */
+  unsplitTerminal(workspaceId: string, terminalId: string): void {
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree) return;
+
+    if (!containsTerminal(tree, terminalId)) return;
+
+    // Clear zoom if needed
+    let zoomedPanes = this.state.zoomedPanes;
+    if (zoomedPanes[workspaceId]) {
+      const { [workspaceId]: _, ...rest } = zoomedPanes;
+      zoomedPanes = rest;
+    }
+
+    const { result } = removeLeaf(tree, terminalId);
+    if (!result || result.type === 'leaf') {
+      // Collapsed to single leaf or empty — clear tree
+      this.clearLayoutTree(workspaceId);
+      this.setState({ zoomedPanes });
+    } else {
+      this.setState({
+        layoutTrees: { ...this.state.layoutTrees, [workspaceId]: result },
+        splitViews: { ...this.state.splitViews, ...this.treeToSplitViews(workspaceId, result) },
+        zoomedPanes,
+      });
+      this.enforceSplitAdjacency(workspaceId);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  /** Return the currently active terminal if it's in the layout tree. */
+  getFocusedPaneId(workspaceId: string): string | null {
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree) return null;
+    const activeId = this.state.activeTerminalId;
+    if (activeId && containsTerminal(tree, activeId)) return activeId;
+    return null;
+  }
+
+  /** Walk the tree to find the nearest terminal in the given direction. */
+  getAdjacentPane(
+    workspaceId: string,
+    terminalId: string,
+    direction: 'horizontal' | 'vertical',
+    goSecond: boolean,
+  ): string | null {
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree) return null;
+    return findAdjacentTerminal(tree, terminalId, direction, goSecond);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resize
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Update the ratio of a split node identified by path.
+   * Path is an array of indices: 0 = first child, 1 = second child.
+   * Ratio is clamped to [0.15, 0.85].
+   */
+  updateTreeRatio(workspaceId: string, path: number[], ratio: number): void {
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree) return;
+
+    const clamped = Math.max(0.15, Math.min(0.85, ratio));
+    const updated = updateRatioAtPath(tree, path, clamped);
+    if (updated) {
+      this.setState({
+        layoutTrees: { ...this.state.layoutTrees, [workspaceId]: updated },
+        splitViews: { ...this.state.splitViews, ...this.treeToSplitViews(workspaceId, updated) },
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Zoom
+  // ---------------------------------------------------------------------------
+
+  /** Zoom a pane to fill the entire area. Pass null to unzoom. */
+  setZoomedPane(workspaceId: string, terminalId: string | null): void {
+    if (terminalId === null) {
+      const { [workspaceId]: _, ...rest } = this.state.zoomedPanes;
+      this.setState({ zoomedPanes: rest });
+    } else {
+      this.setState({
+        zoomedPanes: { ...this.state.zoomedPanes, [workspaceId]: terminalId },
+      });
+    }
+  }
+
+  /** Get the currently zoomed pane for a workspace, or null. */
+  getZoomedPane(workspaceId: string): string | null {
+    return this.state.zoomedPanes[workspaceId] ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Swap
+  // ---------------------------------------------------------------------------
+
+  /** Swap two terminal panes in the layout tree. */
+  swapPanes(workspaceId: string, idA: string, idB: string): void {
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree) return;
+
+    const swapped = swapTerminals(tree, idA, idB);
+    if (swapped) {
+      this.setState({
+        layoutTrees: { ...this.state.layoutTrees, [workspaceId]: swapped },
+        splitViews: { ...this.state.splitViews, ...this.treeToSplitViews(workspaceId, swapped) },
+      });
+      this.enforceSplitAdjacency(workspaceId);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy split view operations (backward compatibility wrappers)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a split view. Internally creates a 2-leaf layout tree.
+   * @deprecated Use setLayoutTree or splitTerminalAt instead.
+   */
   setSplitView(
     workspaceId: string,
     leftTerminalId: string,
@@ -327,57 +675,108 @@ class Store {
     direction: 'horizontal' | 'vertical',
     ratio = 0.5,
   ) {
-    this.setState({
-      splitViews: {
-        ...this.state.splitViews,
-        [workspaceId]: { leftTerminalId, rightTerminalId, direction, ratio },
-      },
-    });
-    this.enforceSplitAdjacency(workspaceId);
+    const tree: LayoutNode = {
+      type: 'split',
+      direction,
+      ratio,
+      first: { type: 'leaf', terminal_id: leftTerminalId },
+      second: { type: 'leaf', terminal_id: rightTerminalId },
+    };
+    this.setLayoutTree(workspaceId, tree);
   }
 
+  /**
+   * Clear a split view.
+   * @deprecated Use clearLayoutTree instead.
+   */
   clearSplitView(workspaceId: string) {
-    const { [workspaceId]: _, ...rest } = this.state.splitViews;
-    this.setState({ splitViews: rest });
+    this.clearLayoutTree(workspaceId);
   }
 
+  /**
+   * Get the legacy split view for a workspace.
+   * Only returns data for simple 2-pane splits. Returns null for 3+ pane trees.
+   * @deprecated Use getLayoutTree instead.
+   */
   getSplitView(workspaceId: string): SplitView | null {
-    return this.state.splitViews[workspaceId] ?? null;
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree || tree.type !== 'split') return null;
+    if (tree.first.type !== 'leaf' || tree.second.type !== 'leaf') return null;
+    return {
+      leftTerminalId: tree.first.terminal_id,
+      rightTerminalId: tree.second.terminal_id,
+      direction: tree.direction,
+      ratio: tree.ratio,
+    };
   }
 
+  /**
+   * Update split ratio.
+   * @deprecated Use updateTreeRatio instead.
+   */
   updateSplitRatio(workspaceId: string, ratio: number) {
-    const split = this.state.splitViews[workspaceId];
-    if (!split) return;
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree || tree.type !== 'split') return;
     this.setState({
+      layoutTrees: {
+        ...this.state.layoutTrees,
+        [workspaceId]: { ...tree, ratio },
+      },
       splitViews: {
         ...this.state.splitViews,
-        [workspaceId]: { ...split, ratio },
+        [workspaceId]: { ...this.state.splitViews[workspaceId], ratio },
       },
     });
   }
 
-  /** Ensure split-paired terminals are adjacent in the tab order. */
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ensure tree-leaf terminals are adjacent in tab order.
+   * Orders tabs to match depth-first traversal of tree leaves.
+   */
   private enforceSplitAdjacency(workspaceId: string) {
-    const split = this.state.splitViews[workspaceId];
-    if (!split) return;
+    const tree = this.state.layoutTrees[workspaceId];
+    if (!tree) {
+      // Legacy fallback (shouldn't happen, but defensive)
+      return;
+    }
+
+    const treeIds = terminalIds(tree);
+    if (treeIds.length < 2) return;
 
     const wsTerminals = this.getWorkspaceTerminals(workspaceId);
-    const leftIdx = wsTerminals.findIndex(t => t.id === split.leftTerminalId);
-    const rightIdx = wsTerminals.findIndex(t => t.id === split.rightTerminalId);
-
-    if (leftIdx === -1 || rightIdx === -1) return;
-    if (Math.abs(leftIdx - rightIdx) === 1) return; // already adjacent
-
-    // Move the right terminal to be immediately after the left terminal
     const ids = wsTerminals.map(t => t.id);
-    ids.splice(rightIdx, 1);
-    const newLeftIdx = ids.indexOf(split.leftTerminalId);
-    ids.splice(newLeftIdx + 1, 0, split.rightTerminalId);
+
+    // Check if the tree IDs already appear in order and adjacent
+    const positions = treeIds.map(tid => ids.indexOf(tid)).filter(i => i !== -1);
+    if (positions.length < 2) return;
+
+    // Check if already adjacent and in DFS order
+    let alreadyCorrect = true;
+    for (let i = 1; i < positions.length; i++) {
+      if (positions[i] !== positions[i - 1] + 1) {
+        alreadyCorrect = false;
+        break;
+      }
+    }
+    if (alreadyCorrect) return;
+
+    // Build new order: place tree IDs adjacent starting at the earliest position
+    const nonTreeIds = ids.filter(i => !treeIds.includes(i));
+    const insertPos = Math.min(...positions);
+    const newOrder = [
+      ...nonTreeIds.slice(0, insertPos),
+      ...treeIds,
+      ...nonTreeIds.slice(insertPos),
+    ];
 
     this.setState({
       terminals: this.state.terminals.map(t => {
         if (t.workspaceId !== workspaceId) return t;
-        const order = ids.indexOf(t.id);
+        const order = newOrder.indexOf(t.id);
         return { ...t, order: order >= 0 ? order : t.order };
       }),
     });
@@ -389,19 +788,20 @@ class Store {
    * This reduces daemon output overhead for background sessions.
    */
   syncSessionPauseState() {
-    const { activeTerminalId, activeWorkspaceId, splitViews } = this.state;
+    const { activeTerminalId, activeWorkspaceId, layoutTrees } = this.state;
     const visibleIds = new Set<string>();
 
     if (activeTerminalId) {
       visibleIds.add(activeTerminalId);
     }
 
-    // Also include split view terminals
+    // Include all terminals from the layout tree
     if (activeWorkspaceId) {
-      const split = splitViews[activeWorkspaceId];
-      if (split) {
-        visibleIds.add(split.leftTerminalId);
-        visibleIds.add(split.rightTerminalId);
+      const tree = layoutTrees[activeWorkspaceId];
+      if (tree) {
+        for (const id of terminalIds(tree)) {
+          visibleIds.add(id);
+        }
       }
     }
 
@@ -419,6 +819,27 @@ class Store {
         }
       }
     }
+  }
+
+  /**
+   * Convert a layout tree to a legacy SplitView record (for backward compat).
+   * Only produces a SplitView if the tree is a simple 2-leaf split.
+   * For nested trees (3+ panes), removes the workspace from splitViews.
+   */
+  private treeToSplitViews(workspaceId: string, tree: LayoutNode): Record<string, SplitView> | null {
+    if (tree.type !== 'split') return null;
+    if (tree.first.type === 'leaf' && tree.second.type === 'leaf') {
+      return {
+        [workspaceId]: {
+          leftTerminalId: tree.first.terminal_id,
+          rightTerminalId: tree.second.terminal_id,
+          direction: tree.direction,
+          ratio: tree.ratio,
+        },
+      };
+    }
+    // Nested trees can't be represented as a flat SplitView
+    return null;
   }
 
   getWorkspaceTerminals(workspaceId: string): Terminal[] {


### PR DESCRIPTION
## Summary

- Replace flat `splitViews: Record<string, SplitView>` with recursive `layoutTrees: Record<string, LayoutNode>` in the store, enabling arbitrary nesting of horizontal and vertical splits
- Add tree operations: `splitTerminalAt`, `unsplitTerminal`, `getAdjacentPane`, `updateTreeRatio`, `setZoomedPane`/`getZoomedPane`, `swapPanes`
- Maintain full backward compatibility — legacy `setSplitView`/`getSplitView`/`clearSplitView`/`updateSplitRatio` are preserved as wrappers

refs #379

## Changes

### New files
- `src/state/split-types.ts` — `LayoutNode` types and tree utility functions (`terminalIds`, `replaceLeaf`, `removeLeaf`, `containsTerminal`, `findAdjacentTerminal`, `swapTerminals`, `updateRatioAtPath`)
- `src/state/split-types.test.ts` — 29 unit tests for tree utilities
- `src/state/store.layout-tree.test.ts` — 51 integration tests for store layout tree operations

### Modified files
- `src/state/store.ts` — Updated `AppState` with `layoutTrees` and `zoomedPanes`, added new methods, updated `removeTerminal`, `setActiveTerminal`, `syncSessionPauseState`, `enforceSplitAdjacency`, `moveTerminalToWorkspace` to use tree model

## Test plan
- [x] All 901 frontend tests pass (`npm test`)
- [x] TypeScript strict mode passes (`npx tsc --noEmit`)
- [x] All 63 existing split/store tests pass unchanged (backward compatibility verified)
- [x] 29 new `split-types.test.ts` tests cover tree utilities
- [x] 51 new `store.layout-tree.test.ts` tests cover: tree creation, nested splitting, terminal removal with tree collapse, zoom toggle, pane swap, adjacent pane navigation, tree ratio updates, session pause/resume with tree, tab adjacency ordering, legacy wrapper behavior