### PR TITLE
feat: add self_split MCP tool for agent self-splitting

### DIFF
--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -621,6 +621,7 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ClearSplit { .. } => Ok(Self::app_only_error("clear_split")),
             McpRequest::GetSplitState { .. } => Ok(Self::app_only_error("get_split_state")),
             McpRequest::SplitTerminal { .. } => Ok(Self::app_only_error("split_terminal")),
+            McpRequest::SelfSplit { .. } => Ok(Self::app_only_error("self_split")),
             McpRequest::UnsplitTerminal { .. } => Ok(Self::app_only_error("unsplit_terminal")),
             McpRequest::GetLayoutTree { .. } => Ok(Self::app_only_error("get_layout_tree")),
             McpRequest::SwapPanes { .. } => Ok(Self::app_only_error("swap_panes")),

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod app_backend;
 mod backend;
 mod daemon_direct;
@@ -15,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 20;
+const BUILD: u32 = 21;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -586,6 +586,35 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "self_split",
+                "description": "Split YOUR OWN terminal pane to create a new terminal next to it. No IDs needed — auto-detects from GODLY_SESSION_ID. The new terminal opens in the same workspace as the calling terminal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "direction": {
+                            "type": "string",
+                            "enum": ["horizontal", "vertical"],
+                            "default": "horizontal",
+                            "description": "Split direction: 'horizontal' for left/right, 'vertical' for top/bottom"
+                        },
+                        "ratio": {
+                            "type": "number",
+                            "default": 0.5,
+                            "description": "Split ratio (0.15–0.85). Default: 0.5 (equal split)"
+                        },
+                        "cwd": {
+                            "type": "string",
+                            "description": "Working directory for the new terminal (optional — defaults to workspace folder)"
+                        },
+                        "command": {
+                            "type": "string",
+                            "description": "Command to run in the new terminal after creation (optional)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
                 "name": "unsplit_terminal",
                 "description": "Remove a terminal pane from the split layout. The sibling pane expands to fill the space. If only one pane remains, the layout returns to single-pane mode.",
                 "inputSchema": {
@@ -1160,6 +1189,24 @@ pub fn call_tool(
             }
         }
 
+        "self_split" => {
+            let session_id = match session_id {
+                Some(id) => id.clone(),
+                None => return Err("self_split requires GODLY_SESSION_ID to be set (are you running inside Godly Terminal?)".to_string()),
+            };
+            let direction = args.get("direction").and_then(|v| v.as_str()).unwrap_or("horizontal").to_string();
+            let ratio = args.get("ratio").and_then(|v| v.as_f64()).unwrap_or(0.5);
+            let cwd = args.get("cwd").and_then(|v| v.as_str()).map(String::from);
+            let command = args.get("command").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::SelfSplit {
+                session_id,
+                direction,
+                ratio,
+                cwd,
+                command,
+            }
+        }
+
         "unsplit_terminal" => {
             let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
             let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).ok_or("Missing terminal_id")?.to_string();
@@ -1342,6 +1389,20 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
             "ratio": ratio,
         })),
         McpResponse::NoSplit => Ok(json!({ "split": null })),
