### PR TITLE
feat: add MCP layout tree tools for recursive split panes

### DIFF
--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -605,12 +605,13 @@ impl Backend for DaemonDirectBackend {
             McpRequest::CreateSplit { .. } => Ok(Self::app_only_error("create_split")),
             McpRequest::ClearSplit { .. } => Ok(Self::app_only_error("clear_split")),
             McpRequest::GetSplitState { .. } => Ok(Self::app_only_error("get_split_state")),
-            McpRequest::ExecuteJs { .. } => Ok(Self::app_only_error("execute_js")),
-            McpRequest::CaptureScreenshot { .. } => Ok(Self::app_only_error("capture_screenshot")),
             McpRequest::SplitTerminal { .. } => Ok(Self::app_only_error("split_terminal")),
             McpRequest::UnsplitTerminal { .. } => Ok(Self::app_only_error("unsplit_terminal")),
             McpRequest::GetLayoutTree { .. } => Ok(Self::app_only_error("get_layout_tree")),
             McpRequest::SwapPanes { .. } => Ok(Self::app_only_error("swap_panes")),
+            McpRequest::ZoomPane { .. } => Ok(Self::app_only_error("zoom_pane")),
+            McpRequest::ExecuteJs { .. } => Ok(Self::app_only_error("execute_js")),
+            McpRequest::CaptureScreenshot { .. } => Ok(Self::app_only_error("capture_screenshot")),
         }
     }
 

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -15,7 +15,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 17;
+const BUILD: u32 = 18;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -553,6 +553,111 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "split_terminal",
+                "description": "Split an existing terminal pane to add another terminal next to it. Supports nested splits — you can split a pane that is already part of a split layout. Creates a binary tree of panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace"
+                        },
+                        "target_terminal_id": {
+                            "type": "string",
+                            "description": "ID of the existing terminal pane to split"
+                        },
+                        "new_terminal_id": {
+                            "type": "string",
+                            "description": "ID of the new terminal to add next to the target"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": ["horizontal", "vertical"],
+                            "default": "horizontal",
+                            "description": "Split direction: 'horizontal' for left/right, 'vertical' for top/bottom"
+                        },
+                        "ratio": {
+                            "type": "number",
+                            "default": 0.5,
+                            "description": "Split ratio (0.15–0.85). Default: 0.5 (equal split)"
+                        }
+                    },
+                    "required": ["workspace_id", "target_terminal_id", "new_terminal_id"]
+                }
+            },
+            {
+                "name": "unsplit_terminal",
+                "description": "Remove a terminal pane from the split layout. The sibling pane expands to fill the space. If only one pane remains, the layout returns to single-pane mode.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace"
+                        },
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to remove from the layout"
+                        }
+                    },
+                    "required": ["workspace_id", "terminal_id"]
+                }
+            },
+            {
+                "name": "get_layout_tree",
+                "description": "Get the full split layout tree for a workspace. Returns a recursive tree structure where each node is either a Leaf (containing a terminal_id) or a Split (containing direction, ratio, and two children). Returns null if the workspace has no split layout.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace to query"
+                        }
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "swap_panes",
+                "description": "Swap the positions of two terminal panes in the split layout.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace"
+                        },
+                        "terminal_id_a": {
+                            "type": "string",
+                            "description": "ID of the first terminal to swap"
+                        },
+                        "terminal_id_b": {
+                            "type": "string",
+                            "description": "ID of the second terminal to swap"
+                        }
+                    },
+                    "required": ["workspace_id", "terminal_id_a", "terminal_id_b"]
+                }
+            },
+            {
+                "name": "zoom_pane",
+                "description": "Zoom (maximize) a terminal pane to fill the workspace, or unzoom by passing null. The layout tree is preserved and restored when unzooming.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace"
+                        },
+                        "terminal_id": {
+                            "type": ["string", "null"],
+                            "description": "ID of the terminal to zoom, or null to unzoom"
+                        }
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
                 "name": "execute_js",
                 "description": "Execute JavaScript in the Godly Terminal webview and return the result. The script runs in the main webview context with access to the DOM, store, and all frontend APIs. The return value is JSON-stringified. Use for DOM inspection, state queries, and UI manipulation.\n\nExamples:\n- Query store state: `return window.__STORE__.getState().splitViews`\n- Get element rect: `return document.querySelector('.split-divider')?.getBoundingClientRect()`\n- Check CSS classes: `return document.querySelector('.terminal-pane')?.className`",
                 "inputSchema": {
@@ -987,7 +1092,94 @@ pub fn call_tool(
 
         "get_split_state" => {
             let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
-            McpRequest::GetSplitState { workspace_id }
+
+            // Send both legacy split state and layout tree requests, merge results
+            let split_req = McpRequest::GetSplitState { workspace_id: workspace_id.clone() };
+            let tree_req = McpRequest::GetLayoutTree { workspace_id };
+
+            let split_resp = client.send_request(&split_req)?;
+            let tree_resp = client.send_request(&tree_req)?;
+
+            let split_json = match split_resp {
+                McpResponse::SplitState {
+                    workspace_id: _,
+                    left_terminal_id,
+                    right_terminal_id,
+                    direction,
+                    ratio,
+                } => json!({
+                    "left_terminal_id": left_terminal_id,
+                    "right_terminal_id": right_terminal_id,
+                    "direction": direction,
+                    "ratio": ratio,
+                }),
+                McpResponse::NoSplit => serde_json::Value::Null,
+                McpResponse::Error { message } => return Err(message),
+                _ => serde_json::Value::Null,
+            };
+
+            let tree_json = match tree_resp {
+                McpResponse::LayoutTree(tree) => tree
+                    .map(|t| serde_json::to_value(t).unwrap_or(serde_json::Value::Null))
+                    .unwrap_or(serde_json::Value::Null),
+                _ => serde_json::Value::Null,
+            };
+
+            return Ok(json!({
+                "split": split_json,
+                "layout_tree": tree_json,
+            }));
+        }
+
+        "split_terminal" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            let target_terminal_id = args.get("target_terminal_id").and_then(|v| v.as_str()).ok_or("Missing target_terminal_id")?.to_string();
+            let new_terminal_id = args.get("new_terminal_id").and_then(|v| v.as_str()).ok_or("Missing new_terminal_id")?.to_string();
+            let direction = args.get("direction").and_then(|v| v.as_str()).unwrap_or("horizontal").to_string();
+            let ratio = args.get("ratio").and_then(|v| v.as_f64()).unwrap_or(0.5);
+            McpRequest::SplitTerminal {
+                workspace_id,
+                target_terminal_id,
+                new_terminal_id,
+                direction,
+                ratio,
+            }
+        }
+
+        "unsplit_terminal" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).ok_or("Missing terminal_id")?.to_string();
+            McpRequest::UnsplitTerminal {
+                workspace_id,
+                terminal_id,
+            }
+        }
+
+        "get_layout_tree" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            McpRequest::GetLayoutTree { workspace_id }
+        }
+
+        "swap_panes" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            let terminal_id_a = args.get("terminal_id_a").and_then(|v| v.as_str()).ok_or("Missing terminal_id_a")?.to_string();
+            let terminal_id_b = args.get("terminal_id_b").and_then(|v| v.as_str()).ok_or("Missing terminal_id_b")?.to_string();
+            McpRequest::SwapPanes {
+                workspace_id,
+                terminal_id_a,
+                terminal_id_b,
+            }
+        }
+
+        "zoom_pane" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            let terminal_id = args.get("terminal_id").and_then(|v| {
+                if v.is_null() { None } else { v.as_str().map(String::from) }
+            });
+            McpRequest::ZoomPane {
+                workspace_id,
+                terminal_id,
+            }
         }
 
         "execute_js" => {
@@ -1129,6 +1321,7 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
             "ratio": ratio,
         })),
         McpResponse::NoSplit => Ok(json!({ "split": null })),
