### PR TITLE
refactor: extract daemon handlers into individual files

### DIFF
--- a/changelog/unreleased/ocp-daemon-handler-extraction.md
+++ b/changelog/unreleased/ocp-daemon-handler-extraction.md
@@ -1,0 +1,2 @@
+### Changed
+- **Refactored daemon handlers** — Extracted 19 request handlers from server.rs into individual files with HandlerContext for better code organization

--- a/src-tauri/daemon/src/handlers/attach.rs
+++ b/src-tauri/daemon/src/handlers/attach.rs
@@ -1,0 +1,112 @@
+use std::sync::atomic::Ordering;
+
+use godly_protocol::{DaemonMessage, Event, Response};
+
+use crate::debug_log::daemon_log;
+
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    let sessions_guard = ctx.sessions.read();
+    match sessions_guard.get(session_id) {
+        Some(session) => {
+            let is_already_dead = !session.is_running();
+            let (buffer, mut rx) = session.attach();
+            ctx.attached_sessions.write().push(session_id.to_string());
+
+            // Spawn a task to forward live output as events.
+            // When the channel closes, check if the PTY exited (running == false)
+            // and send SessionClosed so the client knows the process is dead.
+            let tx = ctx.msg_tx.clone();
+            let sid = session_id.to_string();
+            let running_flag = session.running_flag();
+            let session_exit_code = session.exit_code();
+            let exit_code_arc = session.exit_code_arc();
+            tokio::spawn(async move {
+                // Bug A2 fix: if the session is already dead when we attach,
+                // send SessionClosed immediately. The reader thread and child
+                // monitor are already gone, so the output channel will never
+                // close on its own — rx.recv() would block forever.
+                if is_already_dead {
+                    daemon_log!(
+                        "Session {} already dead at attach time, sending SessionClosed (exit_code={:?})",
+                        sid,
+                        session_exit_code
+                    );
+                    let _ = tx
+                        .send(DaemonMessage::Event(Event::SessionClosed {
+                            session_id: sid,
+                            exit_code: session_exit_code,
+                        }))
+                        .await;
+                    return;
+                }
+
+                while let Some(output) = rx.recv().await {
+                    let event = match output {
+                        crate::session::SessionOutput::RawBytes(data) => {
+                            DaemonMessage::Event(Event::Output {
+                                session_id: sid.clone(),
+                                data,
+                            })
+                        }
+                        crate::session::SessionOutput::GridDiff(diff) => {
+                            DaemonMessage::Event(Event::GridDiff {
+                                session_id: sid.clone(),
+                                diff,
+                            })
+                        }
+                        crate::session::SessionOutput::Bell => {
+                            DaemonMessage::Event(Event::Bell {
+                                session_id: sid.clone(),
+                            })
+                        }
+                    };
+                    if tx.send(event).await.is_err() {
+                        break;
+                    }
+                }
+                // Channel closed — check why:
+                // - running == false → PTY exited → notify client
+                // - running == true  → client detached → session still alive, don't notify
+                if !running_flag.load(Ordering::Relaxed) {
+                    let code = {
+                        let raw = exit_code_arc.load(Ordering::Relaxed);
+                        if raw == i64::MIN { None } else { Some(raw) }
+                    };
+                    daemon_log!("Session {} PTY exited, sending SessionClosed (exit_code={:?})", sid, code);
+                    let _ = tx
+                        .send(DaemonMessage::Event(Event::SessionClosed {
+                            session_id: sid,
+                            exit_code: code,
+                        }))
+                        .await;
+                }
+            });
+
+            eprintln!(
+                "[daemon] Attached to session {} (buffer: {} bytes)",
+                session_id,
+                buffer.len()
+            );
+            daemon_log!(
+                "Attached to session {} (buffer: {} bytes)",
+                session_id,
+                buffer.len()
+            );
+
+            // Return buffered data for replay
+            if buffer.is_empty() {
+                Response::Ok
+            } else {
+                Response::Buffer {
+                    session_id: session_id.to_string(),
+                    data: buffer,
+                }
+            }
+        }
+        None => Response::Error {
+            message: format!("Session {} not found", session_id),
+        },
+    }
+}