+        McpResponse::SplitCreated {
+            original_terminal_id,
+            new_terminal_id,
+            workspace_id,
+            direction,
+            ratio,
+        } => Ok(json!({
+            "success": true,
+            "original_terminal_id": original_terminal_id,
+            "new_terminal_id": new_terminal_id,
+            "workspace_id": workspace_id,
+            "direction": direction,
+            "ratio": ratio,
+        })),
         McpResponse::LayoutTree(tree) => Ok(json!({ "layout_tree": tree })),
         McpResponse::JsResult { result, error } => {
             if let Some(err) = error {

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -154,6 +154,17 @@ pub enum McpRequest {
         #[serde(default = "default_split_ratio")]
         ratio: f64,
     },
+    SelfSplit {
+        session_id: String,
+        #[serde(default = "default_split_direction")]
+        direction: String,
+        #[serde(default = "default_split_ratio")]
+        ratio: f64,
+        #[serde(default)]
+        cwd: Option<String>,
+        #[serde(default)]
+        command: Option<String>,
+    },
     UnsplitTerminal {
         workspace_id: String,
         terminal_id: String,
@@ -279,6 +290,13 @@ pub enum McpResponse {
         ratio: f64,
     },
     NoSplit,
+    SplitCreated {
+        original_terminal_id: String,
+        new_terminal_id: String,
+        workspace_id: String,
+        direction: String,
+        ratio: f64,
+    },
     LayoutTree(Option<crate::layout_tree::LayoutNode>),
     JsResult {
         result: Option<String>,

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1481,6 +1481,190 @@ pub fn handle_mcp_request(
             McpResponse::Ok
         }
 
+        McpRequest::SelfSplit {
+            session_id,
+            direction,
+            ratio,
+            cwd,
+            command,
+        } => {
+            use std::collections::HashMap;
+            use uuid::Uuid;
+
+            // 1. Look up the calling terminal by session_id
+            let (workspace_id, calling_terminal_id) = {
+                let terminals = app_state.terminals.read();
+                match terminals.get(session_id) {
+                    Some(t) => (t.workspace_id.clone(), t.id.clone()),
+                    None => {
+                        return McpResponse::Error {
+                            message: format!(
+                                "Session {} not found — is GODLY_SESSION_ID correct?",
+                                session_id
+                            ),
+                        };
+                    }
+                }
+            };
+
+            // 2. Validate direction
+            if direction != "horizontal" && direction != "vertical" {
+                return McpResponse::Error {
+                    message: format!(
+                        "Invalid direction '{}', must be 'horizontal' or 'vertical'",
+                        direction
+                    ),
+                };
+            }
+
+            // 3. Create new terminal in the SAME workspace as the caller
+            let new_terminal_id = Uuid::new_v4().to_string();
+
+            let shell = app_state
+                .get_workspace(&workspace_id)
+                .map(|ws| to_protocol_shell_type(&ws.shell_type))
+                .unwrap_or(godly_protocol::ShellType::Windows);
+
+            let working_dir = if let Some(dir) = cwd {
+                Some(dir.clone())
+            } else {
+                app_state
+                    .get_workspace(&workspace_id)
+                    .map(|ws| ws.folder_path)
+            };
+
+            let process_name = shell.display_name();
+
+            let mut env_vars = HashMap::new();
+            env_vars.insert("GODLY_SESSION_ID".to_string(), new_terminal_id.clone());
+            env_vars.insert("GODLY_WORKSPACE_ID".to_string(), workspace_id.clone());
+
+            let create_req = godly_protocol::Request::CreateSession {
+                id: new_terminal_id.clone(),
+                shell_type: shell.clone(),
+                cwd: working_dir.clone(),
+                rows: 24,
+                cols: 80,
+                env: Some(env_vars),
+            };
+
+            match daemon.send_request(&create_req) {
+                Ok(godly_protocol::Response::SessionCreated { .. }) => {}
+                Ok(godly_protocol::Response::Error { message }) => {
+                    return McpResponse::Error { message };
+                }
+                Ok(other) => {
+                    return McpResponse::Error {
+                        message: format!("Unexpected response: {:?}", other),
+                    };
+                }
+                Err(e) => return McpResponse::Error { message: e },
+            }
+
+            // Attach
+            let attach_req = godly_protocol::Request::Attach {
+                session_id: new_terminal_id.clone(),
+            };
+            match daemon.send_request(&attach_req) {
+                Ok(godly_protocol::Response::Ok | godly_protocol::Response::Buffer { .. }) => {}
+                Ok(godly_protocol::Response::Error { message }) => {
+                    return McpResponse::Error {
+                        message: format!("Failed to attach: {}", message),
+                    };
+                }
+                _ => {}
+            }
+
+            // Run command if specified
+            if let Some(ref cmd) = command {
+                let write_req = godly_protocol::Request::Write {
+                    session_id: new_terminal_id.clone(),
+                    data: format!("{}\r", cmd).into_bytes(),
+                };
+                let _ = daemon.send_request(&write_req);
+            }
+
+            // Store metadata
+            let app_shell = from_protocol_shell_type(&shell);
+            app_state.add_session_metadata(
+                new_terminal_id.clone(),
+                crate::state::SessionMetadata {
+                    shell_type: app_shell,
+                    cwd: working_dir,
+                    worktree_path: None,
+                    worktree_branch: None,
+                },
+            );
+
+            app_state.add_terminal(crate::state::Terminal {
+                id: new_terminal_id.clone(),
+                workspace_id: workspace_id.clone(),
+                name: String::from("Terminal"),
+                process_name,
+            });
+
+            // Notify frontend about the new terminal
+            #[derive(serde::Serialize, Clone)]
+            struct McpTerminalCreatedPayload {
+                terminal_id: String,
+                workspace_id: String,
+            }
+            let _ = app_handle.emit(
+                "mcp-terminal-created",
+                McpTerminalCreatedPayload {
+                    terminal_id: new_terminal_id.clone(),
+                    workspace_id: workspace_id.clone(),
+                },
+            );
+
+            // 4. Split the calling terminal pane
+            let clamped_ratio = ratio.clamp(0.15, 0.85);
+            let dir = if direction == "vertical" {
+                godly_protocol::SplitDirection::Vertical
+            } else {
+                godly_protocol::SplitDirection::Horizontal
+            };
+
+            if let Err(msg) = app_state.split_terminal_in_tree(
+                &workspace_id,
+                &calling_terminal_id,
+                &new_terminal_id,
+                dir,
+                clamped_ratio,
+            ) {
+                return McpResponse::Error { message: msg };
+            }
+
+            auto_save.mark_dirty();
+
+            #[derive(serde::Serialize, Clone)]
+            struct SplitTerminalPayload {
+                workspace_id: String,
+                target_terminal_id: String,
+                new_terminal_id: String,
+                direction: String,
+                ratio: f64,
+            }
+            let _ = app_handle.emit(
+                "mcp-split-terminal",
+                SplitTerminalPayload {
+                    workspace_id: workspace_id.clone(),
+                    target_terminal_id: calling_terminal_id.clone(),
+                    new_terminal_id: new_terminal_id.clone(),
+                    direction: direction.clone(),
+                    ratio: clamped_ratio,
+                },
+            );
+
+            McpResponse::SplitCreated {
+                original_terminal_id: calling_terminal_id,
+                new_terminal_id,
+                workspace_id,
+                direction: direction.clone(),
+                ratio: clamped_ratio,
+            }
+        }
+
         McpRequest::UnsplitTerminal {
             workspace_id,
             terminal_id,


### PR DESCRIPTION
## Summary

- New `self_split` MCP tool that lets an agent split its own terminal pane with zero IDs required
- Auto-detects the calling terminal via `GODLY_SESSION_ID` env var
- Creates a new terminal + splits the caller's pane atomically (same workspace, not "Agent" workspace)
- Optional params: `direction` (horizontal/vertical), `ratio` (0.15–0.85), `cwd`, `command`

## Changes

| File | Change |
|------|--------|
| `protocol/src/mcp_messages.rs` | +`SelfSplit` request, +`SplitCreated` response |
| `mcp/src/tools.rs` | Tool definition, `call_tool` dispatch, `response_to_json` |
| `src/mcp_server/handler.rs` | `SelfSplit` handler (create + split atomic) |
| `mcp/src/daemon_direct.rs` | App-only error entry |
| `mcp/src/main.rs` | BUILD bump 20→21, `#![recursion_limit = "256"]` |

## Test plan

- [x] `cargo check -p godly-protocol` — compiles
- [x] `cargo check -p godly-mcp` — compiles
- [ ] Manual test: open Claude Code in Godly Terminal, call `self_split` → terminal splits with new pane

Fixes #435