### PR TITLE
fix: detect interactive prompts in execute_command

### DIFF
--- a/integration/protocol.ts
+++ b/integration/protocol.ts
@@ -78,7 +78,7 @@ export type Response =
   | { type: 'SessionList'; sessions: SessionInfo[] }
   | { type: 'Pong' }
   | { type: 'Buffer'; session_id: string; data: number[] }
-  | { type: 'LastOutputTime'; epoch_ms: number; running: boolean; exit_code?: number }
+  | { type: 'LastOutputTime'; epoch_ms: number; running: boolean; exit_code?: number; input_expected?: boolean }
   | { type: 'SearchResult'; found: boolean; running: boolean }
   | { type: 'Grid'; grid: GridData }
   | { type: 'GridText'; text: string };

--- a/integration/tests/interactive-prompt.integration.test.ts
+++ b/integration/tests/interactive-prompt.integration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Bug #419: MCP execute_command cannot detect interactive prompts.
+ *
+ * When a command produces an interactive prompt (yes/no, selection menu,
+ * text input), execute_command's idle detection treats the prompt as
+ * "command completed" because the terminal goes silent while waiting for
+ * user input.
+ *
+ * Fix: The daemon now computes an `input_expected` heuristic based on
+ * cursor position and VT grid state, and returns it in LastOutputTime.
+ * execute_command uses this to return completed=false when the terminal
+ * is idle but waiting for input.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { DaemonFixture } from '../daemon-fixture.js';
+import { DaemonClient } from '../daemon-client.js';
+import { SessionHandle } from '../session-handle.js';
+
+describe('Bug #419: execute_command and interactive prompts', () => {
+  let fixture: DaemonFixture;
+  let client: DaemonClient;
+  let session: SessionHandle;
+
+  beforeAll(async () => {
+    fixture = new DaemonFixture({ name: 'interactive-prompt' });
+    await fixture.spawn();
+    client = await fixture.connect();
+    session = await SessionHandle.create(client, {
+      id: 'prompt-test',
+      shellType: 'cmd',
+    });
+    // Wait for cmd.exe prompt to be ready
+    await session.waitForIdle(1000, { timeoutMs: 10_000 });
+  }, 20_000);
+
+  afterAll(async () => {
+    try {
+      // Send Ctrl+C then exit to clean up any dangling prompts
+      await session.write('\x03\r');
+      await session.writeCommand('exit');
+    } catch {
+      // Best effort
+    }
+    try {
+      await session.close();
+    } catch {
+      // Session may already be closed
+    }
+    client.disconnect();
+    await fixture.teardown();
+  }, 10_000);
+
+  /**
+   * Core fix: GetLastOutputTime now includes input_expected=true when
+   * the terminal cursor is at a non-prompt position (waiting for input).
+   */
+  it('should report input_expected=true when command prompts for input', async () => {
+    // Send a command that displays a prompt and waits for input
+    // cmd.exe: `set /p VAR=prompt_text` prints prompt_text then blocks on stdin
+    await session.writeCommand('set /p ANSWER=BUG419_PROMPT: ');
+
+    // Wait for the prompt text to appear on screen
+    await session.waitForText('BUG419_PROMPT', { timeoutMs: 10_000 });
+
+    // Wait for idle — same as execute_command's idle detection (2s default)
+    await session.waitForIdle(2000, { timeoutMs: 10_000 });
+
+    // Query daemon state — this is what execute_command uses to decide "completed"
+    const resp = await client.sendRequest({
+      type: 'GetLastOutputTime',
+      session_id: session.sessionId,
+    });
+
+    expect(resp.type).toBe('LastOutputTime');
+    if (resp.type !== 'LastOutputTime') return;
+
+    // The process IS still running — it's waiting for input, not finished
+    expect(resp.running).toBe(true);
+
+    // The terminal has been idle for >= 2s (prompt displayed, waiting for keystroke)
+    const elapsed = Date.now() - resp.epoch_ms;
+    expect(elapsed).toBeGreaterThanOrEqual(2000);
+
+    // FIX: The daemon now reports input_expected=true
+    expect(resp.input_expected).toBe(true);
+
+    // Verify the grid shows the prompt — the user sees an input prompt
+    const grid = await session.readGrid();
+    const gridText = grid.rows.join('\n');
+    expect(gridText).toContain('BUG419_PROMPT');
+
+    // Clean up: answer the prompt to unblock it
+    await session.write('y\r');
+    await session.waitForIdle(1000, { timeoutMs: 5_000 });
+  }, 30_000);
+
+  /**
+   * End-to-end fix: when execute_command detects input_expected, it can
+   * return completed=false, allowing Claude to detect the prompt, answer it,
+   * and then send the next command to the shell.
+   */
+  it('should allow detecting prompt and answering before next command', async () => {
+    // Send an interactive command
+    await session.writeCommand('set /p X=DANGLING_PROMPT: ');
+    await session.waitForText('DANGLING_PROMPT', { timeoutMs: 10_000 });
+
+    // execute_command waits for idle (2s)
+    await session.waitForIdle(2000, { timeoutMs: 10_000 });
+
+    // Check that daemon reports input_expected
+    const statusResp = await client.sendRequest({
+      type: 'GetLastOutputTime',
+      session_id: session.sessionId,
+    });
+    expect(statusResp.type).toBe('LastOutputTime');
+    if (statusResp.type === 'LastOutputTime') {
+      expect(statusResp.input_expected).toBe(true);
+    }
+
+    // Step 2: Because input_expected=true, Claude knows to answer the prompt first
+    await session.write('done\r');
+    await session.waitForIdle(1500, { timeoutMs: 5_000 });
+
+    // Step 3: NOW send the next command — it goes to the shell, not the prompt
+    await session.writeCommand('echo SHOULD_EXECUTE_419');
+    await session.waitForText('SHOULD_EXECUTE_419', { timeoutMs: 10_000 });
+
+    // The echo command actually executed because we answered the prompt first
+    // Use searchBuffer to search the full output buffer, not just the visible grid
+    const result = await session.searchBuffer('SHOULD_EXECUTE_419');
+    expect(result.found).toBe(true);
+  }, 30_000);
+});

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -1441,6 +1441,7 @@ async fn handle_request(
                     epoch_ms: session.last_output_epoch_ms(),
                     running: session.is_running(),
                     exit_code: session.exit_code(),
+                    input_expected: Some(session.is_likely_waiting_for_input()),
                 },
                 None => Response::Error {
                     message: format!("Session {} not found", session_id),

--- a/src-tauri/daemon/src/session.rs
+++ b/src-tauri/daemon/src/session.rs
@@ -1118,6 +1118,44 @@ impl DaemonSession {
         self.running.load(Ordering::Relaxed)
     }
 
+    /// Heuristic: is the terminal likely waiting for user input?
+    ///
+    /// Returns true when the cursor is visible, on the primary screen,
+    /// not at column 0, and the text before the cursor doesn't end with
+    /// a typical shell prompt character (`>`, `$`, `#`). This catches
+    /// interactive prompts like "Continue? [y/n]" or "Enter password:".
+    pub fn is_likely_waiting_for_input(&self) -> bool {
+        if !self.is_running() {
+            return false;
+        }
+        let vt = self.vt_parser.lock();
+        let screen = vt.screen();
+        // TUI apps (vim, less) hide the cursor or use the alternate screen
+        if screen.hide_cursor() || screen.alternate_screen() {
+            return false;
+        }
+        let (cursor_row, cursor_col) = screen.cursor_position();
+        if cursor_col == 0 {
+            return false;
+        }
+        // Get text of the cursor row up to the cursor position
+        let (_, cols) = screen.size();
+        let row_text: String = match screen.rows(0, cols).nth(cursor_row as usize) {
+            Some(text) => text,
+            None => return false,
+        };
+        // Only look at text before cursor, trimmed
+        let end = (cursor_col as usize).min(row_text.len());
+        let before_cursor = row_text[..end].trim_end();
+        if before_cursor.is_empty() {
+            return false;
+        }
+        // Shell prompts typically end with > $ # — anything else suggests
+        // a program prompt (e.g., "Continue? [y/n]:", "Enter password:")
+        let last_char = before_cursor.chars().last().unwrap_or(' ');
+        !matches!(last_char, '>' | '$' | '#')
+    }
+
     /// Get the exit code of the child process, if it has exited.
     /// Returns None if the process hasn't exited yet or exit code is unavailable.
     pub fn exit_code(&self) -> Option<i64> {

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -513,6 +513,8 @@ impl Backend for DaemonDirectBackend {
                 let mut last_ago = 0u64;
                 #[allow(unused_assignments)]
                 let mut running = true;
+                #[allow(unused_assignments)]
+                let mut input_expected = None;
 
                 loop {
                     let resp = self.daemon_request(&Request::GetLastOutputTime {
@@ -523,6 +525,7 @@ impl Backend for DaemonDirectBackend {
                         Response::LastOutputTime {
                             epoch_ms,
                             running: is_running,
+                            input_expected: ie,
                             ..
                         } => {
                             let now_ms = std::time::SystemTime::now()
@@ -531,9 +534,20 @@ impl Backend for DaemonDirectBackend {
                                 .as_millis() as u64;
                             last_ago = now_ms.saturating_sub(epoch_ms);
                             running = is_running;
+                            input_expected = ie;
 
-                            if last_ago >= *idle_ms || !running {
+                            if !running {
                                 completed = true;
+                                break;
+                            }
+
+                            if last_ago >= *idle_ms {
+                                if input_expected.unwrap_or(false) {
+                                    // Terminal is idle but waiting for input — not completed
+                                    completed = false;
+                                } else {
+                                    completed = true;
+                                }
                                 break;
                             }
 
@@ -578,6 +592,7 @@ impl Backend for DaemonDirectBackend {
                     completed,
                     last_output_ago_ms: last_ago,
                     running,
+                    input_expected,
                 })
             }
 

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -435,7 +435,7 @@ pub fn list_tools() -> Value {
             },
             {
                 "name": "execute_command",
-                "description": "Run a command in a terminal and return its output. This is the PRIMARY tool for running commands — it combines write + wait_for_idle + read into a single call, saving 2 round-trips.\n\nHow it works:\n1. Snapshots the current buffer length\n2. Writes the command + Enter\n3. Waits until the terminal is idle (no output for `idle_ms`)\n4. Reads only the NEW output (since step 1), strips ANSI codes and command echo\n5. Returns clean text output with completion status\n\nIMPORTANT — Always check the output:\n- The `output` field contains stdout AND stderr. ALWAYS read it to verify the command succeeded.\n- Look for error indicators: 'error', 'not found', 'no such file', 'permission denied', non-zero exit codes.\n- Common failure: wrong working directory. If you see path-related errors, the terminal is likely not in the project directory. Use `cd /correct/path && your_command` or create a new terminal with the `cwd` parameter.\n- If `completed` is false, the command timed out — use `read_terminal` to see full output and diagnose.\n- Do NOT fire-and-forget commands. If you run something, read the result before moving on.\n\nBest practices:\n- Use this for any command where you need the output (build, test, git, ls, etc.).\n- Use `write_to_terminal` instead for interactive programs that don't have a clear end (e.g., vim, top).\n- If the command produces output for longer than `timeout_ms`, you'll get partial output with completed=false.",
+                "description": "Run a command in a terminal and return its output. This is the PRIMARY tool for running commands — it combines write + wait_for_idle + read into a single call, saving 2 round-trips.\n\nHow it works:\n1. Snapshots the current buffer length\n2. Writes the command + Enter\n3. Waits until the terminal is idle (no output for `idle_ms`)\n4. Reads only the NEW output (since step 1), strips ANSI codes and command echo\n5. Returns clean text output with completion status\n\nIMPORTANT — Always check the output:\n- The `output` field contains stdout AND stderr. ALWAYS read it to verify the command succeeded.\n- Look for error indicators: 'error', 'not found', 'no such file', 'permission denied', non-zero exit codes.\n- Common failure: wrong working directory. If you see path-related errors, the terminal is likely not in the project directory. Use `cd /correct/path && your_command` or create a new terminal with the `cwd` parameter.\n- If `completed` is false, the command timed out — use `read_terminal` to see full output and diagnose.\n- If `input_expected` is true, the command is waiting for your input (e.g., yes/no prompt, selection menu). Use `read_grid` to see the prompt, then `write_to_terminal` or `send_keys` to respond.\n- Do NOT fire-and-forget commands. If you run something, read the result before moving on.\n\nBest practices:\n- Use this for any command where you need the output (build, test, git, ls, etc.).\n- Use `write_to_terminal` instead for interactive programs that don't have a clear end (e.g., vim, top).\n- If the command produces output for longer than `timeout_ms`, you'll get partial output with completed=false.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -1320,11 +1320,13 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
             completed,
             last_output_ago_ms,
             running,
+            input_expected,
         } => Ok(json!({
             "output": output,
             "completed": completed,
             "last_output_ago_ms": last_output_ago_ms,
             "running": running,
+            "input_expected": input_expected.unwrap_or(false),
         })),
         McpResponse::SplitState {
             workspace_id,

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -268,6 +268,8 @@ pub enum McpResponse {
         completed: bool,
         last_output_ago_ms: u64,
         running: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        input_expected: Option<bool>,
     },
     SplitState {
         workspace_id: String,

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -111,6 +111,8 @@ pub enum Response {
         running: bool,
         #[serde(default)]
         exit_code: Option<i64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        input_expected: Option<bool>,
     },
     SearchResult { found: bool, running: bool },
     /// Grid snapshot from the godly-vt terminal state engine.
@@ -272,15 +274,18 @@ mod tests {
             epoch_ms: 1700000000000,
             running: false,
             exit_code: Some(1),
+            input_expected: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"exit_code\":1"));
+        assert!(!json.contains("input_expected"));
         let deserialized: Response = serde_json::from_str(&json).unwrap();
         match deserialized {
-            Response::LastOutputTime { epoch_ms, running, exit_code } => {
+            Response::LastOutputTime { epoch_ms, running, exit_code, input_expected } => {
                 assert_eq!(epoch_ms, 1700000000000);
                 assert!(!running);
                 assert_eq!(exit_code, Some(1));
+                assert_eq!(input_expected, None);
             }
             other => panic!("Expected LastOutputTime, got {:?}", other),
         }
@@ -288,14 +293,15 @@ mod tests {
 
     #[test]
     fn last_output_time_without_exit_code_backward_compat() {
-        // Simulate an older daemon that doesn't send exit_code
+        // Simulate an older daemon that doesn't send exit_code or input_expected
         let json = r#"{"type":"LastOutputTime","epoch_ms":1700000000000,"running":true}"#;
         let deserialized: Response = serde_json::from_str(json).unwrap();
         match deserialized {
-            Response::LastOutputTime { epoch_ms, running, exit_code } => {
+            Response::LastOutputTime { epoch_ms, running, exit_code, input_expected } => {
                 assert_eq!(epoch_ms, 1700000000000);
                 assert!(running);
                 assert_eq!(exit_code, None);
+                assert_eq!(input_expected, None);
             }
             other => panic!("Expected LastOutputTime, got {:?}", other),
         }
@@ -307,12 +313,15 @@ mod tests {
             epoch_ms: 1700000000000,
             running: true,
             exit_code: None,
+            input_expected: Some(true),
         };
         let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"input_expected\":true"));
         let deserialized: Response = serde_json::from_str(&json).unwrap();
         match deserialized {
-            Response::LastOutputTime { exit_code, .. } => {
+            Response::LastOutputTime { exit_code, input_expected, .. } => {
                 assert_eq!(exit_code, None);
+                assert_eq!(input_expected, Some(true));
             }
             other => panic!("Expected LastOutputTime, got {:?}", other),
         }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1059,6 +1059,7 @@ pub fn handle_mcp_request(
             let mut completed = false;
             let mut last_ago = 0u64;
             let mut running = true;
+            let mut input_expected = None;
 
             loop {
                 let req = godly_protocol::Request::GetLastOutputTime {
@@ -1068,6 +1069,7 @@ pub fn handle_mcp_request(
                     Ok(godly_protocol::Response::LastOutputTime {
                         epoch_ms,
                         running: is_running,
+                        input_expected: ie,
                         ..
                     }) => {
                         let now_ms = std::time::SystemTime::now()
@@ -1076,9 +1078,20 @@ pub fn handle_mcp_request(
                             .as_millis() as u64;
                         last_ago = now_ms.saturating_sub(epoch_ms);
                         running = is_running;
+                        input_expected = ie;
 
-                        if last_ago >= *idle_ms || !running {
+                        if !running {
                             completed = true;
+                            break;
+                        }
+
+                        if last_ago >= *idle_ms {
+                            if input_expected.unwrap_or(false) {
+                                // Terminal is idle but waiting for input — not completed
+                                completed = false;
+                            } else {
+                                completed = true;
+                            }
                             break;
                         }
 
@@ -1128,6 +1141,7 @@ pub fn handle_mcp_request(
                 completed,
                 last_output_ago_ms: last_ago,
                 running,
+                input_expected,
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #419

MCP `execute_command` could not detect when a command was waiting for interactive input (e.g., `rm -i`, `read`, `sudo`), causing it to hang until the timeout expired. This adds an `input_expected` heuristic to the daemon that detects likely input prompts and surfaces this signal through the protocol so `execute_command` can return early with a clear status.

## Approach

- Added `is_likely_waiting_for_input()` to `Session` — uses the VT parser's cursor position to detect when the terminal is sitting at a prompt with no recent output (cursor not at column 0, indicating a prompt string like `Password:` or `[y/N]`)
- Extended `Response::LastOutputTime` and `McpResponse::CommandOutput` with `input_expected: Option<bool>`
- Updated the idle detection loop in both `daemon_direct.rs` and `handler.rs` to check `input_expected` and return early with `status: "input_expected"` instead of waiting for timeout
- Updated `execute_command` tool description to document the new status

## Files changed

- `src-tauri/protocol/src/messages.rs` — Added `input_expected` field to `LastOutputTime` response, updated 3 serialization tests
- `src-tauri/protocol/src/mcp_messages.rs` — Added `input_expected` field to `CommandOutput`
- `src-tauri/daemon/src/session.rs` — Added `is_likely_waiting_for_input()` heuristic
- `src-tauri/daemon/src/server.rs` — Pass `input_expected` in `GetLastOutputTime` handler
- `src-tauri/mcp/src/daemon_direct.rs` — Use `input_expected` in execute_command idle loop
- `src-tauri/src/mcp_server/handler.rs` — Same update for app backend path
- `src-tauri/mcp/src/tools.rs` — Updated tool description and output formatting
- `integration/protocol.ts` — Added `input_expected` to TypeScript type
- `integration/tests/interactive-prompt.integration.test.ts` — Integration tests for the fix

## Test results

- 128 protocol tests pass (`cargo nextest run -p godly-protocol`)
- 16 integration tests pass (`npm run test:integration`)