### PR TITLE
Fix MCP split panel bugs — missing listeners and pipe closed

### DIFF
--- a/changelog/unreleased/fix-mcp-split-panel-bugs.md
+++ b/changelog/unreleased/fix-mcp-split-panel-bugs.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- **MCP split panel tools don't update UI** — `self_split`, `split_terminal`, `unsplit_terminal`, `swap_panes`, and `zoom_pane` MCP tools now visually update the frontend by adding missing event listeners for `mcp-split-terminal`, `mcp-unsplit-terminal`, `mcp-swap-panes`, and `mcp-zoom-pane` events.
+- **MCP `get_split_state` and `get_layout_tree` fail with "Pipe closed"** — Fixed serde tag collision between `McpResponse` and `LayoutNode` (both used `#[serde(tag = "type")]`), which caused serialization failure and pipe disconnect. Changed `LayoutTree` from tuple variant to struct variant to avoid the collision.

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -1162,7 +1162,7 @@ pub fn call_tool(
             };
 
             let tree_json = match tree_resp {
-                McpResponse::LayoutTree(tree) => tree
+                McpResponse::LayoutTree { tree } => tree
                     .map(|t| serde_json::to_value(t).unwrap_or(serde_json::Value::Null))
                     .unwrap_or(serde_json::Value::Null),
                 _ => serde_json::Value::Null,
@@ -1403,7 +1403,7 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
             "direction": direction,
             "ratio": ratio,
         })),
-        McpResponse::LayoutTree(tree) => Ok(json!({ "layout_tree": tree })),
+        McpResponse::LayoutTree { tree } => Ok(json!({ "layout_tree": tree })),
         McpResponse::JsResult { result, error } => {
             if let Some(err) = error {
                 Err(err)

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -297,7 +297,9 @@ pub enum McpResponse {
         direction: String,
         ratio: f64,
     },
-    LayoutTree(Option<crate::layout_tree::LayoutNode>),
+    LayoutTree {
+        tree: Option<crate::layout_tree::LayoutNode>,
+    },
     JsResult {
         result: Option<String>,
         error: Option<String>,

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1706,7 +1706,7 @@ pub fn handle_mcp_request(
         }
 
         McpRequest::GetLayoutTree { workspace_id } => {
-            McpResponse::LayoutTree(app_state.get_layout_tree(workspace_id))
+            McpResponse::LayoutTree { tree: app_state.get_layout_tree(workspace_id) }
         }
 
         McpRequest::SwapPanes {

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -1553,6 +1553,51 @@ export class App {
       store.clearSplitView(workspaceId);
     });
 
+    // MCP: split terminal (layout tree split)
+    await listen<{
+      workspace_id: string;
+      target_terminal_id: string;
+      new_terminal_id: string;
+      direction: string;
+      ratio: number;
+    }>('mcp-split-terminal', (event) => {
+      const { workspace_id, target_terminal_id, new_terminal_id, direction, ratio } = event.payload;
+      console.log('[App] MCP split terminal:', workspace_id, target_terminal_id, direction);
+      const dir = direction === 'vertical' ? 'vertical' : 'horizontal';
+      store.splitTerminalAt(workspace_id, target_terminal_id, new_terminal_id, dir, ratio);
+    });
+
+    // MCP: unsplit terminal
+    await listen<{
+      workspace_id: string;
+      terminal_id: string;
+    }>('mcp-unsplit-terminal', (event) => {
+      const { workspace_id, terminal_id } = event.payload;
+      console.log('[App] MCP unsplit terminal:', workspace_id, terminal_id);
+      store.unsplitTerminal(workspace_id, terminal_id);
+    });
+
+    // MCP: swap panes
+    await listen<{
+      workspace_id: string;
+      terminal_id_a: string;
+      terminal_id_b: string;
+    }>('mcp-swap-panes', (event) => {
+      const { workspace_id, terminal_id_a, terminal_id_b } = event.payload;
+      console.log('[App] MCP swap panes:', workspace_id, terminal_id_a, terminal_id_b);
+      store.swapPanes(workspace_id, terminal_id_a, terminal_id_b);
+    });
+
+    // MCP: zoom pane
+    await listen<{
+      workspace_id: string;
+      terminal_id: string | null;
+    }>('mcp-zoom-pane', (event) => {
+      const { workspace_id, terminal_id } = event.payload;
+      console.log('[App] MCP zoom pane:', workspace_id, terminal_id);
+      store.setZoomedPane(workspace_id, terminal_id);
+    });
+
     // Terminal bell (BEL character, 0x07) — triggers notification pipeline
     await listen<{ terminal_id: string }>('terminal-bell', async (event) => {
       const { terminal_id } = event.payload;


### PR DESCRIPTION
## Summary

Fixes two bugs in the MCP split panel tools:

- **Missing event listeners**: `self_split`, `split_terminal`, `unsplit_terminal`, `swap_panes`, and `zoom_pane` MCP tools created terminals/modified state but didn't visually update the UI. The backend emitted events (`mcp-split-terminal`, `mcp-unsplit-terminal`, `mcp-swap-panes`, `mcp-zoom-pane`) but the frontend had no listeners for them. Added 4 event listeners in `App.ts`.

- **"Pipe closed" on `get_split_state` / `get_layout_tree`**: Both `McpResponse` and `LayoutNode` use `#[serde(tag = "type")]`. When serializing `McpResponse::LayoutTree(Option<LayoutNode>)`, the inner `LayoutNode`'s `"type"` field collided with the outer enum tag, causing serialization to fail. The MCP pipe server got a write error, closed the connection, and the client saw "Pipe closed (EOF)". Fixed by changing from tuple variant `LayoutTree(Option<LayoutNode>)` to struct variant `LayoutTree { tree: Option<LayoutNode> }`, which nests the inner value and avoids the tag collision.

## Test plan

- [x] `cargo nextest run -p godly-protocol` — 151 tests pass
- [x] `cargo nextest run -p godly-mcp` — 9 tests pass
- [x] `cargo check -p godly-terminal` — compiles cleanly
- [x] `npm test` — 1080 frontend tests pass
- [ ] Manual: call `self_split` via MCP — should visually split the pane
- [ ] Manual: call `get_split_state` / `get_layout_tree` — should return data instead of pipe error
- [ ] Manual: `swap_panes`, `zoom_pane`, `unsplit_terminal` should update UI