### PR TITLE
feat: add @ file/folder path autocomplete to Quick Claude

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -157,6 +157,56 @@ pub fn save_clipboard_image(image_data: Vec<u8>, extension: String) -> Result<St
         .ok_or_else(|| "Invalid path encoding".to_string())
 }
 
+#[derive(serde::Serialize, Clone, Debug)]
+pub struct DirEntry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+const EXCLUDED_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    ".next",
+    "dist",
+    "build",
+    "__pycache__",
+    ".tox",
+    ".venv",
+    "venv",
+    ".cache",
+];
+
+#[tauri::command]
+pub fn list_directory(path: String) -> Vec<DirEntry> {
+    let dir = PathBuf::from(&path);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut results: Vec<DirEntry> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+            if is_dir && EXCLUDED_DIRS.contains(&name.as_str()) {
+                return None;
+            }
+            Some(DirEntry { name, is_dir })
+        })
+        .collect();
+
+    // Sort: directories first, then files, each group alphabetical (case-insensitive)
+    results.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+
+    results
+}
+
 #[tauri::command]
 pub fn get_user_claude_md_path() -> Result<String, String> {
     let home = std::env::var("USERPROFILE")
@@ -336,5 +386,69 @@ mod tests {
             "Bug #292: Expected 'global-command' from ~/.claude/commands/ but got: {:?}",
             names
         );
+    }
+
+    // -- list_directory tests --
+
+    #[test]
+    fn list_directory_sorts_dirs_first_then_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join("src")).unwrap();
+        fs::create_dir(root.join("docs")).unwrap();
+        fs::write(root.join("README.md"), "").unwrap();
+        fs::write(root.join("app.ts"), "").unwrap();
+
+        let entries = list_directory(root.to_string_lossy().to_string());
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+
+        // Dirs first (alphabetical), then files (alphabetical)
+        assert_eq!(names, vec!["docs", "src", "app.ts", "README.md"]);
+        assert!(entries[0].is_dir);
+        assert!(entries[1].is_dir);
+        assert!(!entries[2].is_dir);
+        assert!(!entries[3].is_dir);
+    }
+
+    #[test]
+    fn list_directory_excludes_noise_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join("src")).unwrap();
+        fs::create_dir(root.join("node_modules")).unwrap();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::create_dir(root.join("target")).unwrap();
+        fs::write(root.join("index.ts"), "").unwrap();
+
+        let entries = list_directory(root.to_string_lossy().to_string());
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"src"));
+        assert!(names.contains(&"index.ts"));
+        assert!(!names.contains(&"node_modules"));
+        assert!(!names.contains(&".git"));
+        assert!(!names.contains(&"target"));
+    }
+
+    #[test]
+    fn list_directory_returns_empty_for_nonexistent_path() {
+        let entries = list_directory("/nonexistent/path/that/does/not/exist".to_string());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn list_directory_reads_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let sub = root.join("src").join("components");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("App.ts"), "").unwrap();
+        fs::write(sub.join("Header.ts"), "").unwrap();
+        fs::create_dir(sub.join("utils")).unwrap();
+
+        let entries = list_directory(sub.to_string_lossy().to_string());
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+
+        assert_eq!(names, vec!["utils", "App.ts", "Header.ts"]);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -614,6 +614,7 @@ pub fn run() {
             commands::remove_worktree,
             commands::cleanup_all_worktrees,
             commands::list_skills,
+            commands::list_directory,
             commands::read_file,
             commands::write_file,
             commands::get_user_claude_md_path,

--- a/src/components/dialogs.file-autocomplete.test.ts
+++ b/src/components/dialogs.file-autocomplete.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for @ file/folder autocomplete in the Quick Claude dialog.
+ *
+ * Typing @ in the textarea triggers a file browser dropdown that lists
+ * directory contents from the selected workspace root. Directories appear
+ * first with trailing /. Selecting a dir navigates into it; selecting a
+ * file inserts the full path and closes the dropdown.
+ */
+
+// ── Mock data ────────────────────────────────────────────────────────────
+
+const ROOT_ENTRIES = [
+  { name: 'src', is_dir: true },
+  { name: 'docs', is_dir: true },
+  { name: 'App.ts', is_dir: false },
+  { name: 'package.json', is_dir: false },
+];
+
+const SRC_ENTRIES = [
+  { name: 'components', is_dir: true },
+  { name: 'index.ts', is_dir: false },
+  { name: 'utils.ts', is_dir: false },
+];
+
+const WORKSPACES = [
+  { id: 'ws-a', name: 'Project Alpha', folderPath: '/projects/alpha' },
+  { id: 'ws-b', name: 'Project Beta', folderPath: '/projects/beta' },
+];
+
+const WORKSPACE_A_SKILLS = [
+  { name: 'deploy', description: 'Deploy', usage: '/deploy', source: 'project' },
+];
+
+// ── Setup ────────────────────────────────────────────────────────────────
+
+let mockInvoke: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+
+  mockInvoke = vi.fn(async (cmd: string, args?: Record<string, unknown>) => {
+    if (cmd === 'list_directory') {
+      const path = args?.path as string;
+      if (path === '/projects/alpha') return ROOT_ENTRIES;
+      if (path === '/projects/alpha/src') return SRC_ENTRIES;
+      if (path === '/projects/beta') return [
+        { name: 'lib', is_dir: true },
+        { name: 'main.rs', is_dir: false },
+      ];
+      return [];
+    }
+    if (cmd === 'list_skills') return WORKSPACE_A_SKILLS;
+    return null;
+  });
+
+  vi.doMock('@tauri-apps/api/core', () => ({ invoke: mockInvoke }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('@tauri-apps/api/core');
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+async function openDialog() {
+  const { showQuickClaudeDialog } = await import('./dialogs');
+  const resultPromise = showQuickClaudeDialog({
+    workspaces: WORKSPACES,
+    activeWorkspaceId: 'ws-a',
+  });
+
+  await vi.dynamicImportSettled?.() ?? new Promise(r => setTimeout(r, 0));
+
+  const overlay = document.querySelector('.dialog-overlay') as HTMLDivElement;
+  const promptArea = overlay.querySelector('textarea.dialog-input') as HTMLTextAreaElement;
+  const workspaceSelect = overlay.querySelector('select') as HTMLSelectElement;
+  const fileDropdown = overlay.querySelector('.file-dropdown') as HTMLDivElement;
+
+  return { resultPromise, overlay, promptArea, workspaceSelect, fileDropdown };
+}
+
+function getFileNames(dropdown: HTMLDivElement): string[] {
+  return Array.from(dropdown.querySelectorAll('.file-item-name'))
+    .map(el => el.textContent ?? '');
+}
+
+async function typeAt(promptArea: HTMLTextAreaElement, value = '@') {
+  promptArea.value = value;
+  promptArea.selectionStart = value.length;
+  promptArea.selectionEnd = value.length;
+  promptArea.dispatchEvent(new Event('input', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 50));
+}
+
+function pressKey(el: HTMLElement, key: string, opts: Record<string, boolean> = {}) {
+  el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...opts }));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('Quick Claude @ file autocomplete', () => {
+  it('shows root listing when typing @, dirs first with trailing /', async () => {
+    const { promptArea, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea);
+
+    expect(fileDropdown.style.display).not.toBe('none');
+    const names = getFileNames(fileDropdown);
+    // Dirs first (with /), then files
+    expect(names[0]).toBe('src/');
+    expect(names[1]).toBe('docs/');
+    expect(names[2]).toBe('App.ts');
+    expect(names[3]).toBe('package.json');
+  });
+
+  it('selecting a directory navigates into it', async () => {
+    const { promptArea, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea);
+
+    // Click the "src/" item
+    const srcItem = fileDropdown.querySelector('.file-item') as HTMLDivElement;
+    srcItem.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await new Promise(r => setTimeout(r, 50));
+
+    // Textarea should now have @src/
+    expect(promptArea.value).toBe('@src/');
+    // Dropdown should refresh to show src/ contents
+    const names = getFileNames(fileDropdown);
+    expect(names).toContain('components/');
+    expect(names).toContain('index.ts');
+  });
+
+  it('selecting a file inserts full path + space and closes dropdown', async () => {
+    const { promptArea, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea);
+
+    // Find the App.ts item (3rd item, 0-indexed: index 2)
+    const items = fileDropdown.querySelectorAll('.file-item');
+    const appItem = items[2] as HTMLDivElement;
+    appItem.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(promptArea.value).toBe('@App.ts ');
+    expect(fileDropdown.style.display).toBe('none');
+  });
+
+  it('filters entries by substring match', async () => {
+    const { promptArea, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea, '@App');
+
+    const names = getFileNames(fileDropdown);
+    expect(names).toContain('App.ts');
+    expect(names).not.toContain('package.json');
+    expect(names).not.toContain('src/');
+  });
+
+  it('Escape closes file dropdown', async () => {
+    const { promptArea, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea);
+    expect(fileDropdown.style.display).not.toBe('none');
+
+    pressKey(promptArea, 'Escape');
+    expect(fileDropdown.style.display).toBe('none');
+  });
+
+  it('arrow keys navigate and Tab selects', async () => {
+    const { promptArea, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea);
+
+    // First item (src/) should be highlighted by default
+    let activeItems = fileDropdown.querySelectorAll('.file-item-active');
+    expect(activeItems.length).toBe(1);
+    expect(activeItems[0].querySelector('.file-item-name')?.textContent).toBe('src/');
+
+    // ArrowDown to move to second item (docs/)
+    pressKey(promptArea, 'ArrowDown');
+    activeItems = fileDropdown.querySelectorAll('.file-item-active');
+    expect(activeItems[0].querySelector('.file-item-name')?.textContent).toBe('docs/');
+
+    // ArrowUp back to first
+    pressKey(promptArea, 'ArrowUp');
+    activeItems = fileDropdown.querySelectorAll('.file-item-active');
+    expect(activeItems[0].querySelector('.file-item-name')?.textContent).toBe('src/');
+
+    // Tab to select the current item (src/) — should navigate into it
+    pressKey(promptArea, 'Tab');
+    await new Promise(r => setTimeout(r, 50));
+    expect(promptArea.value).toBe('@src/');
+  });
+
+  it('workspace change clears cache and re-fetches', async () => {
+    const { promptArea, workspaceSelect, fileDropdown } = await openDialog();
+
+    await typeAt(promptArea);
+    expect(mockInvoke).toHaveBeenCalledWith('list_directory', { path: '/projects/alpha' });
+
+    // Change workspace
+    workspaceSelect.value = 'ws-b';
+    workspaceSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    await new Promise(r => setTimeout(r, 50));
+
+    // Should have fetched from the new workspace
+    expect(mockInvoke).toHaveBeenCalledWith('list_directory', { path: '/projects/beta' });
+    const names = getFileNames(fileDropdown);
+    expect(names).toContain('lib/');
+    expect(names).toContain('main.rs');
+  });
+});

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -286,7 +286,7 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
 
     const promptArea = document.createElement('textarea');
     promptArea.className = 'dialog-input';
-    promptArea.placeholder = 'Describe your idea... (type / for skills)';
+    promptArea.placeholder = 'Describe your idea... (/ for skills, @ for files)';
     promptArea.rows = 4;
     promptArea.style.cssText = 'resize: vertical; min-height: 80px; font-family: inherit; font-size: 13px;';
     promptWrapper.appendChild(promptArea);
@@ -295,6 +295,11 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
     skillDropdown.className = 'skill-dropdown';
     skillDropdown.style.display = 'none';
     promptWrapper.appendChild(skillDropdown);
+
+    const fileDropdown = document.createElement('div');
+    fileDropdown.className = 'file-dropdown';
+    fileDropdown.style.display = 'none';
+    promptWrapper.appendChild(fileDropdown);
 
     dialog.appendChild(promptWrapper);
 
@@ -399,14 +404,145 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
       renderDropdown(filtered, activeIndex);
     }
 