--- a/src-tauri/daemon/src/handlers/close_session.rs
+++ b/src-tauri/daemon/src/handlers/close_session.rs
@@ -1,0 +1,27 @@
+use godly_protocol::Response;
+
+use crate::debug_log::daemon_log;
+
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    let mut sessions_guard = ctx.sessions.write();
+    match sessions_guard.remove(session_id) {
+        Some(session) => {
+            session.close();
+            ctx.attached_sessions.write().retain(|id| id != session_id);
+            let remaining = sessions_guard.len();
+            eprintln!("[daemon] Closed session {}", session_id);
+            daemon_log!(
+                "Closed session {} (remaining sessions: {})",
+                session_id,
+                remaining
+            );
+            crate::server::log_memory_usage(&format!("session_close({})", remaining));
+            Response::Ok
+        }
+        None => Response::Error {
+            message: format!("Session {} not found", session_id),
+        },
+    }
+}

--- a/src-tauri/daemon/src/handlers/context.rs
+++ b/src-tauri/daemon/src/handlers/context.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+
+use godly_protocol::{DaemonMessage, Response};
+
+use crate::session::DaemonSession;
+
+/// Shared context passed to all async request handlers.
+pub struct HandlerContext {
+    pub sessions: Arc<RwLock<HashMap<String, DaemonSession>>>,
+    pub msg_tx: mpsc::Sender<DaemonMessage>,
+    pub attached_sessions: Arc<RwLock<Vec<String>>>,
+}
+
+/// Helper: look up a session by ID, returning an error response if not found.
+/// The closure receives the sessions read-guard and the session reference.
+pub fn with_session<F>(ctx: &HandlerContext, session_id: &str, f: F) -> Response
+where
+    F: FnOnce(&DaemonSession) -> Response,
+{
+    let sessions_guard = ctx.sessions.read();
+    match sessions_guard.get(session_id) {
+        Some(session) => f(session),
+        None => Response::Error {
+            message: format!("Session {} not found", session_id),
+        },
+    }
+}

--- a/src-tauri/daemon/src/handlers/create_session.rs
+++ b/src-tauri/daemon/src/handlers/create_session.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+use godly_protocol::Response;
+
+use crate::debug_log::daemon_log;
+use crate::session::DaemonSession;
+
+use super::HandlerContext;
+
+pub async fn handle(
+    ctx: &HandlerContext,
+    id: &str,
+    shell_type: &godly_protocol::ShellType,
+    cwd: &Option<String>,
+    rows: u16,
+    cols: u16,
+    env: &Option<HashMap<String, String>>,
+) -> Response {
+    match DaemonSession::new(id.to_string(), shell_type.clone(), cwd.clone(), rows, cols, env.clone()) {
+        Ok(session) => {
+            let info = session.info();
+            ctx.sessions.write().insert(id.to_string(), session);
+            let session_count = ctx.sessions.read().len();
+            eprintln!("[daemon] Created session {}", id);
+            daemon_log!("Created session {} (total sessions: {})", id, session_count);
+            crate::server::log_memory_usage(&format!("session_create({})", session_count));
+            Response::SessionCreated { session: info }
+        }
+        Err(e) => {
+            eprintln!("[daemon] Failed to create session {}: {}", id, e);
+            daemon_log!("Failed to create session {}: {}", id, e);
+            Response::Error { message: e }
+        }
+    }
+}

--- a/src-tauri/daemon/src/handlers/detach.rs
+++ b/src-tauri/daemon/src/handlers/detach.rs
@@ -1,0 +1,16 @@
+use godly_protocol::Response;
+
+use crate::debug_log::daemon_log;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        session.detach();
+        ctx.attached_sessions.write().retain(|id| id != session_id);
+        eprintln!("[daemon] Detached from session {}", session_id);
+        daemon_log!("Detached from session {}", session_id);
+        Response::Ok
+    })
+}

--- a/src-tauri/daemon/src/handlers/get_last_output_time.rs
+++ b/src-tauri/daemon/src/handlers/get_last_output_time.rs
@@ -1,0 +1,13 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| Response::LastOutputTime {
+        epoch_ms: session.last_output_epoch_ms(),
+        running: session.is_running(),
+        exit_code: session.exit_code(),
+        input_expected: Some(session.is_likely_waiting_for_input()),
+    })
+}

