### PR TITLE
fix: whisper test recording shows [object Object] instead of text

### DIFF
--- a/changelog/unreleased/442-fix-whisper-object-object.md
+++ b/changelog/unreleased/442-fix-whisper-object-object.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Whisper test recording shows [object Object]** — The "Test Recording" button in settings and the Quick Claude voice input displayed `[object Object]` instead of the transcribed text because `whisperStopRecording()` returns a `TranscriptionResult` object, not a string. (#442)
+
+### Tests
+
+- **Fixed whisper test mocks** — Test mocks for `whisperStopRecording` now return `TranscriptionResult { text, durationMs }` matching the real return type. Added regression test that exercises the test recording button and verifies the displayed text.

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -787,10 +787,10 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
         } else if (status.state === 'recording') {
           voiceBtn.textContent = '...';
           voiceBtn.classList.remove('voice-recording');
-          const text = await whisperStopRecording();
+          const result = await whisperStopRecording();
           voiceBtn.textContent = 'Voice';
-          if (text) {
-            promptArea.value += (promptArea.value ? ' ' : '') + text;
+          if (result.text) {
+            promptArea.value += (promptArea.value ? ' ' : '') + result.text;
             promptArea.dispatchEvent(new Event('input'));
           }
         }

--- a/src/plugins/voice/index.ts
+++ b/src/plugins/voice/index.ts
@@ -507,8 +507,8 @@ export class VoiceToTextPlugin implements GodlyPlugin {
         await whisperStartRecording();
         await new Promise(resolve => setTimeout(resolve, 3000));
         testBtn.textContent = 'Transcribing...';
-        const text = await whisperStopRecording();
-        testResult.textContent = text ? `"${text}"` : '(no speech detected)';
+        const result = await whisperStopRecording();
+        testResult.textContent = result.text ? `"${result.text}"` : '(no speech detected)';
         testResult.style.color = 'var(--accent)';
         // Enable playback after successful recording
         playBtn.disabled = false;

--- a/src/plugins/voice/voice-plugin.test.ts
+++ b/src/plugins/voice/voice-plugin.test.ts
@@ -25,7 +25,10 @@ vi.mock('./whisper-service', () => ({
   whisperStartSidecar: vi.fn().mockResolvedValue('started'),
   whisperRestartSidecar: vi.fn().mockResolvedValue('restarted'),
   whisperStartRecording: vi.fn().mockResolvedValue(undefined),
-  whisperStopRecording: vi.fn().mockResolvedValue('test text'),
+  whisperStopRecording: vi.fn().mockResolvedValue({ text: 'test text', durationMs: 1200 }),
+  listGpuDevices: vi.fn().mockResolvedValue([]),
+  whisperListAudioDevices: vi.fn().mockResolvedValue([]),
+  whisperPlaybackRecording: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock Tauri event listener
@@ -88,5 +91,28 @@ describe('VoiceToTextPlugin', () => {
     plugin.destroy();
     expect(mockUnlisten).toHaveBeenCalled();
     expect((plugin as any).progressUnlisten).toBeNull();
+  });
+
+  it('test recording button displays transcription text, not [object Object]', async () => {
+    // Bug: whisperStopRecording returns TranscriptionResult { text, durationMs }
+    // but the UI was interpolating the whole object as a string → "[object Object]"
+    const el = plugin.renderSettings();
+    const buttons = el.querySelectorAll('button');
+    const testBtn = Array.from(buttons).find(b => b.textContent === 'Test Recording (3s)');
+    expect(testBtn).toBeDefined();
+
+    // Click the test recording button
+    testBtn!.click();
+
+    // Wait for recording (3s timeout) + transcription to complete
+    // The mock resolves immediately so we just need to flush promises
+    await vi.waitFor(() => {
+      const spans = el.querySelectorAll('span[style*="monospace"]');
+      const resultSpan = Array.from(spans).find(s => s.textContent && s.textContent.length > 0);
+      expect(resultSpan).toBeDefined();
+      // Must show the actual text, never [object Object]
+      expect(resultSpan!.textContent).not.toContain('[object Object]');
+      expect(resultSpan!.textContent).toBe('"test text"');
+    }, { timeout: 5000 });
   });
 });

--- a/src/plugins/voice/whisper-service.test.ts
+++ b/src/plugins/voice/whisper-service.test.ts
@@ -37,11 +37,13 @@ describe('whisper-service', () => {
     expect(mockInvoke).toHaveBeenCalledWith('whisper_start_recording');
   });
 
-  it('whisperStopRecording invokes correct command', async () => {
-    mockInvoke.mockResolvedValue('hello world');
+  it('whisperStopRecording invokes correct command and returns TranscriptionResult', async () => {
+    mockInvoke.mockResolvedValue({ text: 'hello world', durationMs: 1500 });
     const result = await whisperStopRecording();
     expect(mockInvoke).toHaveBeenCalledWith('whisper_stop_recording');
-    expect(result).toBe('hello world');
+    expect(result).toEqual({ text: 'hello world', durationMs: 1500 });
+    expect(result.text).toBe('hello world');
+    expect(result.durationMs).toBe(1500);
   });
 
   it('whisperLoadModel invokes with correct args', async () => {


### PR DESCRIPTION
## Summary

- **Settings "Test Recording" button** and **Quick Claude voice input** displayed `"[object Object]"` instead of the transcribed text
- `whisperStopRecording()` returns `TranscriptionResult { text, durationMs }` — two callers were interpolating the whole object as a string instead of accessing `.text`
- Test mocks returned plain strings instead of `TranscriptionResult`, masking the type mismatch

## Changes

- `src/plugins/voice/index.ts` — use `result.text` for settings test recording display
- `src/components/dialogs.ts` — use `result.text` for Quick Claude voice input
- `src/plugins/voice/whisper-service.test.ts` — mock returns proper `TranscriptionResult` object
- `src/plugins/voice/voice-plugin.test.ts` — fixed mock + added regression test that clicks the test recording button and verifies `"test text"` is displayed (not `[object Object]`)

## Test plan

- [x] New regression test: clicks "Test Recording", asserts displayed text is `"test text"` not `[object Object]`
- [x] All 1080 frontend unit tests pass
- [x] Whisper service tests updated with correct `TranscriptionResult` mock shape

fixes #442