-    promptArea.addEventListener('input', refreshSkillDropdown);
+    promptArea.addEventListener('input', () => {
+      refreshSkillDropdown();
+      refreshFileDropdown();
+    });
 
     workspaceSelect.addEventListener('change', () => {
       const before = promptArea.value.slice(0, promptArea.selectionStart);
       if (dropdownVisible || before.match(/(^|[\s\n])\/([\w-]*)$/)) {
         refreshSkillDropdown();
       }
+      // Clear file cache and refresh if file dropdown is active
+      dirCache.clear();
+      if (fileDropdownVisible) {
+        refreshFileDropdown();
+      }
     });
+
+    // -- File autocomplete state --
+    interface DirEntryInfo { name: string; is_dir: boolean }
+    const dirCache = new Map<string, DirEntryInfo[]>();
+    let activeFiles: DirEntryInfo[] = [];
+    let fileActiveIndex = -1;
+    let fileDropdownVisible = false;
+
+    async function fetchDirEntries(dirPath: string): Promise<DirEntryInfo[]> {
+      const wsId = workspaceSelect.value;
+      const cacheKey = `${wsId}:${dirPath}`;
+      if (dirCache.has(cacheKey)) return dirCache.get(cacheKey)!;
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const entries = await invoke<DirEntryInfo[]>('list_directory', { path: dirPath });
+        dirCache.set(cacheKey, entries);
+        return entries;
+      } catch {
+        return [];
+      }
+    }
+
+    function renderFileDropdown(entries: DirEntryInfo[], highlightIndex: number) {
+      fileDropdown.innerHTML = '';
+      if (entries.length === 0) {
+        hideFileDropdown();
+        return;
+      }
+      entries.forEach((entry, i) => {
+        const item = document.createElement('div');
+        item.className = 'file-item' + (i === highlightIndex ? ' file-item-active' : '');
+        const icon = document.createElement('span');
+        icon.className = 'file-item-icon';
+        icon.textContent = entry.is_dir ? '\uD83D\uDCC1' : '\uD83D\uDCC4';
+        const nameEl = document.createElement('span');
+        nameEl.className = 'file-item-name';
+        nameEl.textContent = entry.name + (entry.is_dir ? '/' : '');
+        item.appendChild(icon);
+        item.appendChild(nameEl);
+        item.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+          selectFile(entry);
+        });
+        item.addEventListener('mouseenter', () => {
+          fileActiveIndex = i;
+          updateFileHighlight();
+        });
+        fileDropdown.appendChild(item);
+      });
+      fileDropdown.style.display = '';
+      fileDropdownVisible = true;
+    }
+
+    function updateFileHighlight() {
+      const items = fileDropdown.querySelectorAll('.file-item');
+      items.forEach((el, i) => {
+        el.classList.toggle('file-item-active', i === fileActiveIndex);
+        if (i === fileActiveIndex) el.scrollIntoView?.({ block: 'nearest' });
+      });
+    }
+
+    function hideFileDropdown() {
+      fileDropdown.style.display = 'none';
+      fileDropdownVisible = false;
+      fileActiveIndex = -1;
+      activeFiles = [];
+    }
+
+    function selectFile(entry: DirEntryInfo) {
+      const val = promptArea.value;
+      const cursor = promptArea.selectionStart;
+      const before = val.slice(0, cursor);
+      const atMatch = before.match(/(^|[\s\n])@([\w./_-]*)$/);
+      if (!atMatch) { hideFileDropdown(); return; }
+      const atStart = before.lastIndexOf('@');
+      const currentPath = atMatch[2];
+      const lastSlash = currentPath.lastIndexOf('/');
+      const dirPrefix = lastSlash >= 0 ? currentPath.slice(0, lastSlash + 1) : '';
+
+      if (entry.is_dir) {
+        const newPath = dirPrefix + entry.name + '/';
+        promptArea.value = val.slice(0, atStart) + '@' + newPath + val.slice(cursor);
+        const newPos = atStart + 1 + newPath.length;
+        promptArea.setSelectionRange(newPos, newPos);
+        promptArea.focus();
+        refreshFileDropdown();
+      } else {
+        const fullPath = dirPrefix + entry.name;
+        promptArea.value = val.slice(0, atStart) + '@' + fullPath + ' ' + val.slice(cursor);
+        const newPos = atStart + 1 + fullPath.length + 1;
+        promptArea.setSelectionRange(newPos, newPos);
+        hideFileDropdown();
+        promptArea.focus();
+      }
+    }
+
+    async function refreshFileDropdown() {
+      const val = promptArea.value;
+      const cursor = promptArea.selectionStart;
+      const before = val.slice(0, cursor);
+      const atMatch = before.match(/(^|[\s\n])@([\w./_-]*)$/);
+      if (!atMatch) {
+        hideFileDropdown();
+        return;
+      }
+      const currentPath = atMatch[2];
+      const lastSlash = currentPath.lastIndexOf('/');
+      const dirPart = lastSlash >= 0 ? currentPath.slice(0, lastSlash) : '';
+      const filterPart = lastSlash >= 0 ? currentPath.slice(lastSlash + 1) : currentPath;
+
+      const ws = options.workspaces.find(w => w.id === workspaceSelect.value);
+      if (!ws) { hideFileDropdown(); return; }
+
+      const fullDirPath = dirPart ? `${ws.folderPath}/${dirPart}` : ws.folderPath;
+      const entries = await fetchDirEntries(fullDirPath);
+      const filtered = filterPart
+        ? entries.filter(e => e.name.toLowerCase().includes(filterPart.toLowerCase()))
+        : entries;
+
+      activeFiles = filtered;
+      fileActiveIndex = filtered.length > 0 ? 0 : -1;
+      renderFileDropdown(filtered, fileActiveIndex);
+    }
 
     // -- Image attachments (drag-and-drop) --
     const attachedImages: string[] = [];