--- a/src-tauri/daemon/src/handlers/list_sessions.rs
+++ b/src-tauri/daemon/src/handlers/list_sessions.rs
@@ -1,0 +1,9 @@
+use godly_protocol::Response;
+
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext) -> Response {
+    let sessions_guard = ctx.sessions.read();
+    let list: Vec<_> = sessions_guard.values().map(|s| s.info()).collect();
+    Response::SessionList { sessions: list }
+}

--- a/src-tauri/daemon/src/handlers/mod.rs
+++ b/src-tauri/daemon/src/handlers/mod.rs
@@ -1,0 +1,21 @@
+mod context;
+pub use context::HandlerContext;
+
+pub mod create_session;
+pub mod list_sessions;
+pub mod attach;
+pub mod detach;
+pub mod write;
+pub mod resize;
+pub mod close_session;
+pub mod read_buffer;
+pub mod get_last_output_time;
+pub mod search_buffer;
+pub mod read_grid;
+pub mod read_rich_grid;
+pub mod read_rich_grid_diff;
+pub mod read_grid_text;
+pub mod set_scrollback;
+pub mod scroll_and_read_rich_grid;
+pub mod pause_session;
+pub mod resume_session;

--- a/src-tauri/daemon/src/handlers/pause_session.rs
+++ b/src-tauri/daemon/src/handlers/pause_session.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use godly_protocol::Response;
+
+use crate::session::DaemonSession;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+/// Async handler (fallback if request reaches the async handler loop).
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        session.pause();
+        Response::Ok
+    })
+}
+
+/// Synchronous version for the I/O thread fast path (no HandlerContext available).
+pub fn handle_raw(
+    sessions: &Arc<RwLock<HashMap<String, DaemonSession>>>,
+    session_id: &str,
+) -> Response {
+    let sessions_guard = sessions.read();
+    match sessions_guard.get(session_id) {
+        Some(session) => {
+            session.pause();
+            Response::Ok
+        }
+        None => Response::Error {
+            message: format!("Session {} not found", session_id),
+        },
+    }
+}

--- a/src-tauri/daemon/src/handlers/read_buffer.rs
+++ b/src-tauri/daemon/src/handlers/read_buffer.rs
@@ -1,0 +1,14 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        let data = session.read_output_history();
+        Response::Buffer {
+            session_id: session_id.to_string(),
+            data,
+        }
+    })
+}

--- a/src-tauri/daemon/src/handlers/read_grid.rs
+++ b/src-tauri/daemon/src/handlers/read_grid.rs
@@ -1,0 +1,11 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        let grid = session.read_grid();
+        Response::Grid { grid }
+    })
+}

--- a/src-tauri/daemon/src/handlers/read_grid_text.rs
+++ b/src-tauri/daemon/src/handlers/read_grid_text.rs
@@ -1,0 +1,19 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(
+    ctx: &HandlerContext,
+    session_id: &str,
+    start_row: i32,
+    start_col: u16,
+    end_row: i32,
+    end_col: u16,
+    scrollback_offset: usize,
+) -> Response {
+    with_session(ctx, session_id, |session| {
+        let text = session.read_grid_text(start_row, start_col, end_row, end_col, scrollback_offset);
+        Response::GridText { text }
+    })
+}

--- a/src-tauri/daemon/src/handlers/read_rich_grid.rs
+++ b/src-tauri/daemon/src/handlers/read_rich_grid.rs
@@ -1,0 +1,11 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        let grid = session.read_rich_grid();
+        Response::RichGrid { grid }
+    })
+}

--- a/src-tauri/daemon/src/handlers/read_rich_grid_diff.rs
+++ b/src-tauri/daemon/src/handlers/read_rich_grid_diff.rs
@@ -1,0 +1,11 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        let diff = session.read_rich_grid_diff();
+        Response::RichGridDiff { diff }
+    })
+}

