### PR TITLE
feat: whisper UX polish - audio levels, timer, and toast

### DIFF
--- a/src-tauri/protocol/src/whisper.rs
+++ b/src-tauri/protocol/src/whisper.rs
@@ -19,6 +19,7 @@ pub enum WhisperRequest {
     },
     ListAudioDevices,
     PlaybackLastRecording,
+    GetAudioLevel,
 }
 
 /// Info about an available audio input device.
@@ -53,7 +54,198 @@ pub enum WhisperResponse {
         devices: Vec<AudioDeviceInfo>,
     },
     PlaybackComplete,
+    AudioLevel {
+        rms: f32,
+        peak: f32,
+        duration_ms: u64,
+    },
     Error {
         message: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_ping_roundtrip() {
+        let req = WhisperRequest::Ping;
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperRequest::Ping));
+    }
+
+    #[test]
+    fn request_shutdown_roundtrip() {
+        let req = WhisperRequest::Shutdown;
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperRequest::Shutdown));
+    }
+
+    #[test]
+    fn request_start_recording_roundtrip() {
+        let req = WhisperRequest::StartRecording { device_name: None };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperRequest::StartRecording { .. }));
+    }
+
+    #[test]
+    fn request_stop_recording_roundtrip() {
+        let req = WhisperRequest::StopRecording;
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperRequest::StopRecording));
+    }
+
+    #[test]
+    fn request_get_status_roundtrip() {
+        let req = WhisperRequest::GetStatus;
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperRequest::GetStatus));
+    }
+
+    #[test]
+    fn request_load_model_roundtrip() {
+        let req = WhisperRequest::LoadModel {
+            model_path: "/path/to/model.bin".to_string(),
+            use_gpu: true,
+            gpu_device: 1,
+            language: "en".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WhisperRequest::LoadModel { model_path, use_gpu, gpu_device, language } => {
+                assert_eq!(model_path, "/path/to/model.bin");
+                assert!(use_gpu);
+                assert_eq!(gpu_device, 1);
+                assert_eq!(language, "en");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn request_get_audio_level_roundtrip() {
+        let req = WhisperRequest::GetAudioLevel;
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: WhisperRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperRequest::GetAudioLevel));
+    }
+
+    #[test]
+    fn response_pong_roundtrip() {
+        let resp = WhisperResponse::Pong;
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: WhisperResponse = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, WhisperResponse::Pong));
+    }
+
+    #[test]
+    fn response_transcription_result_roundtrip() {
+        let resp = WhisperResponse::TranscriptionResult {
+            text: "hello world".to_string(),
+            duration_ms: 1234,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: WhisperResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WhisperResponse::TranscriptionResult { text, duration_ms } => {
+                assert_eq!(text, "hello world");
+                assert_eq!(duration_ms, 1234);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn response_status_roundtrip() {
+        let resp = WhisperResponse::Status {
+            state: "idle".to_string(),
+            model_loaded: true,
+            model_name: Some("ggml-base.bin".to_string()),
+            gpu_available: true,
+            gpu_in_use: false,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: WhisperResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WhisperResponse::Status { state, model_loaded, model_name, gpu_available, gpu_in_use } => {
+                assert_eq!(state, "idle");
+                assert!(model_loaded);
+                assert_eq!(model_name, Some("ggml-base.bin".to_string()));
+                assert!(gpu_available);
+                assert!(!gpu_in_use);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn response_model_loaded_roundtrip() {
+        let resp = WhisperResponse::ModelLoaded {
+            model_name: "ggml-large.bin".to_string(),
+            gpu_in_use: true,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: WhisperResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WhisperResponse::ModelLoaded { model_name, gpu_in_use } => {
+                assert_eq!(model_name, "ggml-large.bin");
+                assert!(gpu_in_use);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn response_audio_level_roundtrip() {
+        let resp = WhisperResponse::AudioLevel {
+            rms: 0.25,
+            peak: 0.8,
+            duration_ms: 500,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: WhisperResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WhisperResponse::AudioLevel { rms, peak, duration_ms } => {
+                assert!((rms - 0.25).abs() < 1e-6);
+                assert!((peak - 0.8).abs() < 1e-6);
+                assert_eq!(duration_ms, 500);
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn response_error_roundtrip() {
+        let resp = WhisperResponse::Error {
+            message: "Something went wrong".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: WhisperResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WhisperResponse::Error { message } => {
+                assert_eq!(message, "Something went wrong");
+            }
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn request_tagged_serialization() {
+        // Verify serde(tag = "type") works -- JSON should have a "type" field
+        let json = serde_json::to_string(&WhisperRequest::Ping).unwrap();
+        assert!(json.contains("\"type\":\"Ping\"") || json.contains("\"type\": \"Ping\""));
+    }
+
+    #[test]
+    fn response_tagged_serialization() {
+        let json = serde_json::to_string(&WhisperResponse::Pong).unwrap();
+        assert!(json.contains("\"type\":\"Pong\"") || json.contains("\"type\": \"Pong\""));
+    }
 }

--- a/src-tauri/src/commands/whisper.rs
+++ b/src-tauri/src/commands/whisper.rs
@@ -166,10 +166,17 @@ pub async fn whisper_start_recording(
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptionResult {
+    pub text: String,
+    pub duration_ms: u64,
+}
+
 #[tauri::command]
 pub async fn whisper_stop_recording(
     whisper: State<'_, Arc<WhisperState>>,
-) -> Result<String, String> {
+) -> Result<TranscriptionResult, String> {
     whisper.set_recording_state(WhisperRecordingState::Transcribing);
 
     let resp = whisper.client().send_request(&WhisperRequest::StopRecording)
@@ -179,9 +186,9 @@ pub async fn whisper_stop_recording(
         })?;
 
     match resp {
-        WhisperResponse::TranscriptionResult { text, .. } => {
+        WhisperResponse::TranscriptionResult { text, duration_ms } => {
             whisper.set_recording_state(WhisperRecordingState::Idle);
-            Ok(text)
+            Ok(TranscriptionResult { text, duration_ms })
         }
         WhisperResponse::Error { message } => {
             whisper.set_recording_state(WhisperRecordingState::Idle);
@@ -191,6 +198,30 @@ pub async fn whisper_stop_recording(
             whisper.set_recording_state(WhisperRecordingState::Idle);
             Err(format!("Unexpected response: {:?}", other))
         }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioLevelInfo {
+    pub rms: f32,
+    pub peak: f32,
+    pub duration_ms: u64,
+}
+
+#[tauri::command]
+pub async fn whisper_get_audio_level(
+    whisper: State<'_, Arc<WhisperState>>,
+) -> Result<AudioLevelInfo, String> {
+    let resp = whisper.client().send_request(&WhisperRequest::GetAudioLevel)
+        .map_err(|e| format!("Failed to get audio level: {}", e))?;
+
+    match resp {
+        WhisperResponse::AudioLevel { rms, peak, duration_ms } => {
+            Ok(AudioLevelInfo { rms, peak, duration_ms })
+        }
+        WhisperResponse::Error { message } => Err(message),
+        other => Err(format!("Unexpected response: {:?}", other)),
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -665,6 +665,7 @@ pub fn run() {
             commands::list_gpu_devices,
             commands::whisper_list_audio_devices,
             commands::whisper_playback_recording,
+            commands::whisper_get_audio_level,
             persistence::save_layout,
             persistence::load_layout,
             persistence::save_scrollback,

--- a/src-tauri/whisper/src/audio.rs
+++ b/src-tauri/whisper/src/audio.rs
@@ -11,6 +11,7 @@ pub struct AudioRecorder {
     native_sample_rate: u32,
     native_channels: u16,
     last_recording: Option<Vec<f32>>,
+    recording_start: Option<std::time::Instant>,
 }
 
 impl AudioRecorder {
@@ -21,6 +22,7 @@ impl AudioRecorder {
             native_sample_rate: 16_000,
             native_channels: 1,
             last_recording: None,
+            recording_start: None,
         }
     }
 
@@ -70,7 +72,7 @@ impl AudioRecorder {
                 .ok_or("No audio input device found")?
         };
 
-        // Use the device's default config — most devices don't support 16kHz directly
+        // Use the device's default config -- most devices don't support 16kHz directly
         let default_config = device
             .default_input_config()
             .map_err(|e| format!("Failed to get default input config: {}", e))?;
@@ -113,12 +115,14 @@ impl AudioRecorder {
             .map_err(|e| format!("Failed to start audio stream: {}", e))?;
 
         self.stream = Some(stream);
+        self.recording_start = Some(std::time::Instant::now());
         Ok(())
     }
 
     /// Stop recording and return the captured PCM samples (16kHz mono f32).
     /// Also stores the samples for later playback.
     pub fn stop(&mut self) -> Result<Vec<f32>, String> {
+        self.recording_start = None;
         let stream = self.stream.take().ok_or("Not recording")?;
 
         drop(stream);
@@ -156,6 +160,39 @@ impl AudioRecorder {
 
     pub fn has_last_recording(&self) -> bool {
         self.last_recording.is_some()
+    }
+
+    /// Compute RMS and peak from the last ~50ms of the buffer.
+    pub fn current_levels(&self) -> (f32, f32) {
+        let buf = match self.buffer.lock() {
+            Ok(b) => b,
+            Err(_) => return (0.0, 0.0),
+        };
+        if buf.is_empty() {
+            return (0.0, 0.0);
+        }
+        // Look at last ~50ms of samples (native_sample_rate * native_channels * 0.05)
+        let window = (self.native_sample_rate as usize * self.native_channels as usize / 20).max(1);
+        let start = buf.len().saturating_sub(window);
+        let slice = &buf[start..];
+
+        let mut sum_sq = 0.0f64;
+        let mut peak = 0.0f32;
+        for &s in slice {
+            sum_sq += (s as f64) * (s as f64);
+            let abs = s.abs();
+            if abs > peak {
+                peak = abs;
+            }
+        }
+        let rms = (sum_sq / slice.len() as f64).sqrt() as f32;
+        (rms, peak)
+    }
+
+    pub fn recording_duration_ms(&self) -> u64 {
+        self.recording_start
+            .map(|start| start.elapsed().as_millis() as u64)
+            .unwrap_or(0)
     }
 
     /// Play back the last recording through the default output device.
@@ -281,4 +318,79 @@ fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_mono_single_channel() {
+        let input = vec![0.5, -0.3, 0.7];
+        let result = to_mono(&input, 1);
+        assert_eq!(result, vec![0.5, -0.3, 0.7]);
+    }
+
+    #[test]
+    fn to_mono_stereo() {
+        let input = vec![0.4, 0.6, -0.2, 0.8];
+        let result = to_mono(&input, 2);
+        assert_eq!(result.len(), 2);
+        assert!((result[0] - 0.5).abs() < 1e-6); // (0.4 + 0.6) / 2
+        assert!((result[1] - 0.3).abs() < 1e-6); // (-0.2 + 0.8) / 2
+    }
+
+    #[test]
+    fn to_mono_empty() {
+        let result = to_mono(&[], 2);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resample_same_rate() {
+        let input = vec![1.0, 2.0, 3.0];
+        let result = resample(&input, 16000, 16000);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn resample_downsample() {
+        // 48kHz to 16kHz = 3:1 ratio
+        let input: Vec<f32> = (0..48000).map(|i| (i as f32) / 48000.0).collect();
+        let result = resample(&input, 48000, 16000);
+        // Should produce approximately 16000 samples
+        assert!((result.len() as i32 - 16000).abs() < 2);
+    }
+
+    #[test]
+    fn resample_upsample() {
+        // 8kHz to 16kHz = 1:2 ratio
+        let input: Vec<f32> = (0..800).map(|i| (i as f32) / 800.0).collect();
+        let result = resample(&input, 8000, 16000);
+        // Should produce approximately 1600 samples
+        assert!((result.len() as i32 - 1600).abs() < 2);
+    }
+
+    #[test]
+    fn resample_empty() {
+        let result = resample(&[], 48000, 16000);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resample_interpolation_accuracy() {
+        // Simple case: 2 samples at 2Hz resampled to 4Hz
+        let input = vec![0.0, 1.0];
+        let result = resample(&input, 2, 4);
+        // Should interpolate: 0.0, 0.5, 1.0, (possibly 1.0)
+        assert!(result.len() >= 3);
+        assert!((result[0] - 0.0).abs() < 1e-5);
+        assert!((result[1] - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn audio_recorder_new_defaults() {
+        let recorder = AudioRecorder::new();
+        assert!(!recorder.is_recording());
+    }
 }

--- a/src-tauri/whisper/src/pipe_server.rs
+++ b/src-tauri/whisper/src/pipe_server.rs
@@ -63,7 +63,7 @@ pub fn handle_client(
     loop {
         let request: WhisperRequest = match read_message(pipe)? {
             Some(req) => req,
-            None => return Ok(()), // EOF — client disconnected
+            None => return Ok(()), // EOF -- client disconnected
         };
 
         let response = handle_request(request, recorder, transcriber);
@@ -76,7 +76,7 @@ pub fn handle_client(
     }
 }
 
-fn handle_request(
+pub(crate) fn handle_request(
     request: WhisperRequest,
     recorder: &mut AudioRecorder,
     transcriber: &mut Transcriber,
@@ -165,6 +165,17 @@ fn handle_request(
             }
         }
 
+        WhisperRequest::GetAudioLevel => {
+            if !recorder.is_recording() {
+                return WhisperResponse::Error {
+                    message: "Not recording".to_string(),
+                };
+            }
+            let (rms, peak) = recorder.current_levels();
+            let duration_ms = recorder.recording_duration_ms();
+            WhisperResponse::AudioLevel { rms, peak, duration_ms }
+        }
+
         WhisperRequest::StopRecording => {
             let samples = match recorder.stop() {
                 Ok(s) => s,
@@ -193,6 +204,83 @@ fn handle_request(
                     WhisperResponse::Error { message: e }
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_ping() {
+        let mut recorder = AudioRecorder::new();
+        let mut transcriber = Transcriber::new();
+        let resp = handle_request(WhisperRequest::Ping, &mut recorder, &mut transcriber);
+        assert!(matches!(resp, WhisperResponse::Pong));
+    }
+
+    #[test]
+    fn handle_get_status_idle_no_model() {
+        let mut recorder = AudioRecorder::new();
+        let mut transcriber = Transcriber::new();
+        let resp = handle_request(WhisperRequest::GetStatus, &mut recorder, &mut transcriber);
+        match resp {
+            WhisperResponse::Status { state, model_loaded, model_name, gpu_in_use, .. } => {
+                assert_eq!(state, "idle");
+                assert!(!model_loaded);
+                assert!(model_name.is_none());
+                assert!(!gpu_in_use);
+            }
+            other => panic!("Expected Status, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn handle_start_recording_without_model() {
+        let mut recorder = AudioRecorder::new();
+        let mut transcriber = Transcriber::new();
+        let resp = handle_request(WhisperRequest::StartRecording { device_name: None }, &mut recorder, &mut transcriber);
+        match resp {
+            WhisperResponse::Error { message } => {
+                assert!(message.contains("No model loaded"));
+            }
+            other => panic!("Expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn handle_stop_recording_when_not_recording() {
+        let mut recorder = AudioRecorder::new();
+        let mut transcriber = Transcriber::new();
+        let resp = handle_request(WhisperRequest::StopRecording, &mut recorder, &mut transcriber);
+        match resp {
+            WhisperResponse::Error { message } => {
+                assert!(message.contains("Not recording"));
+            }
+            other => panic!("Expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn handle_load_model_bad_path() {
+        let mut recorder = AudioRecorder::new();
+        let mut transcriber = Transcriber::new();
+        let resp = handle_request(
+            WhisperRequest::LoadModel {
+                model_path: "/nonexistent/model.bin".to_string(),
+                use_gpu: false,
+                gpu_device: 0,
+                language: String::new(),
+            },
+            &mut recorder,
+            &mut transcriber,
+        );
+        match resp {
+            WhisperResponse::Error { message } => {
+                assert!(message.contains("not found"));
+            }
+            other => panic!("Expected Error, got {:?}", other),
         }
     }
 }

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -97,6 +97,7 @@ export class App {
   private zoomedPaneId: string | null = null;
   /** Stores the split ratio before zoom, so it can be restored on unzoom. */
   private preZoomRatio: number | null = null;
+  private voicePollInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -1153,22 +1154,41 @@ export class App {
    */
   private async handleVoiceToggle(): Promise<void> {
     try {
-      const { whisperGetStatus, whisperStartRecording, whisperStopRecording } = await import('../plugins/voice/whisper-service');
+      const { whisperGetStatus, whisperStartRecording, whisperStopRecording, whisperGetAudioLevel } = await import('../plugins/voice/whisper-service');
       const status = await whisperGetStatus();
 
       if (status.state === 'idle') {
         await whisperStartRecording();
         this.updateMicButtonState('recording');
+        // Start polling audio levels every 60ms
+        this.voicePollInterval = setInterval(async () => {
+          try {
+            const level = await whisperGetAudioLevel();
+            this.updateMicLevel(level.rms, level.durationMs);
+          } catch {
+            // ignore polling errors
+          }
+        }, 60);
       } else if (status.state === 'recording') {
-        this.updateMicButtonState('transcribing');
-        const text = await whisperStopRecording();
-        this.updateMicButtonState('idle');
-        if (text && store.getState().activeTerminalId) {
-          await terminalService.writeToTerminal(store.getState().activeTerminalId!, text);
+        // Stop polling
+        if (this.voicePollInterval) {
+          clearInterval(this.voicePollInterval);
+          this.voicePollInterval = null;
         }
+        this.updateMicButtonState('transcribing');
+        const result = await whisperStopRecording();
+        this.updateMicButtonState('idle');
+        if (result.text && store.getState().activeTerminalId) {
+          await terminalService.writeToTerminal(store.getState().activeTerminalId!, result.text);
+        }
+        this.showTranscriptionToast(result.text, result.durationMs);
       }
     } catch (err) {
       console.error('Voice toggle failed:', err);
+      if (this.voicePollInterval) {
+        clearInterval(this.voicePollInterval);
+        this.voicePollInterval = null;
+      }
       this.updateMicButtonState('idle');
     }
   }
@@ -1182,6 +1202,38 @@ export class App {
       state === 'recording' ? 'Stop recording (Ctrl+Shift+M)' :
       'Transcribing...'
     );
+  }
+
+  private updateMicLevel(rms: number, durationMs: number): void {
+    const levelBar = document.querySelector('.mic-level-bar') as HTMLElement;
+    const timer = document.querySelector('.mic-timer') as HTMLElement;
+    if (levelBar) {
+      // Scale RMS (typically 0-0.3) to height percentage
+      const height = Math.min(100, rms * 300);
+      levelBar.style.height = `${height}%`;
+    }
+    if (timer) {
+      const secs = Math.floor(durationMs / 1000);
+      const mins = Math.floor(secs / 60);
+      const remainder = secs % 60;
+      timer.textContent = `${mins}:${String(remainder).padStart(2, '0')}`;
+    }
+  }
+
+  private showTranscriptionToast(text: string, durationMs: number): void {
+    // Remove any existing toast
+    document.querySelector('.mic-toast')?.remove();
+
+    const toast = document.createElement('div');
+    toast.className = 'mic-toast';
+    const speed = durationMs > 0 ? `${durationMs}ms` : '';
+    toast.textContent = text ? `"${text.slice(0, 50)}${text.length > 50 ? '...' : ''}" ${speed}` : '(no speech detected)';
+
+    const micBtn = document.querySelector('.mic-btn');
+    if (micBtn) {
+      micBtn.parentElement?.appendChild(toast);
+      setTimeout(() => toast.remove(), 3000);
+    }
   }
 
   private async createNewTerminal(): Promise<string | null> {

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -66,6 +66,18 @@ export class TabBar {
     micBtn.setAttribute('role', 'button');
     micBtn.setAttribute('aria-label', 'Toggle voice recording');
     micBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>`;
+    // Recording overlay (level bar + timer)
+    const micOverlay = document.createElement('div');
+    micOverlay.className = 'mic-overlay';
+    const micLevelBar = document.createElement('div');
+    micLevelBar.className = 'mic-level-bar';
+    micOverlay.appendChild(micLevelBar);
+    const micTimer = document.createElement('div');
+    micTimer.className = 'mic-timer';
+    micTimer.textContent = '0:00';
+    micOverlay.appendChild(micTimer);
+    micBtn.appendChild(micOverlay);
+
     micBtn.addEventListener('click', () => {
       document.dispatchEvent(new CustomEvent('voice-toggle-recording'));
     });

--- a/src/plugins/voice/whisper-service.ts
+++ b/src/plugins/voice/whisper-service.ts
@@ -36,8 +36,23 @@ export async function whisperStartRecording(): Promise<void> {
   return invoke<void>('whisper_start_recording');
 }
 
-export async function whisperStopRecording(): Promise<string> {
-  return invoke<string>('whisper_stop_recording');
+export interface TranscriptionResult {
+  text: string;
+  durationMs: number;
+}
+
+export async function whisperStopRecording(): Promise<TranscriptionResult> {
+  return invoke<TranscriptionResult>('whisper_stop_recording');
+}
+
+export interface AudioLevelInfo {
+  rms: number;
+  peak: number;
+  durationMs: number;
+}
+
+export async function whisperGetAudioLevel(): Promise<AudioLevelInfo> {
+  return invoke<AudioLevelInfo>('whisper_get_audio_level');
 }
 
 export async function whisperLoadModel(

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2080,6 +2080,64 @@ body.dragging-active * {
   100% { transform: rotate(360deg); }
 }
 
+.mic-overlay {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  pointer-events: none;
+}
+
+.mic-btn.mic-recording .mic-overlay {
+  display: flex;
+}
+
+.mic-level-bar {
+  width: 3px;
+  height: 0%;
+  max-height: 30px;
+  background: var(--accent);
+  border-radius: 1.5px;
+  transition: height 0.06s ease-out;
+}
+
+.mic-timer {
+  font-family: monospace;
+  font-size: 9px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.mic-toast {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  right: 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  animation: mic-toast-fade 3s ease-in-out forwards;
+  pointer-events: none;
+  z-index: 100;
+}
+
+@keyframes mic-toast-fade {
+  0% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
 /* Voice plugin settings */
 .voice-plugin-settings .plugin-settings-section {
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary

- Add real-time audio level metering during voice recording (RMS + peak via `GetAudioLevel` protocol message)
- Add recording overlay on mic button showing level bar and elapsed timer
- Show transcription toast with result text and processing duration after recording stops
- Change `whisper_stop_recording` to return `TranscriptionResult` with duration metadata

## Changes

### Backend (Rust)
- **Protocol**: Add `GetAudioLevel` request and `AudioLevel { rms, peak, duration_ms }` response
- **AudioRecorder**: Add `recording_start` field, `current_levels()` (last ~50ms RMS/peak), `recording_duration_ms()`
- **Pipe server**: Handle `GetAudioLevel` request
- **Tauri commands**: Add `whisper_get_audio_level` command, change `whisper_stop_recording` to return `TranscriptionResult`

### Frontend (TypeScript)
- **whisper-service.ts**: Add `TranscriptionResult` and `AudioLevelInfo` types, update function signatures
- **App.ts**: Poll audio levels every 60ms during recording, update level bar + timer, show toast on completion
- **TabBar.ts**: Add recording overlay DOM elements (level bar + timer) inside mic button
- **main.css**: Styles for overlay, level bar, timer, toast with fade animation

## Verification
- `cargo check -p godly-protocol` -- pass
- `cargo check -p godly-whisper` -- pass

## Test plan
- [ ] Start recording and verify level bar animates with mic input
- [ ] Verify timer counts up during recording
- [ ] Stop recording and verify toast appears with transcription text
- [ ] Verify toast auto-dismisses after 3s
- [ ] Test error path (recording fails) -- mic button returns to idle