@@ -670,6 +806,32 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
             selectSkill(activeSkills[activeIndex]);
             return;
           }
+        }
+      }
+      if (fileDropdownVisible) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          fileActiveIndex = Math.min(fileActiveIndex + 1, activeFiles.length - 1);
+          updateFileHighlight();
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          fileActiveIndex = Math.max(fileActiveIndex - 1, 0);
+          updateFileHighlight();
+          return;
+        }
+        if ((e.key === 'Enter' || e.key === 'Tab') && !e.ctrlKey) {
+          if (fileActiveIndex >= 0 && fileActiveIndex < activeFiles.length) {
+            e.preventDefault();
+            selectFile(activeFiles[fileActiveIndex]);
+            return;
+          }
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          hideFileDropdown();
+          return;
         }
       }
       if (e.key === 'Enter' && e.ctrlKey) { e.preventDefault(); submit(); }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -600,6 +600,49 @@ body.dragging-active * {
   white-space: nowrap;
 }
 
+/* File autocomplete dropdown */
+.file-dropdown {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  z-index: 100;
+  margin-top: 4px;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.file-item:hover,
+.file-item-active {
+  background: var(--bg-active);
+}
+
+.file-item-icon {
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.file-item-name {
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Shell type selection */
 .shell-type-options {
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary

Adds `@` file/folder path autocomplete to the Quick Claude dialog, mirroring the existing `/` skill autocomplete. Typing `@` triggers a dropdown showing files and folders in the active workspace's directory, with directory navigation, substring filtering, and keyboard support.

### Changes

- **Backend** (`src-tauri/src/commands/files.rs`): New `list_directory` Tauri command returning `DirEntry` structs, with excluded noise directories (node_modules, .git, target, etc.) and dirs-first alphabetical sorting
- **Backend** (`src-tauri/src/lib.rs`): Register `list_directory` in the invoke handler
- **Frontend** (`src/components/dialogs.ts`): File autocomplete dropdown with directory navigation (selecting a dir drills in), file selection (inserts `@path` into prompt), per-(workspace, dirPath) caching, and full keyboard navigation (Arrow Up/Down, Enter/Tab to select, Escape to dismiss)
- **Styles** (`src/styles/main.css`): `.file-dropdown`, `.file-item`, `.file-item-active`, `.file-item-icon`, `.file-item-name` styles matching the existing skill dropdown
- **Tests** (`src/components/dialogs.file-autocomplete.test.ts`): 7 unit tests covering root listing, directory navigation, file selection with path insertion, substring filtering, Escape dismissal, Arrow/Tab keyboard navigation, and workspace-change cache clearing

### Testing

- All 12 frontend tests pass (7 new file-autocomplete + 5 existing skill-autocomplete)
- 4 Rust unit tests for `list_directory` (dirs-first sorting, noise exclusion, nonexistent path, subdirectory reads)