--- a/src-tauri/daemon/src/handlers/resize.rs
+++ b/src-tauri/daemon/src/handlers/resize.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use godly_protocol::Response;
+
+use crate::session::DaemonSession;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str, rows: u16, cols: u16) -> Response {
+    with_session(ctx, session_id, |session| match session.resize(rows, cols) {
+        Ok(()) => Response::Ok,
+        Err(e) => Response::Error { message: e },
+    })
+}
+
+/// Synchronous version for the I/O thread fast path (no HandlerContext available).
+pub fn handle_raw(
+    sessions: &Arc<RwLock<HashMap<String, DaemonSession>>>,
+    session_id: &str,
+    rows: u16,
+    cols: u16,
+) -> Response {
+    let sessions_guard = sessions.read();
+    match sessions_guard.get(session_id) {
+        Some(session) => match session.resize(rows, cols) {
+            Ok(()) => Response::Ok,
+            Err(e) => Response::Error { message: e },
+        },
+        None => Response::Error {
+            message: format!("Session {} not found", session_id),
+        },
+    }
+}

--- a/src-tauri/daemon/src/handlers/resume_session.rs
+++ b/src-tauri/daemon/src/handlers/resume_session.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use godly_protocol::Response;
+
+use crate::session::DaemonSession;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+/// Async handler (fallback if request reaches the async handler loop).
+pub async fn handle(ctx: &HandlerContext, session_id: &str) -> Response {
+    with_session(ctx, session_id, |session| {
+        session.resume();
+        Response::Ok
+    })
+}
+
+/// Synchronous version for the I/O thread fast path (no HandlerContext available).
+pub fn handle_raw(
+    sessions: &Arc<RwLock<HashMap<String, DaemonSession>>>,
+    session_id: &str,
+) -> Response {
+    let sessions_guard = sessions.read();
+    match sessions_guard.get(session_id) {
+        Some(session) => {
+            session.resume();
+            Response::Ok
+        }
+        None => Response::Error {
+            message: format!("Session {} not found", session_id),
+        },
+    }
+}

--- a/src-tauri/daemon/src/handlers/scroll_and_read_rich_grid.rs
+++ b/src-tauri/daemon/src/handlers/scroll_and_read_rich_grid.rs
@@ -1,0 +1,12 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str, offset: usize) -> Response {
+    with_session(ctx, session_id, |session| {
+        session.set_scrollback(offset);
+        let grid = session.read_rich_grid();
+        Response::RichGrid { grid }
+    })
+}

--- a/src-tauri/daemon/src/handlers/search_buffer.rs
+++ b/src-tauri/daemon/src/handlers/search_buffer.rs
@@ -1,0 +1,16 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(
+    ctx: &HandlerContext,
+    session_id: &str,
+    text: &str,
+    strip_ansi: bool,
+) -> Response {
+    with_session(ctx, session_id, |session| Response::SearchResult {
+        found: session.search_output_history(text, strip_ansi),
+        running: session.is_running(),
+    })
+}

--- a/src-tauri/daemon/src/handlers/set_scrollback.rs
+++ b/src-tauri/daemon/src/handlers/set_scrollback.rs
@@ -1,0 +1,11 @@
+use godly_protocol::Response;
+
+use super::context::with_session;
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str, offset: usize) -> Response {
+    with_session(ctx, session_id, |session| {
+        session.set_scrollback(offset);
+        Response::Ok
+    })
+}

--- a/src-tauri/daemon/src/handlers/write.rs
+++ b/src-tauri/daemon/src/handlers/write.rs
@@ -1,0 +1,43 @@
+use godly_protocol::Response;
+
+use crate::debug_log::daemon_log;
+
+use super::HandlerContext;
+
+pub async fn handle(ctx: &HandlerContext, session_id: &str, data: &[u8]) -> Response {
+    // Pre-check: reject writes to dead or missing sessions immediately
+    // so remote clients get actionable errors instead of silent success.
+    {
+        let sessions_guard = ctx.sessions.read();
+        match sessions_guard.get(session_id) {
+            None => {
+                return Response::Error {
+                    message: format!("Session {} not found", session_id),
+                };
+            }
+            Some(session) if !session.is_running() => {
+                return Response::Error {
+                    message: format!("Session {} has exited", session_id),
+                };
+            }
+            _ => {}
+        }
+    }
+
+    // Fire-and-forget: spawn_blocking so write_all() never blocks
+    // the async handler or the I/O thread. This breaks the circular
+    // deadlock when ConPTY input fills during heavy output.
+    // Write ordering is preserved by session.writer Mutex.
+    let sessions = ctx.sessions.clone();
+    let session_id = session_id.to_string();
+    let data = data.to_vec();
+    tokio::task::spawn_blocking(move || {
+        let sessions_guard = sessions.read();
+        if let Some(session) = sessions_guard.get(&session_id) {
+            if let Err(e) = session.write(&data) {
+                daemon_log!("Write failed for session {}: {}", session_id, e);
+            }
+        }
+    });
+    Response::Ok
+}

