### PR TITLE
fix: re-parent pane containers on SplitContainer destroy

### DIFF
--- a/src/components/SplitContainer.browser.test.ts
+++ b/src/components/SplitContainer.browser.test.ts
@@ -5,65 +5,13 @@
  * real CSS flexbox layout, and real pointer events.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { SplitContainer, SplitPaneHandle } from './SplitContainer';
-import { LayoutNode, LeafNode, SplitNode } from '../state/split-types';
-
-function leaf(id: string): LeafNode {
-  return { type: 'leaf', terminal_id: id };
-}
-
-function split(
-  dir: 'horizontal' | 'vertical',
-  first: LayoutNode,
-  second: LayoutNode,
-  ratio = 0.5,
-): SplitNode {
-  return { type: 'split', direction: dir, ratio, first, second };
-}
-
-function mockPane(id: string): SplitPaneHandle {
-  const container = document.createElement('div');
-  container.className = 'terminal-pane';
-  container.dataset.id = id;
-  // Give it some default size so flex layout has something to work with
-  container.style.minWidth = '50px';
-  container.style.minHeight = '50px';
-  return {
-    getContainer: () => container,
-    setSplitVisible: vi.fn(),
-    setActive: vi.fn(),
-  };
-}
-
-function createPaneMap(ids: string[]): Map<string, SplitPaneHandle> {
-  const map = new Map<string, SplitPaneHandle>();
-  for (const id of ids) {
-    map.set(id, mockPane(id));
-  }
-  return map;
-}
-
-/** Mount the split container into the real DOM and inject layout styles. */
-function mountWithStyles(sc: SplitContainer): HTMLElement {
-  const root = sc.getElement();
-
-  // Inject minimal split layout CSS
-  const style = document.createElement('style');
-  style.textContent = `
-    .split-root { width: 800px; height: 600px; position: relative; }
-    .split-container { display: flex; width: 100%; height: 100%; }
-    .split-container.horizontal { flex-direction: row; }
-    .split-container.vertical { flex-direction: column; }
-    .split-divider { flex-shrink: 0; }
-    .split-divider.horizontal { width: 2px; cursor: col-resize; }
-    .split-divider.vertical { height: 2px; cursor: row-resize; }
-    .terminal-pane { overflow: hidden; }
-  `;
-  document.head.appendChild(style);
-  document.body.appendChild(root);
-
-  return root;
-}
+import { SplitContainer } from './SplitContainer';
+import {
+  leaf,
+  split,
+  createMockPaneMap,
+  mountSplitContainer,
+} from '../test-utils/browser-split-helpers';
 
 describe('SplitContainer (browser)', () => {
   let onRatioChange: ReturnType<typeof vi.fn>;
@@ -81,23 +29,24 @@ describe('SplitContainer (browser)', () => {
   });
 
   it('renders a single leaf pane into the DOM', () => {
-    const paneMap = createPaneMap(['t1']);
+    const paneMap = createMockPaneMap(['t1']);
     const sc = new SplitContainer(leaf('t1'), {
       paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1',
     });
 
-    const root = mountWithStyles(sc);
+    const { root, cleanup } = mountSplitContainer(sc);
     expect(root.querySelector('[data-id="t1"]')).not.toBeNull();
+    cleanup();
   });
 
   it('creates a horizontal split with real flex layout', () => {
-    const paneMap = createPaneMap(['t1', 't2']);
+    const paneMap = createMockPaneMap(['t1', 't2']);
     const sc = new SplitContainer(
       split('horizontal', leaf('t1'), leaf('t2'), 0.5),
       { paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1' },
     );
 
-    const root = mountWithStyles(sc);
+    const { root, cleanup } = mountSplitContainer(sc);
 
     const container = root.querySelector('.split-container.horizontal');
     expect(container).not.toBeNull();
@@ -107,18 +56,20 @@ describe('SplitContainer (browser)', () => {
     const rootRect = root.getBoundingClientRect();
     expect(rootRect.width).toBeGreaterThan(0);
     expect(rootRect.height).toBeGreaterThan(0);
+    cleanup();
   });
 
   it('creates a vertical split', () => {
-    const paneMap = createPaneMap(['t1', 't2']);
+    const paneMap = createMockPaneMap(['t1', 't2']);
     const sc = new SplitContainer(
       split('vertical', leaf('t1'), leaf('t2')),
       { paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1' },
     );
 
-    const root = mountWithStyles(sc);
+    const { root, cleanup } = mountSplitContainer(sc);
     const container = root.querySelector('.split-container.vertical');
     expect(container).not.toBeNull();
+    cleanup();
   });
 
   it('renders nested 3-pane layout with real bounding rects', () => {
@@ -126,12 +77,12 @@ describe('SplitContainer (browser)', () => {
       leaf('t1'),
       split('vertical', leaf('t2'), leaf('t3')),
     );
-    const paneMap = createPaneMap(['t1', 't2', 't3']);
+    const paneMap = createMockPaneMap(['t1', 't2', 't3']);
     const sc = new SplitContainer(tree, {
       paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1',
     });
 
-    const root = mountWithStyles(sc);
+    const { root, cleanup } = mountSplitContainer(sc);
 
     // All 3 panes should be in the DOM
     expect(root.querySelectorAll('.terminal-pane').length).toBe(3);
@@ -144,16 +95,17 @@ describe('SplitContainer (browser)', () => {
       // In real Chromium, dividers get actual layout — not zeros like jsdom
       expect(rect.width + rect.height).toBeGreaterThan(0);
     }
+    cleanup();
   });
 
   it('updates focus without re-rendering structure', () => {
-    const paneMap = createPaneMap(['t1', 't2']);
+    const paneMap = createMockPaneMap(['t1', 't2']);
     const sc = new SplitContainer(
       split('horizontal', leaf('t1'), leaf('t2')),
       { paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1' },
     );
 
-    mountWithStyles(sc);
+    const { cleanup } = mountSplitContainer(sc);
 
     vi.mocked(paneMap.get('t1')!.setSplitVisible).mockClear();
     vi.mocked(paneMap.get('t2')!.setSplitVisible).mockClear();
@@ -162,16 +114,17 @@ describe('SplitContainer (browser)', () => {
 
     expect(paneMap.get('t1')!.setSplitVisible).toHaveBeenCalledWith(true, false);
     expect(paneMap.get('t2')!.setSplitVisible).toHaveBeenCalledWith(true, true);
+    cleanup();
   });
 
   it('handles divider drag with real getBoundingClientRect', () => {
-    const paneMap = createPaneMap(['t1', 't2']);
+    const paneMap = createMockPaneMap(['t1', 't2']);
     const sc = new SplitContainer(
       split('horizontal', leaf('t1'), leaf('t2'), 0.5),
       { paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1' },
     );
 
-    const root = mountWithStyles(sc);
+    const { root, cleanup } = mountSplitContainer(sc);
     const divider = root.querySelector('.split-divider') as HTMLElement;
     expect(divider).not.toBeNull();
 
@@ -198,15 +151,16 @@ describe('SplitContainer (browser)', () => {
 
     // Clean up: mouseup
     document.dispatchEvent(new MouseEvent('mouseup'));
+    cleanup();
   });
 
   it('destroy removes element from DOM', () => {
-    const paneMap = createPaneMap(['t1']);
+    const paneMap = createMockPaneMap(['t1']);
     const sc = new SplitContainer(leaf('t1'), {
       paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1',
     });
 
-    mountWithStyles(sc);
+    mountSplitContainer(sc);
     expect(document.body.querySelector('.split-root')).not.toBeNull();
 
     sc.destroy();

--- a/src/components/SplitContainer.focus.browser.test.ts
+++ b/src/components/SplitContainer.focus.browser.test.ts
@@ -1,0 +1,317 @@
+/**
+ * SplitContainer focus navigation browser tests.
+ *
+ * Tests the focus navigation pipeline: findAdjacentTerminal() → sc.updateFocus()
+ * → setSplitVisible calls. This is the DOM integration seam that App.ts keyboard
+ * handlers use on Ctrl+Arrow.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SplitContainer } from './SplitContainer';
+import { findAdjacentTerminal } from '../state/split-types';
+import {
+  leaf,
+  split,
+  createMockPaneMap,
+  mountSplitContainer,
+  assertFocusedPane,
+} from '../test-utils/browser-split-helpers';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.head.querySelectorAll('style').forEach(s => s.remove());
+});
+
+// ---------------------------------------------------------------------------
+// 2-pane horizontal split [t1 | t2]
+// ---------------------------------------------------------------------------
+
+describe('2-pane horizontal [t1 | t2]', () => {
+  function setup(focusedId: string) {
+    const paneMap = createMockPaneMap(['t1', 't2']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+    const sc = new SplitContainer(layout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: focusedId,
+    });
+    const { cleanup } = mountSplitContainer(sc);
+    // Clear constructor calls so assertions only see updateFocus calls
+    for (const [, pane] of paneMap) vi.mocked(pane.setSplitVisible).mockClear();
+    return { layout, paneMap, sc, cleanup };
+  }
+
+  it('focus right: t1 → t2', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'horizontal', true);
+    expect(adjacent).toBe('t2');
+    sc.updateFocus('t2');
+    assertFocusedPane(paneMap, 't2');
+    cleanup();
+  });
+
+  it('focus left: t2 → t1', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t2');
+    const adjacent = findAdjacentTerminal(layout, 't2', 'horizontal', false);
+    expect(adjacent).toBe('t1');
+    sc.updateFocus('t1');
+    assertFocusedPane(paneMap, 't1');
+    cleanup();
+  });
+
+  it('focus up from horizontal: no-op', () => {
+    const { layout, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'vertical', false);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+
+  it('focus down from horizontal: no-op', () => {
+    const { layout, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'vertical', true);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+
+  it('boundary: focus right at rightmost stays put', () => {
+    const { layout, cleanup } = setup('t2');
+    const adjacent = findAdjacentTerminal(layout, 't2', 'horizontal', true);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2-pane vertical split [t1 / t2]
+// ---------------------------------------------------------------------------
+
+describe('2-pane vertical [t1 / t2]', () => {
+  function setup(focusedId: string) {
+    const paneMap = createMockPaneMap(['t1', 't2']);
+    const layout = split('vertical', leaf('t1'), leaf('t2'));
+    const sc = new SplitContainer(layout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: focusedId,
+    });
+    const { cleanup } = mountSplitContainer(sc);
+    for (const [, pane] of paneMap) vi.mocked(pane.setSplitVisible).mockClear();
+    return { layout, paneMap, sc, cleanup };
+  }
+
+  it('focus down: t1 → t2', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'vertical', true);
+    expect(adjacent).toBe('t2');
+    sc.updateFocus('t2');
+    assertFocusedPane(paneMap, 't2');
+    cleanup();
+  });
+
+  it('focus up: t2 → t1', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t2');
+    const adjacent = findAdjacentTerminal(layout, 't2', 'vertical', false);
+    expect(adjacent).toBe('t1');
+    sc.updateFocus('t1');
+    assertFocusedPane(paneMap, 't1');
+    cleanup();
+  });
+
+  it('focus left from vertical: no-op', () => {
+    const { layout, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'horizontal', false);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+
+  it('focus right from vertical: no-op', () => {
+    const { layout, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'horizontal', true);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4-pane grid (horizontal of two verticals)
+//   [t1] [t3]
+//   [t2] [t4]
+// ---------------------------------------------------------------------------
+
+describe('4-pane grid [t1|t3 / t2|t4]', () => {
+  function setup(focusedId: string) {
+    const paneMap = createMockPaneMap(['t1', 't2', 't3', 't4']);
+    const layout = split('horizontal',
+      split('vertical', leaf('t1'), leaf('t2')),
+      split('vertical', leaf('t3'), leaf('t4')),
+    );
+    const sc = new SplitContainer(layout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: focusedId,
+    });
+    const { cleanup } = mountSplitContainer(sc);
+    for (const [, pane] of paneMap) vi.mocked(pane.setSplitVisible).mockClear();
+    return { layout, paneMap, sc, cleanup };
+  }
+
+  it('right from t1 → t3', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'horizontal', true);
+    expect(adjacent).toBe('t3');
+    sc.updateFocus('t3');
+    assertFocusedPane(paneMap, 't3');
+    cleanup();
+  });
+
+  it('down from t1 → t2', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'vertical', true);
+    expect(adjacent).toBe('t2');
+    sc.updateFocus('t2');
+    assertFocusedPane(paneMap, 't2');
+    cleanup();
+  });
+
+  it('right from t2 → t3 (nearest leaf in adjacent subtree)', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t2');
+    // findAdjacentTerminal returns firstLeaf of the right column, not grid-aligned
+    const adjacent = findAdjacentTerminal(layout, 't2', 'horizontal', true);
+    expect(adjacent).toBe('t3');
+    sc.updateFocus('t3');
+    assertFocusedPane(paneMap, 't3');
+    cleanup();
+  });
+
+  it('up from t4 → t3', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t4');
+    const adjacent = findAdjacentTerminal(layout, 't4', 'vertical', false);
+    expect(adjacent).toBe('t3');
+    sc.updateFocus('t3');
+    assertFocusedPane(paneMap, 't3');
+    cleanup();
+  });
+
+  it('left from t3 → t2 (lastLeaf of adjacent subtree)', () => {
+    const { layout, paneMap, sc, cleanup } = setup('t3');
+    // findAdjacentTerminal returns lastLeaf of the left column, not grid-aligned
+    const adjacent = findAdjacentTerminal(layout, 't3', 'horizontal', false);
+    expect(adjacent).toBe('t2');
+    sc.updateFocus('t2');
+    assertFocusedPane(paneMap, 't2');
+    cleanup();
+  });
+
+  it('boundary: up from t1 stays put', () => {
+    const { layout, cleanup } = setup('t1');
+    const adjacent = findAdjacentTerminal(layout, 't1', 'vertical', false);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+
+  it('boundary: right from t4 stays put', () => {
+    const { layout, cleanup } = setup('t4');
+    const adjacent = findAdjacentTerminal(layout, 't4', 'horizontal', true);
+    expect(adjacent).toBeNull();
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus after structural changes
+// ---------------------------------------------------------------------------
+
+describe('focus after structural changes', () => {
+  it('focus correct after adding a new split', () => {
+    const paneMap = createMockPaneMap(['t1', 't2', 't3']);
+    const initialLayout = split('horizontal', leaf('t1'), leaf('t2'));
+    const sc = new SplitContainer(initialLayout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: 't1',
+    });
+    const { cleanup } = mountSplitContainer(sc);
+
+    // Add a vertical split on the right side
+    const newLayout = split('horizontal',
+      leaf('t1'),
+      split('vertical', leaf('t2'), leaf('t3')),
+    );
+    sc.update(newLayout, 't3');
+
+    // Clear and re-check
+    for (const [, pane] of paneMap) vi.mocked(pane.setSplitVisible).mockClear();
+    sc.updateFocus('t3');
+    assertFocusedPane(paneMap, 't3');
+    cleanup();
+  });
+
+  it('focus moves to sibling when focused pane removed', () => {
+    const paneMap = createMockPaneMap(['t1', 't2']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+    const sc = new SplitContainer(layout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: 't2',
+    });
+    const { cleanup } = mountSplitContainer(sc);
+
+    // Remove t2: layout collapses to just t1
+    sc.update(leaf('t1'), 't1');
+
+    for (const [, pane] of paneMap) vi.mocked(pane.setSplitVisible).mockClear();
+    sc.updateFocus('t1');
+
+    // Only t1 should get setSplitVisible calls now
+    const t1Mock = vi.mocked(paneMap.get('t1')!.setSplitVisible);
+    const lastCall = t1Mock.mock.calls[t1Mock.mock.calls.length - 1];
+    expect(lastCall).toEqual([true, true]);
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DOM correctness
+// ---------------------------------------------------------------------------
+
+describe('DOM correctness on focus change', () => {
+  it('no structural DOM rebuild on focus change', () => {
+    const paneMap = createMockPaneMap(['t1', 't2']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+    const sc = new SplitContainer(layout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: 't1',
+    });
+    const { root, cleanup } = mountSplitContainer(sc);
+
+    // Capture element references before focus change
+    const pane1Before = root.querySelector('[data-id="t1"]');
+    const pane2Before = root.querySelector('[data-id="t2"]');
+    const dividerBefore = root.querySelector('.split-divider');
+
+    sc.updateFocus('t2');
+
+    // Same DOM elements should still be in place (no rebuild)
+    expect(root.querySelector('[data-id="t1"]')).toBe(pane1Before);
+    expect(root.querySelector('[data-id="t2"]')).toBe(pane2Before);
+    expect(root.querySelector('.split-divider')).toBe(dividerBefore);
+    cleanup();
+  });
+
+  it('setSplitVisible(true, true) called for focused pane only', () => {
+    const paneMap = createMockPaneMap(['t1', 't2', 't3']);
+    const layout = split('horizontal',
+      leaf('t1'),
+      split('vertical', leaf('t2'), leaf('t3')),
+    );
+    const sc = new SplitContainer(layout, {
+      paneMap, onRatioChange: vi.fn(), onFocusPane: vi.fn(),
+      focusedTerminalId: 't1',
+    });
+    const { cleanup } = mountSplitContainer(sc);
+
+    for (const [, pane] of paneMap) vi.mocked(pane.setSplitVisible).mockClear();
+    sc.updateFocus('t2');
+
+    // t2 focused
+    expect(paneMap.get('t2')!.setSplitVisible).toHaveBeenCalledWith(true, true);
+    // t1 and t3 visible but not focused
+    expect(paneMap.get('t1')!.setSplitVisible).toHaveBeenCalledWith(true, false);
+    expect(paneMap.get('t3')!.setSplitVisible).toHaveBeenCalledWith(true, false);
+    cleanup();
+  });
+});

--- a/src/components/SplitContainer.lifecycle.browser.test.ts
+++ b/src/components/SplitContainer.lifecycle.browser.test.ts
@@ -1,0 +1,263 @@
+/**
+ * SplitContainer lifecycle browser tests — reproduces pane orphaning bug #405.
+ *
+ * Bug: Split a terminal → create new tab → switch back → nothing shows.
+ * Root cause: SplitContainer.destroy() removes the split-root from DOM,
+ * which also removes re-parented pane containers. The single-pane rendering
+ * code calls setActive(true) on orphaned containers that are no longer in
+ * the document tree.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SplitContainer, SplitPaneHandle } from './SplitContainer';
+import {
+  leaf,
+  split,
+  createMockPaneMap,
+} from '../test-utils/browser-split-helpers';
+
+/** Minimal CSS for split layout. */
+const SPLIT_CSS = `
+  .split-root { width: 800px; height: 600px; position: relative; }
+  .split-container { display: flex; width: 100%; height: 100%; }
+  .split-container.horizontal { flex-direction: row; }
+  .split-container.vertical { flex-direction: column; }
+  .split-divider { flex-shrink: 0; }
+  .split-divider.horizontal { width: 2px; cursor: col-resize; }
+  .split-divider.vertical { height: 2px; cursor: row-resize; }
+  .terminal-pane { overflow: hidden; min-width: 50px; min-height: 50px; }
+`;
+
+/**
+ * Simulates the App.ts pane lifecycle:
+ * 1. Creates a terminalContainer (like App.ts this.terminalContainer)
+ * 2. Mounts pane containers into it (like pane.mount(terminalContainer))
+ * 3. Returns helpers to create/destroy splits and check DOM state
+ */
+function setupAppSimulation(paneIds: string[]) {
+  const style = document.createElement('style');
+  style.textContent = SPLIT_CSS;
+  document.head.appendChild(style);
+
+  // Simulate App.ts terminalContainer
+  const terminalContainer = document.createElement('div');
+  terminalContainer.className = 'terminal-container';
+  terminalContainer.style.width = '800px';
+  terminalContainer.style.height = '600px';
+  document.body.appendChild(terminalContainer);
+
+  const paneMap = createMockPaneMap(paneIds);
+
+  // Simulate pane.mount(terminalContainer) — App.ts:166
+  for (const [, pane] of paneMap) {
+    terminalContainer.appendChild(pane.getContainer());
+  }
+
+  let splitContainer: SplitContainer | null = null;
+
+  return {
+    terminalContainer,
+    paneMap,
+
+    /** Simulate App.ts creating a split (lines 195-229). */
+    createSplit(layout: ReturnType<typeof split>) {
+      splitContainer = new SplitContainer(layout, {
+        paneMap,
+        onRatioChange: vi.fn(),
+        onFocusPane: vi.fn(),
+        focusedTerminalId: null,
+      });
+      terminalContainer.appendChild(splitContainer.getElement());
+      return splitContainer;
+    },
+
+    /** Simulate App.ts destroySplitContainer() (lines 1023-1028). */
+    destroySplit() {
+      if (splitContainer) {
+        splitContainer.destroy();
+        splitContainer = null;
+      }
+    },
+
+    /**
+     * Simulate App.ts single-pane rendering (lines 279-293).
+     * Sets the active pane and hides others.
+     */
+    activateSinglePane(activeId: string) {
+      for (const [id, pane] of paneMap) {
+        const isActive = id === activeId;
+        // Mirrors App.ts: pane.setActive(isVisible)
+        pane.setSplitVisible(false, false);
+        pane.setActive(isActive);
+        pane.getContainer().classList.toggle('active', isActive);
+        pane.getContainer().classList.remove('split-visible', 'split-focused');
+      }
+    },
+
+    cleanup() {
+      if (splitContainer) splitContainer.destroy();
+      document.body.innerHTML = '';
+      style.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.head.querySelectorAll('style').forEach(s => s.remove());
+});
+
+// ---------------------------------------------------------------------------
+// Bug #405: Pane containers orphaned after split destroy
+// ---------------------------------------------------------------------------
+
+describe('Bug #405: split destroy orphans pane containers', () => {
+  it('pane containers are in DOM before split is created', () => {
+    const app = setupAppSimulation(['t1', 't2']);
+
+    // Before any split, panes should be direct children of terminalContainer
+    const t1Container = app.paneMap.get('t1')!.getContainer();
+    const t2Container = app.paneMap.get('t2')!.getContainer();
+
+    expect(t1Container.parentElement).toBe(app.terminalContainer);
+    expect(t2Container.parentElement).toBe(app.terminalContainer);
+    expect(document.body.contains(t1Container)).toBe(true);
+    expect(document.body.contains(t2Container)).toBe(true);
+
+    app.cleanup();
+  });
+
+  it('pane containers are re-parented into split DOM tree', () => {
+    const app = setupAppSimulation(['t1', 't2']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+
+    app.createSplit(layout);
+
+    // After split, panes should be inside the split-root, NOT terminalContainer
+    const t1Container = app.paneMap.get('t1')!.getContainer();
+    const t2Container = app.paneMap.get('t2')!.getContainer();
+
+    expect(t1Container.parentElement).not.toBe(app.terminalContainer);
+    expect(t2Container.parentElement).not.toBe(app.terminalContainer);
+    // But still in the document
+    expect(document.body.contains(t1Container)).toBe(true);
+    expect(document.body.contains(t2Container)).toBe(true);
+
+    app.cleanup();
+  });
+
+  it('pane containers remain in DOM after split is destroyed', () => {
+    // Bug #405: pane containers orphaned when split is destroyed
+    // This is the core reproduction — after destroy, containers should
+    // still be in the document so setActive(true) actually works.
+    const app = setupAppSimulation(['t1', 't2']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+
+    // Step 1: Create split (re-parents panes into split DOM tree)
+    app.createSplit(layout);
+
+    // Step 2: Destroy split (simulates what happens when new terminal is created)
+    app.destroySplit();
+
+    // Step 3: Check that pane containers are still in the document
+    const t1Container = app.paneMap.get('t1')!.getContainer();
+    const t2Container = app.paneMap.get('t2')!.getContainer();
+
+    expect(document.body.contains(t1Container)).toBe(true);
+    expect(document.body.contains(t2Container)).toBe(true);
+
+    app.cleanup();
+  });
+
+  it('full lifecycle: split → new tab → switch back shows pane', () => {
+    // Bug #405: Full user scenario reproduction
+    // 1. Split t1 into [t1|t2]
+    // 2. Create new terminal t3 (destroys split, activates t3)
+    // 3. Switch back to t1 — should be visible
+    const app = setupAppSimulation(['t1', 't2', 't3']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+
+    // Step 1: Create split [t1|t2]
+    app.createSplit(layout);
+
+    // Step 2: "Create new terminal" — destroys split, shows t3
+    app.destroySplit();
+    app.activateSinglePane('t3');
+
+    // Verify t3 is visible
+    const t3Container = app.paneMap.get('t3')!.getContainer();
+    expect(document.body.contains(t3Container)).toBe(true);
+    expect(t3Container.classList.contains('active')).toBe(true);
+
+    // Step 3: Switch back to t1
+    app.activateSinglePane('t1');
+
+    const t1Container = app.paneMap.get('t1')!.getContainer();
+    // t1 should be in the DOM and have the active class
+    expect(document.body.contains(t1Container)).toBe(true);
+    expect(t1Container.classList.contains('active')).toBe(true);
+
+    // t1 should have real dimensions (visible in layout)
+    const rect = t1Container.getBoundingClientRect();
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+
+    app.cleanup();
+  });
+
+  it('full lifecycle: split → new tab → switch back to OTHER split pane', () => {
+    // Same as above but switching to t2 (the second pane of the split)
+    const app = setupAppSimulation(['t1', 't2', 't3']);
+    const layout = split('horizontal', leaf('t1'), leaf('t2'));
+
+    app.createSplit(layout);
+    app.destroySplit();
+    app.activateSinglePane('t3');
+
+    // Switch to t2
+    app.activateSinglePane('t2');
+
+    const t2Container = app.paneMap.get('t2')!.getContainer();
+    expect(document.body.contains(t2Container)).toBe(true);
+    expect(t2Container.classList.contains('active')).toBe(true);
+
+    const rect = t2Container.getBoundingClientRect();
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+
+    app.cleanup();
+  });
+
+  it('vertical split: pane containers survive destroy', () => {
+    const app = setupAppSimulation(['t1', 't2']);
+    const layout = split('vertical', leaf('t1'), leaf('t2'));
+
+    app.createSplit(layout);
+    app.destroySplit();
+
+    const t1Container = app.paneMap.get('t1')!.getContainer();
+    const t2Container = app.paneMap.get('t2')!.getContainer();
+
+    expect(document.body.contains(t1Container)).toBe(true);
+    expect(document.body.contains(t2Container)).toBe(true);
+
+    app.cleanup();
+  });
+
+  it('nested 3-pane split: all pane containers survive destroy', () => {
+    const app = setupAppSimulation(['t1', 't2', 't3']);
+    const layout = split('horizontal',
+      leaf('t1'),
+      split('vertical', leaf('t2'), leaf('t3')),
+    );
+
+    app.createSplit(layout);
+    app.destroySplit();
+
+    for (const id of ['t1', 't2', 't3']) {
+      const container = app.paneMap.get(id)!.getContainer();
+      expect(document.body.contains(container)).toBe(true);
+    }
+
+    app.cleanup();
+  });
+});

--- a/src/components/SplitContainer.test.ts
+++ b/src/components/SplitContainer.test.ts
@@ -349,7 +349,7 @@ describe('SplitContainer', () => {
   });
 
   describe('destroy', () => {
-    it('removes the element from DOM', () => {
+    it('removes the split-root from DOM', () => {
       const paneMap = createPaneMap(['t1']);
       const sc = new SplitContainer(leaf('t1'), {
         paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1',
@@ -357,10 +357,27 @@ describe('SplitContainer', () => {
 
       const parent = document.createElement('div');
       parent.appendChild(sc.getElement());
-      expect(parent.children.length).toBe(1);
+      expect(parent.querySelector('.split-root')).not.toBeNull();
 
       sc.destroy();
-      expect(parent.children.length).toBe(0);
+      expect(parent.querySelector('.split-root')).toBeNull();
+    });
+
+    it('re-parents pane containers back to parent on destroy', () => {
+      const paneMap = createPaneMap(['t1', 't2']);
+      const sc = new SplitContainer(
+        split('horizontal', leaf('t1'), leaf('t2')),
+        { paneMap, onRatioChange, onFocusPane, focusedTerminalId: 't1' },
+      );
+
+      const parent = document.createElement('div');
+      parent.appendChild(sc.getElement());
+
+      sc.destroy();
+
+      // Pane containers should be back in the parent, not orphaned
+      expect(parent.contains(paneMap.get('t1')!.getContainer())).toBe(true);
+      expect(parent.contains(paneMap.get('t2')!.getContainer())).toBe(true);
     });
   });
 });

--- a/src/components/SplitContainer.ts
+++ b/src/components/SplitContainer.ts
@@ -88,6 +88,13 @@ export class SplitContainer {
 
   destroy(): void {
     this.cleanup();
+    // Re-parent pane containers back to the split-root's parent before
+    // removing the split-root. Without this, pane containers become orphaned
+    // and invisible when single-pane mode tries to show them. (Bug #405)
+    const parent = this.element.parentElement;
+    if (parent) {
+      this.restorePaneContainers(this.root, parent);
+    }
     this.element.remove();
   }
 
@@ -242,6 +249,23 @@ export class SplitContainer {
       }
       // Note: hiding non-visible panes is handled by the caller (App.ts)
       // since the paneMap may contain panes from other workspaces.
+    }
+  }
+
+  /**
+   * Walk the rendered tree and move pane containers (leaf elements that
+   * came from the paneMap) back to the given parent element.
+   */
+  private restorePaneContainers(rendered: RenderedNode | null, parent: HTMLElement): void {
+    if (!rendered) return;
+    if (rendered.node.type === 'leaf') {
+      const pane = this.options.paneMap.get(rendered.node.terminal_id);
+      if (pane) {
+        parent.appendChild(pane.getContainer());
+      }
+    } else if (rendered.children) {
+      this.restorePaneContainers(rendered.children.first, parent);
+      this.restorePaneContainers(rendered.children.second, parent);
     }
   }
 

--- a/src/test-utils/browser-split-helpers.ts
+++ b/src/test-utils/browser-split-helpers.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared browser test helpers for SplitContainer tests.
+ *
+ * Provides tree builders, mock pane factories, and assertion helpers
+ * for tests that run in real Chromium via Vitest Browser Mode.
+ */
+import { vi } from 'vitest';
+import { SplitContainer, SplitPaneHandle } from '../components/SplitContainer';
+import { LayoutNode, LeafNode, SplitNode } from '../state/split-types';
+
+// ---------------------------------------------------------------------------
+// Tree builders
+// ---------------------------------------------------------------------------
+
+export function leaf(id: string): LeafNode {
+  return { type: 'leaf', terminal_id: id };
+}
+
+export function split(
+  dir: 'horizontal' | 'vertical',
+  first: LayoutNode,
+  second: LayoutNode,
+  ratio = 0.5,
+): SplitNode {
+  return { type: 'split', direction: dir, ratio, first, second };
+}
+
+// ---------------------------------------------------------------------------
+// Mock pane factory
+// ---------------------------------------------------------------------------
+
+export function createMockPane(id: string): SplitPaneHandle {
+  const container = document.createElement('div');
+  container.className = 'terminal-pane';
+  container.dataset.id = id;
+  container.style.minWidth = '50px';
+  container.style.minHeight = '50px';
+  return {
+    getContainer: () => container,
+    setSplitVisible: vi.fn(),
+    setActive: vi.fn(),
+  };
+}
+
+export function createMockPaneMap(ids: string[]): Map<string, SplitPaneHandle> {
+  const map = new Map<string, SplitPaneHandle>();
+  for (const id of ids) {
+    map.set(id, createMockPane(id));
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Mount helper
+// ---------------------------------------------------------------------------
+
+/** CSS that matches the production split layout from SplitContainer.ts. */
+const SPLIT_CSS = `
+  .split-root { width: 800px; height: 600px; position: relative; }
+  .split-container { display: flex; width: 100%; height: 100%; }
+  .split-container.horizontal { flex-direction: row; }
+  .split-container.vertical { flex-direction: column; }
+  .split-divider { flex-shrink: 0; }
+  .split-divider.horizontal { width: 2px; cursor: col-resize; }
+  .split-divider.vertical { height: 2px; cursor: row-resize; }
+  .terminal-pane { overflow: hidden; }
+`;
+
+/**
+ * Mount a SplitContainer into the real DOM with production-matching CSS.
+ * Returns the root element and a cleanup function.
+ */
+export function mountSplitContainer(sc: SplitContainer): { root: HTMLElement; cleanup: () => void } {
+  const root = sc.getElement();
+
+  const style = document.createElement('style');
+  style.textContent = SPLIT_CSS;
+  document.head.appendChild(style);
+  document.body.appendChild(root);
+
+  return {
+    root,
+    cleanup: () => {
+      sc.destroy();
+      style.remove();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Focus assertion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that the given pane is the only focused pane.
+ * Checks that `setSplitVisible(true, true)` was called for `expectedId`
+ * and `setSplitVisible(true, false)` for all others in the map.
+ */
+export function assertFocusedPane(
+  paneMap: Map<string, SplitPaneHandle>,
+  expectedId: string,
+): void {
+  for (const [id, pane] of paneMap) {
+    const mock = vi.mocked(pane.setSplitVisible);
+    const lastCall = mock.mock.calls[mock.mock.calls.length - 1];
+    if (id === expectedId) {
+      if (!lastCall || lastCall[0] !== true || lastCall[1] !== true) {
+        throw new Error(
+          `Expected pane "${id}" to be focused (setSplitVisible(true, true)), ` +
+          `but last call was ${lastCall ? `(${lastCall.join(', ')})` : 'never called'}`,
+        );
+      }
+    } else {
+      if (!lastCall || lastCall[0] !== true || lastCall[1] !== false) {
+        throw new Error(
+          `Expected pane "${id}" to be unfocused (setSplitVisible(true, false)), ` +
+          `but last call was ${lastCall ? `(${lastCall.join(', ')})` : 'never called'}`,
+        );
+      }
+    }
+  }
+}
+
+/** Wait for DOM layout to settle. */
+export function waitForLayout(): Promise<void> {
+  return new Promise(r => requestAnimationFrame(() => r()));
+}


### PR DESCRIPTION
## Summary

- **fixes #405** — Split pane containers orphaned after destroy, switching back shows nothing
- `SplitContainer.destroy()` now walks the rendered tree and re-parents pane containers back to the parent element before removing the split-root from DOM
- Extracted shared browser test helpers into `src/test-utils/browser-split-helpers.ts`
- Added focus navigation browser test suite (20 tests)
- Added lifecycle browser test suite reproducing bug #405 (7 tests)

## Test plan

- [x] All 46 browser tests pass (`npm run test:browser`)
- [x] All 1028 unit tests pass (`npm test`)
- [x] Bug #405 lifecycle tests pass after fix, failed consistently before (5/5 failures, 3/3 runs)
- [ ] Manual: split terminal → new tab → switch back → content visible