+        McpResponse::LayoutTree(tree) => Ok(json!({ "layout_tree": tree })),
         McpResponse::JsResult { result, error } => {
             if let Some(err) = error {
                 Err(err)
@@ -1140,9 +1333,6 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         }
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
-        })),
-        McpResponse::LayoutTree(tree) => Ok(json!({
-            "layout_tree": tree,
         })),
     }
 }

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::layout_tree::{LayoutNode, SplitDirection};
 use crate::types::ShellType;
 
 fn default_erase_count() -> usize {
@@ -150,7 +149,8 @@ pub enum McpRequest {
         workspace_id: String,
         target_terminal_id: String,
         new_terminal_id: String,
-        direction: SplitDirection,
+        #[serde(default = "default_split_direction")]
+        direction: String,
         #[serde(default = "default_split_ratio")]
         ratio: f64,
     },
@@ -165,6 +165,10 @@ pub enum McpRequest {
         workspace_id: String,
         terminal_id_a: String,
         terminal_id_b: String,
+    },
+    ZoomPane {
+        workspace_id: String,
+        terminal_id: Option<String>,
     },
 
     // JS bridge (execute JavaScript in WebView, return result)
@@ -267,7 +271,7 @@ pub enum McpResponse {
         ratio: f64,
     },
     NoSplit,
-    LayoutTree(Option<LayoutNode>),
+    LayoutTree(Option<crate::layout_tree::LayoutNode>),
     JsResult {
         result: Option<String>,
         error: Option<String>,

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1302,6 +1302,7 @@ pub fn handle_mcp_request(
             // Clamp ratio
             let ratio = ratio.clamp(0.15, 0.85);
 
+            // Legacy split view
             app_state.set_split_view(
                 workspace_id,
                 crate::state::SplitView {
@@ -1311,6 +1312,27 @@ pub fn handle_mcp_request(
                     ratio,
                 },
             );
+
+            // Also create a layout tree for backward compat
+            let dir = if direction == "vertical" {
+                godly_protocol::SplitDirection::Vertical
+            } else {
+                godly_protocol::SplitDirection::Horizontal
+            };
+            app_state.set_layout_tree(
+                workspace_id,
+                godly_protocol::LayoutNode::Split {
+                    direction: dir,
+                    ratio,
+                    first: Box::new(godly_protocol::LayoutNode::Leaf {
+                        terminal_id: left_terminal_id.clone(),
+                    }),
+                    second: Box::new(godly_protocol::LayoutNode::Leaf {
+                        terminal_id: right_terminal_id.clone(),
+                    }),
+                },
+            );
+
             auto_save.mark_dirty();
 
             #[derive(serde::Serialize, Clone)]
@@ -1337,6 +1359,8 @@ pub fn handle_mcp_request(
 
         McpRequest::ClearSplit { workspace_id } => {
             app_state.clear_split_view(workspace_id);
+            app_state.clear_layout_tree(workspace_id);
+            app_state.set_zoomed_pane(workspace_id, None);
             auto_save.mark_dirty();
             let _ = app_handle.emit("mcp-clear-split-view", workspace_id);
             McpResponse::Ok
@@ -1365,20 +1389,72 @@ pub fn handle_mcp_request(
             direction,
             ratio,
         } => {
-            let ratio = ratio.clamp(0.15, 0.85);
-            let mut trees = app_state.layout_trees.write();
-            let tree = trees.entry(workspace_id.clone()).or_insert_with(|| {
-                godly_protocol::LayoutNode::Leaf {
-                    terminal_id: target_terminal_id.clone(),
-                }
-            });
-            if !tree.split_at(target_terminal_id, new_terminal_id, *direction, ratio) {
+            // Validate workspace exists
+            if !app_state.workspaces.read().contains_key(workspace_id) {
                 return McpResponse::Error {
-                    message: format!("Terminal {} not found in layout tree", target_terminal_id),
+                    message: format!("Workspace {} not found", workspace_id),
                 };
             }
-            drop(trees);
+
+            // Validate both terminals exist
+            {
+                let terminals = app_state.terminals.read();
+                if !terminals.contains_key(target_terminal_id) {
+                    return McpResponse::Error {
+                        message: format!("Terminal {} not found", target_terminal_id),
+                    };
+                }
+                if !terminals.contains_key(new_terminal_id) {
+                    return McpResponse::Error {
+                        message: format!("Terminal {} not found", new_terminal_id),
+                    };
+                }
+            }
+
+            // Validate direction
+            if direction != "horizontal" && direction != "vertical" {
+                return McpResponse::Error {
+                    message: format!("Invalid direction '{}', must be 'horizontal' or 'vertical'", direction),
+                };
+            }
+
+            let dir = if direction == "vertical" {
+                godly_protocol::SplitDirection::Vertical
+            } else {
+                godly_protocol::SplitDirection::Horizontal
+            };
+
+            if let Err(msg) = app_state.split_terminal_in_tree(
+                workspace_id,
+                target_terminal_id,
+                new_terminal_id,
+                dir,
+                *ratio,
+            ) {
+                return McpResponse::Error { message: msg };
+            }
+
             auto_save.mark_dirty();
+
+            #[derive(serde::Serialize, Clone)]
+            struct SplitTerminalPayload {
+                workspace_id: String,
+                target_terminal_id: String,
+                new_terminal_id: String,
+                direction: String,
+                ratio: f64,
+            }
+            let _ = app_handle.emit(
+                "mcp-split-terminal",
+                SplitTerminalPayload {
+                    workspace_id: workspace_id.clone(),
+                    target_terminal_id: target_terminal_id.clone(),
+                    new_terminal_id: new_terminal_id.clone(),
+                    direction: direction.clone(),
+                    ratio: ratio.clamp(0.15, 0.85),
+                },
+            );
+
             McpResponse::Ok
         }
 
@@ -1386,35 +1462,39 @@ pub fn handle_mcp_request(
             workspace_id,
             terminal_id,
         } => {
-            let mut trees = app_state.layout_trees.write();
-            if let Some(tree) = trees.get_mut(workspace_id) {
-                if let godly_protocol::LayoutNode::Leaf { terminal_id: ref id } = tree {
-                    if id == terminal_id {
-                        trees.remove(workspace_id);
-                        drop(trees);
-                        auto_save.mark_dirty();
-                        return McpResponse::Ok;
-                    }
-                }
-                match tree.remove_terminal(terminal_id) {
-                    Some(_) => {
-                        if tree.count_leaves() <= 1 {
-                            trees.remove(workspace_id);
-                        }
-                    }
-                    None => {
-                        return McpResponse::Error {
-                            message: format!("Terminal {} not found in layout tree", terminal_id),
-                        };
-                    }
-                }
-            } else {
+            // Validate workspace exists
+            if !app_state.workspaces.read().contains_key(workspace_id) {
                 return McpResponse::Error {
-                    message: format!("No layout tree for workspace {}", workspace_id),
+                    message: format!("Workspace {} not found", workspace_id),
                 };
             }
-            drop(trees);
+
+            if let Err(msg) = app_state.unsplit_terminal_in_tree(workspace_id, terminal_id) {
+                return McpResponse::Error { message: msg };
+            }
+
+            // Clear zoom if the unsplit removed the zoomed pane
+            if let Some(zoomed) = app_state.get_zoomed_pane(workspace_id) {
+                if zoomed == *terminal_id {
+                    app_state.set_zoomed_pane(workspace_id, None);
+                }
+            }
+
             auto_save.mark_dirty();
+
+            #[derive(serde::Serialize, Clone)]
+            struct UnsplitPayload {
+                workspace_id: String,
+                terminal_id: String,
+            }
+            let _ = app_handle.emit(
+                "mcp-unsplit-terminal",
+                UnsplitPayload {
+                    workspace_id: workspace_id.clone(),
+                    terminal_id: terminal_id.clone(),
+                },
+            );
+
             McpResponse::Ok
         }
 
@@ -1427,23 +1507,87 @@ pub fn handle_mcp_request(
             terminal_id_a,
             terminal_id_b,
         } => {
-            let mut trees = app_state.layout_trees.write();
-            if let Some(tree) = trees.get_mut(workspace_id) {
-                if !tree.swap_terminals(terminal_id_a, terminal_id_b) {
-                    return McpResponse::Error {
-                        message: format!(
-                            "One or both terminals ({}, {}) not found in layout tree",
-                            terminal_id_a, terminal_id_b
-                        ),
-                    };
-                }
-            } else {
+            // Validate workspace exists
+            if !app_state.workspaces.read().contains_key(workspace_id) {
                 return McpResponse::Error {
-                    message: format!("No layout tree for workspace {}", workspace_id),
+                    message: format!("Workspace {} not found", workspace_id),
                 };
             }
-            drop(trees);
+
+            // Validate both terminals exist
+            {
+                let terminals = app_state.terminals.read();
+                if !terminals.contains_key(terminal_id_a) {
+                    return McpResponse::Error {
+                        message: format!("Terminal {} not found", terminal_id_a),
+                    };
+                }
+                if !terminals.contains_key(terminal_id_b) {
+                    return McpResponse::Error {
+                        message: format!("Terminal {} not found", terminal_id_b),
+                    };
+                }
+            }
+
+            if let Err(msg) = app_state.swap_panes_in_tree(workspace_id, terminal_id_a, terminal_id_b) {
+                return McpResponse::Error { message: msg };
+            }
+
             auto_save.mark_dirty();
+
+            #[derive(serde::Serialize, Clone)]
+            struct SwapPayload {
+                workspace_id: String,
+                terminal_id_a: String,
+                terminal_id_b: String,
+            }
+            let _ = app_handle.emit(
+                "mcp-swap-panes",
+                SwapPayload {
+                    workspace_id: workspace_id.clone(),
+                    terminal_id_a: terminal_id_a.clone(),
+                    terminal_id_b: terminal_id_b.clone(),
+                },
+            );
+
+            McpResponse::Ok
+        }
+
+        McpRequest::ZoomPane {
+            workspace_id,
+            terminal_id,
+        } => {
+            // Validate workspace exists
+            if !app_state.workspaces.read().contains_key(workspace_id) {
+                return McpResponse::Error {
+                    message: format!("Workspace {} not found", workspace_id),
+                };
+            }
+
+            // If zooming, validate terminal exists
+            if let Some(tid) = terminal_id {
+                if !app_state.terminals.read().contains_key(tid) {
+                    return McpResponse::Error {
+                        message: format!("Terminal {} not found", tid),
+                    };
+                }
+            }
+
+            app_state.set_zoomed_pane(workspace_id, terminal_id.clone());
+
+            #[derive(serde::Serialize, Clone)]
+            struct ZoomPayload {
+                workspace_id: String,
+                terminal_id: Option<String>,
+            }
+            let _ = app_handle.emit(
+                "mcp-zoom-pane",
+                ZoomPayload {
+                    workspace_id: workspace_id.clone(),
+                    terminal_id: terminal_id.clone(),
+                },
+            );
+
             McpResponse::Ok
         }
 

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,4 +1,4 @@
-use godly_protocol::LayoutNode;
+use godly_protocol::{LayoutNode, SplitDirection};
 use parking_lot::RwLock;
 use std::collections::HashMap;
 
@@ -22,6 +22,8 @@ pub struct AppState {
     pub split_views: RwLock<HashMap<String, SplitView>>,
     /// Recursive layout trees per workspace (workspace_id → LayoutNode)
     pub layout_trees: RwLock<HashMap<String, LayoutNode>>,
+    /// Zoomed pane per workspace (workspace_id → terminal_id)
+    pub zoomed_panes: RwLock<HashMap<String, String>>,
     /// Workspace ID for MCP-created terminals (Agent workspace in separate window)
     pub mcp_workspace_id: RwLock<Option<String>>,
 }
@@ -39,6 +41,7 @@ impl AppState {
             notification_overrides_workspace: RwLock::new(HashMap::new()),
             split_views: RwLock::new(HashMap::new()),
             layout_trees: RwLock::new(HashMap::new()),
+            zoomed_panes: RwLock::new(HashMap::new()),
             mcp_workspace_id: RwLock::new(None),
         }
     }
@@ -157,7 +160,6 @@ impl AppState {
         trees.get(workspace_id).cloned()
     }
 
-    #[allow(dead_code)]
     pub fn clear_layout_tree(&self, workspace_id: &str) {
         let mut trees = self.layout_trees.write();
         trees.remove(workspace_id);
@@ -165,6 +167,205 @@ impl AppState {
 
     pub fn get_all_layout_trees(&self) -> HashMap<String, LayoutNode> {
         self.layout_trees.read().clone()
+    }
+
+    /// Split a target terminal in the layout tree, inserting a new terminal next to it.
+    /// If no layout tree exists for the workspace, creates a 2-leaf tree.
+    /// Returns Ok(()) on success or Err with a message.
+    pub fn split_terminal_in_tree(
+        &self,
+        workspace_id: &str,
+        target_terminal_id: &str,
+        new_terminal_id: &str,
+        direction: SplitDirection,
+        ratio: f64,
+    ) -> Result<(), String> {
+        let mut trees = self.layout_trees.write();
+        let ratio = ratio.clamp(0.15, 0.85);
+
+        if let Some(tree) = trees.get_mut(workspace_id) {
+            // Insert into existing tree: find the target leaf and replace it with a split
+            if !Self::insert_split(tree, target_terminal_id, new_terminal_id, direction, ratio) {
+                return Err(format!(
+                    "Terminal {} not found in layout tree for workspace {}",
+                    target_terminal_id, workspace_id
+                ));
+            }
+        } else {
+            // No tree exists -- create a 2-leaf tree
+            let tree = LayoutNode::Split {
+                direction,
+                ratio,
+                first: Box::new(LayoutNode::Leaf {
+                    terminal_id: target_terminal_id.to_string(),
+                }),
+                second: Box::new(LayoutNode::Leaf {
+                    terminal_id: new_terminal_id.to_string(),
+                }),
+            };
+            trees.insert(workspace_id.to_string(), tree);
+        }
+
+        Ok(())
+    }
+
+    /// Remove a terminal from the layout tree. The sibling takes its parent's place.
+    /// Returns Ok(()) on success, Err if terminal not found.
+    pub fn unsplit_terminal_in_tree(
+        &self,
+        workspace_id: &str,
+        terminal_id: &str,
+    ) -> Result<(), String> {
+        let mut trees = self.layout_trees.write();
+
+        let tree = trees.get_mut(workspace_id).ok_or_else(|| {
+            format!("No layout tree for workspace {}", workspace_id)
+        })?;
+
+        // If the tree is just a single leaf, remove the whole tree
+        if let LayoutNode::Leaf { terminal_id: tid } = tree {
+            if tid == terminal_id {
+                trees.remove(workspace_id);
+                return Ok(());
+            }
+            return Err(format!(
+                "Terminal {} not found in layout tree",
+                terminal_id
+            ));
+        }
+
+        // Try to remove the terminal and collapse
+        match Self::remove_from_tree(tree, terminal_id) {
+            Some(replacement) => {
+                // If replacement is a single leaf, we could keep or remove the tree
+                *tree = replacement;
+                // If the result is a single leaf, remove the tree entirely
+                // (single-pane mode needs no tree)
+                if matches!(tree, LayoutNode::Leaf { .. }) {
+                    trees.remove(workspace_id);
+                }
+                Ok(())
+            }
+            None => Err(format!(
+                "Terminal {} not found in layout tree for workspace {}",
+                terminal_id, workspace_id
+            )),
+        }
+    }
+
+    /// Swap two terminals' positions in the layout tree.
+    pub fn swap_panes_in_tree(
+        &self,
+        workspace_id: &str,
+        terminal_id_a: &str,
+        terminal_id_b: &str,
+    ) -> Result<(), String> {
+        let mut trees = self.layout_trees.write();
+        let tree = trees.get_mut(workspace_id).ok_or_else(|| {
+            format!("No layout tree for workspace {}", workspace_id)
+        })?;
+
+        Self::swap_terminals(tree, terminal_id_a, terminal_id_b);
+        Ok(())
+    }
+
+    /// Set/clear zoomed pane for a workspace.
+    pub fn set_zoomed_pane(&self, workspace_id: &str, terminal_id: Option<String>) {
+        let mut zoomed = self.zoomed_panes.write();
+        match terminal_id {
+            Some(tid) => { zoomed.insert(workspace_id.to_string(), tid); }
+            None => { zoomed.remove(workspace_id); }
+        }
+    }
+
+    pub fn get_zoomed_pane(&self, workspace_id: &str) -> Option<String> {
+        self.zoomed_panes.read().get(workspace_id).cloned()
+    }
+
+    // --- Private tree helpers ---
+
+    /// Recursively find a leaf with `target_id` and replace it with a split
+    /// containing both the original and the new terminal.
+    fn insert_split(
+        node: &mut LayoutNode,
+        target_id: &str,
+        new_id: &str,
+        direction: SplitDirection,
+        ratio: f64,
+    ) -> bool {
+        match node {
+            LayoutNode::Leaf { terminal_id } if terminal_id == target_id => {
+                // Replace this leaf with a split
+                let old_leaf = LayoutNode::Leaf {
+                    terminal_id: target_id.to_string(),
+                };
+                let new_leaf = LayoutNode::Leaf {
+                    terminal_id: new_id.to_string(),
+                };
+                *node = LayoutNode::Split {
+                    direction,
+                    ratio,
+                    first: Box::new(old_leaf),
+                    second: Box::new(new_leaf),
+                };
+                true
+            }
+            LayoutNode::Split { first, second, .. } => {
+                Self::insert_split(first, target_id, new_id, direction, ratio)
+                    || Self::insert_split(second, target_id, new_id, direction, ratio)
+            }
+            _ => false,
+        }
+    }
+
+    /// Remove a terminal from the tree. Returns the replacement subtree (the sibling)
+    /// or None if the terminal was not found.
+    fn remove_from_tree(node: &mut LayoutNode, terminal_id: &str) -> Option<LayoutNode> {
+        match node {
+            LayoutNode::Leaf { .. } => None, // Can't remove from a leaf at this level
+            LayoutNode::Split { first, second, .. } => {
+                // Check if either child is the target leaf
+                if let LayoutNode::Leaf { terminal_id: tid } = first.as_ref() {
+                    if tid == terminal_id {
+                        return Some(*second.clone());
+                    }
+                }
+                if let LayoutNode::Leaf { terminal_id: tid } = second.as_ref() {
+                    if tid == terminal_id {
+                        return Some(*first.clone());
+                    }
+                }
+
+                // Recurse into children
+                if let Some(replacement) = Self::remove_from_tree(first, terminal_id) {
+                    *first = Box::new(replacement);
+                    return Some(node.clone());
+                }
+                if let Some(replacement) = Self::remove_from_tree(second, terminal_id) {
+                    *second = Box::new(replacement);
+                    return Some(node.clone());
+                }
+
+                None
+            }
+        }
+    }
+
+    /// Swap two terminals in the tree by swapping their IDs in-place.
+    fn swap_terminals(node: &mut LayoutNode, id_a: &str, id_b: &str) {
+        match node {
+            LayoutNode::Leaf { terminal_id } => {
+                if terminal_id == id_a {
+                    *terminal_id = id_b.to_string();
+                } else if terminal_id == id_b {
+                    *terminal_id = id_a.to_string();
+                }
+            }
+            LayoutNode::Split { first, second, .. } => {
+                Self::swap_terminals(first, id_a, id_b);
+                Self::swap_terminals(second, id_a, id_b);
+            }
+        }
     }
 
     /// Check if notifications are enabled for a given terminal/workspace.

--- a/src-tauri/src/state/models.rs
+++ b/src-tauri/src/state/models.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
-use godly_protocol::LayoutNode;
 use serde::{Deserialize, Serialize};
+
+// Re-export layout tree types from protocol
+pub use godly_protocol::LayoutNode;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary

refs #379

- Add 5 new MCP tools (`split_terminal`, `unsplit_terminal`, `get_layout_tree`, `swap_panes`, `zoom_pane`) for the recursive layout tree model that replaces the flat `SplitView`
- Add `LayoutNode` and `SplitDirection` types to `godly-protocol` with new `McpRequest`/`McpResponse` variants
- Add tree state management to `AppState` with `layout_trees` and `zoomed_panes` fields, plus recursive tree manipulation helpers
- Update existing `create_split`/`clear_split`/`get_split_state` for backward compatibility with the tree model
- Bump MCP BUILD constant to 18

## Changed files

| File | Change |
|------|--------|
| `src-tauri/protocol/src/mcp_messages.rs` | `LayoutNode`, `SplitDirection` types + 5 new request/response variants |
| `src-tauri/protocol/src/lib.rs` | Export new types |
| `src-tauri/mcp/src/tools.rs` | 5 new tool definitions + dispatch + enhanced `get_split_state` response |
| `src-tauri/mcp/src/daemon_direct.rs` | App-only error routing for new tools |
| `src-tauri/mcp/src/main.rs` | BUILD 17 -> 18 |
| `src-tauri/src/mcp_server/handler.rs` | Handler implementations for all 5 new tools + backward compat updates |
| `src-tauri/src/state/app_state.rs` | `layout_trees`, `zoomed_panes` fields + tree manipulation methods |
| `src-tauri/src/state/models.rs` | Re-export `LayoutNode`, `SplitDirection` from protocol |

## Test plan

- [x] `cargo check -p godly-protocol` passes
- [x] `cargo check -p godly-mcp` passes
- [x] `cargo check -p godly-terminal` passes
- [x] `cargo nextest run -p godly-protocol` - 85 tests pass
- [ ] Manual MCP testing: `split_terminal`, `unsplit_terminal`, `get_layout_tree`, `swap_panes`, `zoom_pane`
- [ ] Verify `create_split` backward compat creates layout tree
- [ ] Verify `get_split_state` returns both `split` and `layout_tree` fields