--- a/src-tauri/daemon/src/main.rs
+++ b/src-tauri/daemon/src/main.rs
@@ -1,4 +1,5 @@
 mod debug_log;
+mod handlers;
 mod pid;
 mod scrollback_budget;
 mod server;

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -9,12 +9,14 @@ use tokio::sync::mpsc;
 use godly_protocol::{DaemonMessage, Event, Request, Response, read_request, write_daemon_message};
 
 use crate::debug_log::daemon_log;
+use crate::handlers;
+use crate::handlers::HandlerContext;
 use crate::scrollback_budget::ScrollbackBudget;
 use crate::session::DaemonSession;
 
 /// Log current process memory usage (Windows: working set via GetProcessMemoryInfo).
 #[cfg(windows)]
-fn log_memory_usage(label: &str) {
+pub(crate) fn log_memory_usage(label: &str) {
     use winapi::um::processthreadsapi::GetCurrentProcess;
     use winapi::um::psapi::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
 
@@ -34,7 +36,7 @@ fn log_memory_usage(label: &str) {
 }
 
 #[cfg(not(windows))]
-fn log_memory_usage(label: &str) {
+pub(crate) fn log_memory_usage(label: &str) {
     daemon_log!("MEMORY [{}]: (not available on this platform)", label);
 }
 
@@ -590,18 +592,7 @@ fn io_thread(
                         // I/O thread when ConPTY input fills during heavy output (deadlock fix).
                         match &request {
                             Request::Resize { session_id, rows, cols } => {
-                                let response = {
-                                    let sessions_guard = sessions.read();
-                                    match sessions_guard.get(session_id) {
-                                        Some(session) => match session.resize(*rows, *cols) {
-                                            Ok(()) => Response::Ok,
-                                            Err(e) => Response::Error { message: e },
-                                        },
-                                        None => Response::Error {
-                                            message: format!("Session {} not found", session_id),
-                                        },
-                                    }
-                                };
+                                let response = handlers::resize::handle_raw(&sessions, session_id, *rows, *cols);
                                 let msg = DaemonMessage::Response(response);
                                 if write_daemon_message(&mut pipe, &msg).is_err() {
                                     daemon_log!("Write error on direct Resize response, stopping");
@@ -613,18 +604,7 @@ fn io_thread(
                                 did_work = true;
                             }
                             Request::PauseSession { session_id } => {
-                                let response = {
-                                    let sessions_guard = sessions.read();
-                                    match sessions_guard.get(session_id) {
-                                        Some(session) => {
-                                            session.pause();
-                                            Response::Ok
-                                        }
-                                        None => Response::Error {
-                                            message: format!("Session {} not found", session_id),
-                                        },
-                                    }
-                                };
+                                let response = handlers::pause_session::handle_raw(&sessions, session_id);
                                 let msg = DaemonMessage::Response(response);
                                 if write_daemon_message(&mut pipe, &msg).is_err() {
                                     daemon_log!("Write error on direct PauseSession response, stopping");
@@ -636,18 +616,7 @@ fn io_thread(
                                 did_work = true;
                             }
                             Request::ResumeSession { session_id } => {
-                                let response = {
-                                    let sessions_guard = sessions.read();
-                                    match sessions_guard.get(session_id) {
-                                        Some(session) => {
-                                            session.resume();
-                                            Response::Ok
-                                        }
-                                        None => Response::Error {
-                                            message: format!("Session {} not found", session_id),
-                                        },
-                                    }
-                                };
+                                let response = handlers::resume_session::handle_raw(&sessions, session_id);
                                 let msg = DaemonMessage::Response(response);
                                 if write_daemon_message(&mut pipe, &msg).is_err() {
                                     daemon_log!("Write error on direct ResumeSession response, stopping");
@@ -1207,395 +1176,81 @@ async fn handle_request(
     msg_tx: &mpsc::Sender<DaemonMessage>,
     attached_sessions: &Arc<RwLock<Vec<String>>>,
 ) -> Response {
+    let ctx = HandlerContext {
+        sessions: sessions.clone(),
+        msg_tx: msg_tx.clone(),
+        attached_sessions: attached_sessions.clone(),
+    };
+
     match request {
         Request::Ping => Response::Pong,
 
-        Request::CreateSession {
-            id,
-            shell_type,
-            cwd,
-            rows,
-            cols,
-            env,
-        } => {
-            match DaemonSession::new(id.clone(), shell_type.clone(), cwd.clone(), *rows, *cols, env.clone()) {
-                Ok(session) => {
-                    let info = session.info();
-                    sessions.write().insert(id.clone(), session);
-                    let session_count = sessions.read().len();
-                    eprintln!("[daemon] Created session {}", id);
-                    daemon_log!("Created session {} (total sessions: {})", id, session_count);
-                    log_memory_usage(&format!("session_create({})", session_count));
-                    Response::SessionCreated { session: info }
-                }
-                Err(e) => {
-                    eprintln!("[daemon] Failed to create session {}: {}", id, e);
-                    daemon_log!("Failed to create session {}: {}", id, e);
-                    Response::Error { message: e }
-                }
-            }
+        Request::CreateSession { id, shell_type, cwd, rows, cols, env } => {
+            handlers::create_session::handle(&ctx, id, shell_type, cwd, *rows, *cols, env).await
         }
 
-        Request::ListSessions => {
-            let sessions_guard = sessions.read();
-            let list: Vec<_> = sessions_guard.values().map(|s| s.info()).collect();
-            Response::SessionList { sessions: list }
-        }
+        Request::ListSessions => handlers::list_sessions::handle(&ctx).await,
 
-        Request::Attach { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    let is_already_dead = !session.is_running();
-                    let (buffer, mut rx) = session.attach();
-                    attached_sessions.write().push(session_id.clone());
+        Request::Attach { session_id } => handlers::attach::handle(&ctx, session_id).await,
 
-                    // Spawn a task to forward live output as events.
-                    // When the channel closes, check if the PTY exited (running == false)
-                    // and send SessionClosed so the client knows the process is dead.
-                    let tx = msg_tx.clone();
-                    let sid = session_id.clone();
-                    let running_flag = session.running_flag();
-                    let session_exit_code = session.exit_code();
-                    let exit_code_arc = session.exit_code_arc();
-                    tokio::spawn(async move {
-                        // Bug A2 fix: if the session is already dead when we attach,
-                        // send SessionClosed immediately. The reader thread and child
-                        // monitor are already gone, so the output channel will never
-                        // close on its own — rx.recv() would block forever.
-                        if is_already_dead {
-                            daemon_log!(
-                                "Session {} already dead at attach time, sending SessionClosed (exit_code={:?})",
-                                sid,
-                                session_exit_code
-                            );
-                            let _ = tx
-                                .send(DaemonMessage::Event(Event::SessionClosed {
-                                    session_id: sid,
-                                    exit_code: session_exit_code,
-                                }))
-                                .await;
-                            return;
-                        }
-
-                        while let Some(output) = rx.recv().await {
-                            let event = match output {
-                                crate::session::SessionOutput::RawBytes(data) => {
-                                    DaemonMessage::Event(Event::Output {
-                                        session_id: sid.clone(),
-                                        data,
-                                    })
-                                }
-                                crate::session::SessionOutput::GridDiff(diff) => {
-                                    DaemonMessage::Event(Event::GridDiff {
-                                        session_id: sid.clone(),
-                                        diff,
-                                    })
-                                }
-                                crate::session::SessionOutput::Bell => {
-                                    DaemonMessage::Event(Event::Bell {
-                                        session_id: sid.clone(),
-                                    })
-                                }
-                            };
-                            if tx.send(event).await.is_err() {
-                                break;
-                            }
-                        }
-                        // Channel closed — check why:
-                        // - running == false → PTY exited → notify client
-                        // - running == true  → client detached → session still alive, don't notify
-                        if !running_flag.load(Ordering::Relaxed) {
-                            let code = {
-                                let raw = exit_code_arc.load(Ordering::Relaxed);
-                                if raw == i64::MIN { None } else { Some(raw) }
-                            };
-                            daemon_log!("Session {} PTY exited, sending SessionClosed (exit_code={:?})", sid, code);
-                            let _ = tx
-                                .send(DaemonMessage::Event(Event::SessionClosed {
-                                    session_id: sid,
-                                    exit_code: code,
-                                }))
-                                .await;
-                        }
-                    });
-
-                    eprintln!(
-                        "[daemon] Attached to session {} (buffer: {} bytes)",
-                        session_id,
-                        buffer.len()
-                    );
-                    daemon_log!(
-                        "Attached to session {} (buffer: {} bytes)",
-                        session_id,
-                        buffer.len()
-                    );
-
-                    // Return buffered data for replay
-                    if buffer.is_empty() {
-                        Response::Ok
-                    } else {
-                        Response::Buffer {
-                            session_id: session_id.clone(),
-                            data: buffer,
-                        }
-                    }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::Detach { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    session.detach();
-                    attached_sessions.write().retain(|id| id != session_id);
-                    eprintln!("[daemon] Detached from session {}", session_id);
-                    daemon_log!("Detached from session {}", session_id);
-                    Response::Ok
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
+        Request::Detach { session_id } => handlers::detach::handle(&ctx, session_id).await,
 
         Request::Write { session_id, data } => {
-            // Pre-check: reject writes to dead or missing sessions immediately
-            // so remote clients get actionable errors instead of silent success.
-            {
-                let sessions_guard = sessions.read();
-                match sessions_guard.get(session_id) {
-                    None => {
-                        return Response::Error {
-                            message: format!("Session {} not found", session_id),
-                        };
-                    }
-                    Some(session) if !session.is_running() => {
-                        return Response::Error {
-                            message: format!("Session {} has exited", session_id),
-                        };
-                    }
-                    _ => {}
-                }
-            }
-
-            // Fire-and-forget: spawn_blocking so write_all() never blocks
-            // the async handler or the I/O thread. This breaks the circular
-            // deadlock when ConPTY input fills during heavy output.
-            // Write ordering is preserved by session.writer Mutex.
-            let sessions = sessions.clone();
-            let session_id = session_id.clone();
-            let data = data.clone();
-            tokio::task::spawn_blocking(move || {
-                let sessions_guard = sessions.read();
-                if let Some(session) = sessions_guard.get(&session_id) {
-                    if let Err(e) = session.write(&data) {
-                        daemon_log!("Write failed for session {}: {}", session_id, e);
-                    }
-                }
-            });
-            Response::Ok
+            handlers::write::handle(&ctx, session_id, data).await
         }
 
-        Request::Resize {
-            session_id,
-            rows,
-            cols,
-        } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => match session.resize(*rows, *cols) {
-                    Ok(()) => Response::Ok,
-                    Err(e) => Response::Error { message: e },
-                },
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::ReadBuffer { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    let data = session.read_output_history();
-                    Response::Buffer {
-                        session_id: session_id.clone(),
-                        data,
-                    }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::GetLastOutputTime { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => Response::LastOutputTime {
-                    epoch_ms: session.last_output_epoch_ms(),
-                    running: session.is_running(),
-                    exit_code: session.exit_code(),
-                    input_expected: Some(session.is_likely_waiting_for_input()),
-                },
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::SearchBuffer {
-            session_id,
-            text,
-            strip_ansi,
-        } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => Response::SearchResult {
-                    found: session.search_output_history(text, *strip_ansi),
-                    running: session.is_running(),
-                },
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::ReadGrid { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    let grid = session.read_grid();
-                    Response::Grid { grid }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::ReadRichGrid { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    let grid = session.read_rich_grid();
-                    Response::RichGrid { grid }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::ReadRichGridDiff { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    let diff = session.read_rich_grid_diff();
-                    Response::RichGridDiff { diff }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::ReadGridText {
-            session_id,
-            start_row,
-            start_col,
-            end_row,
-            end_col,
-            scrollback_offset,
-        } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    let text = session.read_grid_text(*start_row, *start_col, *end_row, *end_col, *scrollback_offset);
-                    Response::GridText { text }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::SetScrollback { session_id, offset } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    session.set_scrollback(*offset);
-                    Response::Ok
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
-        }
-
-        Request::ScrollAndReadRichGrid { session_id, offset } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    session.set_scrollback(*offset);
-                    let grid = session.read_rich_grid();
-                    Response::RichGrid { grid }
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
+        Request::Resize { session_id, rows, cols } => {
+            handlers::resize::handle(&ctx, session_id, *rows, *cols).await
         }
 
         Request::CloseSession { session_id } => {
-            let mut sessions_guard = sessions.write();
-            match sessions_guard.remove(session_id) {
-                Some(session) => {
-                    session.close();
-                    attached_sessions.write().retain(|id| id != session_id);
-                    let remaining = sessions_guard.len(); // already removed
-                    eprintln!("[daemon] Closed session {}", session_id);
-                    daemon_log!("Closed session {} (remaining sessions: {})", session_id, remaining);
-                    log_memory_usage(&format!("session_close({})", remaining));
-                    Response::Ok
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
+            handlers::close_session::handle(&ctx, session_id).await
+        }
+
+        Request::ReadBuffer { session_id } => {
+            handlers::read_buffer::handle(&ctx, session_id).await
+        }
+
+        Request::GetLastOutputTime { session_id } => {
+            handlers::get_last_output_time::handle(&ctx, session_id).await
+        }
+
+        Request::SearchBuffer { session_id, text, strip_ansi } => {
+            handlers::search_buffer::handle(&ctx, session_id, text, *strip_ansi).await
+        }
+
+        Request::ReadGrid { session_id } => {
+            handlers::read_grid::handle(&ctx, session_id).await
+        }
+
+        Request::ReadRichGrid { session_id } => {
+            handlers::read_rich_grid::handle(&ctx, session_id).await
+        }
+
+        Request::ReadRichGridDiff { session_id } => {
+            handlers::read_rich_grid_diff::handle(&ctx, session_id).await
+        }
+
+        Request::ReadGridText { session_id, start_row, start_col, end_row, end_col, scrollback_offset } => {
+            handlers::read_grid_text::handle(&ctx, session_id, *start_row, *start_col, *end_row, *end_col, *scrollback_offset).await
+        }
+
+        Request::SetScrollback { session_id, offset } => {
+            handlers::set_scrollback::handle(&ctx, session_id, *offset).await
+        }
+
+        Request::ScrollAndReadRichGrid { session_id, offset } => {
+            handlers::scroll_and_read_rich_grid::handle(&ctx, session_id, *offset).await
         }
 
         // PauseSession/ResumeSession are handled directly in the I/O thread
         // for low latency. If they somehow reach here, handle them gracefully.
         Request::PauseSession { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    session.pause();
-                    Response::Ok
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
+            handlers::pause_session::handle(&ctx, session_id).await
         }
 
         Request::ResumeSession { session_id } => {
-            let sessions_guard = sessions.read();
-            match sessions_guard.get(session_id) {
-                Some(session) => {
-                    session.resume();
-                    Response::Ok
-                }
-                None => Response::Error {
-                    message: format!("Session {} not found", session_id),
-                },
-            }
+            handlers::resume_session::handle(&ctx, session_id).await
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extracted 19 request handlers from `server.rs` `handle_request()` into individual files under `src-tauri/daemon/src/handlers/`
- Introduced `HandlerContext` struct to bundle shared parameters (`sessions`, `msg_tx`, `attached_sessions`)
- Added `with_session` helper for the common pattern of looking up a session by ID with error response on miss
- I/O thread fast-path handlers (Resize, PauseSession, ResumeSession) expose `handle_raw()` for synchronous use without HandlerContext

## Changes
- `server.rs`: ~400 lines of match arm bodies replaced with clean one-line delegations
- `main.rs`: Added `mod handlers` declaration
- `log_memory_usage`: Changed visibility to `pub(crate)` so handler modules can call it
- New `handlers/` directory with 19 handler files + `context.rs` + `mod.rs`

## Test plan
- [x] `cargo check -p godly-daemon` passes clean (no warnings)
- [x] `cargo nextest run -p godly-daemon` — 87/88 pass, 1 pre-existing failure (`arrow_up_during_multi_session_contention` — known Issue #149)