### PR TITLE
feat: Godly Flows — node-graph automation engine (Phase 1 MVP)

### DIFF
--- a/changelog/unreleased/459-godly-flows-phase1.md
+++ b/changelog/unreleased/459-godly-flows-phase1.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Godly Flows — Visual Node-Graph Automation System (Phase 1)** — A flow engine that lets users compose terminal operations into reusable, triggerable workflows without writing code. Includes:
+  - Flow store with localStorage persistence and full CRUD (create, duplicate, import/export JSON)
+  - DAG-based execution engine with layered topological sort and cancellation support
+  - 12 built-in node types across 3 categories: Triggers (hotkey, manual), Terminal (create, close, write, read, execute, focus, rename, wait-for-text), Data (constant, template)
+  - Hotkey trigger system for binding flows to keyboard shortcuts
+  - Settings tab UI with flow list, step-based editor, chord picker, and import/export
+  - Node type registry for extensible node definitions
+  - Exposed via `window.__FLOW_ENGINE__` for MCP integration (refs #459)

--- a/src/components/settings/flows-tab.ts
+++ b/src/components/settings/flows-tab.ts
@@ -1,0 +1,966 @@
+import { flowStore } from '../../flow-engine/flow-store';
+import { nodeTypeRegistry } from '../../flow-engine/node-type-registry';
+import type { Flow, FlowNode, FlowEdge, NodeCategory, ConfigField } from '../../flow-engine/types';
+import { NODE_CATEGORY_LABELS, NODE_CATEGORY_COLORS } from '../../flow-engine/types';
+import { formatChord, eventToChord, type KeyChord } from '../../state/keybinding-store';
+import type { SettingsTabProvider, SettingsDialogContext } from './types';
+
+// ── Flows Settings Tab ──────────────────────────────────────────────
+
+export class FlowsTab implements SettingsTabProvider {
+  id = 'flows';
+  label = 'Flows';
+
+  private capturing = false;
+
+  buildContent(_dialog: SettingsDialogContext): HTMLDivElement {
+    const content = document.createElement('div');
+    content.className = 'settings-tab-content';
+
+    let editingFlowId: string | null = null;
+
+    const renderList = () => {
+      this.capturing = false;
+      editingFlowId = null;
+      content.textContent = '';
+      this.renderFlowList(content, (flowId) => {
+        editingFlowId = flowId;
+        renderEditor();
+      });
+    };
+
+    const renderEditor = () => {
+      if (!editingFlowId) return;
+      content.textContent = '';
+      this.renderFlowEditor(content, editingFlowId, () => renderList());
+    };
+
+    renderList();
+
+    // Subscribe to store changes for live updates when on list view
+    const unsub = flowStore.subscribe(() => {
+      if (!editingFlowId) {
+        renderList();
+      }
+    });
+
+    // Store unsubscribe for cleanup when the dialog closes
+    (content as any).__flowsUnsub = unsub;
+
+    return content;
+  }
+
+  onDialogClose(): void {
+    this.capturing = false;
+  }
+
+  isCapturing(): boolean {
+    return this.capturing;
+  }
+
+  // ── Flow List View ──────────────────────────────────────────────
+
+  private renderFlowList(
+    container: HTMLElement,
+    onEdit: (flowId: string) => void,
+  ): void {
+    // Header row with title and action buttons
+    const header = document.createElement('div');
+    header.className = 'flow-list-header';
+
+    const title = document.createElement('div');
+    title.className = 'settings-section-title';
+    title.textContent = 'Flows';
+    title.style.marginBottom = '0';
+    header.appendChild(title);
+
+    const headerActions = document.createElement('div');
+    headerActions.className = 'flow-header-actions';
+
+    const importBtn = document.createElement('button');
+    importBtn.className = 'flow-btn flow-btn-secondary';
+    importBtn.textContent = 'Import';
+    importBtn.addEventListener('click', () => this.handleImport(container, onEdit));
+    headerActions.appendChild(importBtn);
+
+    const newBtn = document.createElement('button');
+    newBtn.className = 'flow-btn flow-btn-primary';
+    newBtn.textContent = 'New Flow';
+    newBtn.addEventListener('click', () => {
+      const flow = flowStore.create({
+        name: 'New Flow',
+        description: '',
+        tags: [],
+        enabled: true,
+        nodes: [],
+        edges: [],
+        variables: [],
+      });
+      onEdit(flow.id);
+    });
+    headerActions.appendChild(newBtn);
+
+    header.appendChild(headerActions);
+    container.appendChild(header);
+
+    const desc = document.createElement('div');
+    desc.className = 'settings-description';
+    desc.textContent = 'Automate terminal workflows with node-based flows. Assign hotkeys, chain commands, and orchestrate workspaces.';
+    container.appendChild(desc);
+
+    // Flow cards
+    const flows = flowStore.getAll();
+
+    if (flows.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'flow-empty';
+      empty.textContent = 'No flows yet. Create one to get started.';
+      container.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('div');
+    list.className = 'flow-list';
+
+    for (const flow of flows) {
+      const card = this.createFlowCard(flow, onEdit);
+      list.appendChild(card);
+    }
+
+    container.appendChild(list);
+  }
+
+  private createFlowCard(
+    flow: Flow,
+    onEdit: (flowId: string) => void,
+  ): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'flow-card';
+
+    const cardHeader = document.createElement('div');
+    cardHeader.className = 'flow-card-header';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'flow-card-name';
+    nameEl.textContent = flow.name;
+    cardHeader.appendChild(nameEl);
+
+    // Hotkey badge (if any)
+    const hotkeyNode = flow.nodes.find(n => n.type === 'trigger.hotkey' && !n.disabled);
+    if (hotkeyNode) {
+      const chord = hotkeyNode.config.chord as KeyChord | undefined;
+      if (chord && chord.key) {
+        const badge = document.createElement('span');
+        badge.className = 'flow-chord-badge';
+        badge.textContent = formatChord(chord);
+        cardHeader.appendChild(badge);
+      }
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'flow-card-actions';
+
+    // Toggle
+    const toggle = this.createToggle(flow.enabled, (enabled) => {
+      flowStore.setEnabled(flow.id, enabled);
+    });
+    actions.appendChild(toggle);
+
+    // Edit button
+    const editBtn = document.createElement('button');
+    editBtn.className = 'flow-btn flow-btn-icon';
+    editBtn.title = 'Edit';
+    editBtn.textContent = '\u270E'; // pencil
+    editBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      onEdit(flow.id);
+    });
+    actions.appendChild(editBtn);
+
+    // Duplicate button
+    const dupBtn = document.createElement('button');
+    dupBtn.className = 'flow-btn flow-btn-icon';
+    dupBtn.title = 'Duplicate';
+    dupBtn.textContent = '\u2398'; // copy symbol
+    dupBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      flowStore.duplicate(flow.id);
+    });
+    actions.appendChild(dupBtn);
+
+    // Export button
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'flow-btn flow-btn-icon';
+    exportBtn.title = 'Export JSON';
+    exportBtn.textContent = '\u21E9'; // download arrow
+    exportBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.handleExport(flow.id);
+    });
+    actions.appendChild(exportBtn);
+
+    // Delete button
+    const delBtn = document.createElement('button');
+    delBtn.className = 'flow-btn flow-btn-icon flow-btn-danger-icon';
+    delBtn.title = 'Delete';
+    delBtn.textContent = '\u2715'; // x mark
+    delBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      flowStore.delete(flow.id);
+    });
+    actions.appendChild(delBtn);
+
+    cardHeader.appendChild(actions);
+    card.appendChild(cardHeader);
+
+    if (flow.description) {
+      const descEl = document.createElement('div');
+      descEl.className = 'flow-card-description';
+      descEl.textContent = flow.description;
+      card.appendChild(descEl);
+    }
+
+    // Step count
+    const enabledNodes = flow.nodes.filter(n => !n.disabled && !n.type.startsWith('trigger.'));
+    if (enabledNodes.length > 0) {
+      const stepsEl = document.createElement('div');
+      stepsEl.className = 'flow-card-meta';
+      stepsEl.textContent = `${enabledNodes.length} step${enabledNodes.length !== 1 ? 's' : ''}`;
+      card.appendChild(stepsEl);
+    }
+
+    return card;
+  }
+
+  // ── Flow Editor View ────────────────────────────────────────────
+
+  private renderFlowEditor(
+    container: HTMLElement,
+    flowId: string,
+    onBack: () => void,
+  ): void {
+    const flow = flowStore.getById(flowId);
+    if (!flow) {
+      onBack();
+      return;
+    }
+
+    // Work on a mutable copy of the flow data
+    let editName = flow.name;
+    let editDescription = flow.description;
+    let editNodes = structuredClone(flow.nodes);
+    let editVariables = structuredClone(flow.variables);
+
+    const editor = document.createElement('div');
+    editor.className = 'flow-editor';
+
+    // ── Header ──
+    const header = document.createElement('div');
+    header.className = 'flow-editor-header';
+
+    const backBtn = document.createElement('button');
+    backBtn.className = 'flow-btn flow-btn-secondary';
+    backBtn.textContent = '\u2190 Back';
+    backBtn.addEventListener('click', onBack);
+    header.appendChild(backBtn);
+
+    const headerTitle = document.createElement('span');
+    headerTitle.className = 'flow-editor-title';
+    headerTitle.textContent = 'Edit Flow';
+    header.appendChild(headerTitle);
+
+    editor.appendChild(header);
+
+    // ── Name ──
+    const nameGroup = this.createFieldGroup('Name');
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'flow-input';
+    nameInput.value = editName;
+    nameInput.placeholder = 'Flow name';
+    nameInput.addEventListener('input', () => {
+      editName = nameInput.value;
+    });
+    nameGroup.appendChild(nameInput);
+    editor.appendChild(nameGroup);
+
+    // ── Description ──
+    const descGroup = this.createFieldGroup('Description');
+    const descInput = document.createElement('input');
+    descInput.type = 'text';
+    descInput.className = 'flow-input';
+    descInput.value = editDescription;
+    descInput.placeholder = 'Optional description';
+    descInput.addEventListener('input', () => {
+      editDescription = descInput.value;
+    });
+    descGroup.appendChild(descInput);
+    editor.appendChild(descGroup);
+
+    // ── Trigger Section ──
+    const triggerGroup = this.createFieldGroup('Trigger');
+    const triggerNode = editNodes.find(n => n.type.startsWith('trigger.'));
+    const triggerTypes = nodeTypeRegistry.getByCategory('trigger');
+
+    const triggerSelect = document.createElement('select');
+    triggerSelect.className = 'flow-select';
+
+    const noneOpt = document.createElement('option');
+    noneOpt.value = '';
+    noneOpt.textContent = 'None (manual only)';
+    triggerSelect.appendChild(noneOpt);
+
+    for (const def of triggerTypes) {
+      const opt = document.createElement('option');
+      opt.value = def.type;
+      opt.textContent = def.label;
+      triggerSelect.appendChild(opt);
+    }
+
+    if (triggerNode) {
+      triggerSelect.value = triggerNode.type;
+    }
+
+    triggerGroup.appendChild(triggerSelect);
+
+    // Trigger config container
+    const triggerConfigContainer = document.createElement('div');
+    triggerConfigContainer.className = 'flow-trigger-config';
+    triggerGroup.appendChild(triggerConfigContainer);
+
+    const renderTriggerConfig = () => {
+      triggerConfigContainer.textContent = '';
+      const currentTrigger = editNodes.find(n => n.type.startsWith('trigger.'));
+      if (!currentTrigger) return;
+
+      if (currentTrigger.type === 'trigger.hotkey') {
+        this.renderChordPicker(triggerConfigContainer, currentTrigger);
+      } else {
+        const def = nodeTypeRegistry.get(currentTrigger.type);
+        if (def) {
+          this.renderConfigFields(triggerConfigContainer, def.configSchema, currentTrigger);
+        }
+      }
+    };
+
+    triggerSelect.addEventListener('change', () => {
+      // Remove existing trigger nodes
+      editNodes = editNodes.filter(n => !n.type.startsWith('trigger.'));
+
+      if (triggerSelect.value) {
+        const newTrigger: FlowNode = {
+          id: crypto.randomUUID(),
+          type: triggerSelect.value,
+          label: triggerSelect.options[triggerSelect.selectedIndex].textContent || triggerSelect.value,
+          position: { x: 0, y: 0 },
+          config: {},
+          disabled: false,
+        };
+        editNodes.unshift(newTrigger);
+      }
+      renderTriggerConfig();
+    });
+
+    renderTriggerConfig();
+    editor.appendChild(triggerGroup);
+
+    // ── Steps Section ──
+    const stepsGroup = this.createFieldGroup('Steps');
+    const stepsContainer = document.createElement('div');
+    stepsContainer.className = 'flow-steps';
+
+    const renderSteps = () => {
+      stepsContainer.textContent = '';
+
+      // Get non-trigger nodes (these are the "steps")
+      const stepNodes = editNodes.filter(n => !n.type.startsWith('trigger.'));
+
+      if (stepNodes.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'flow-empty flow-empty-small';
+        empty.textContent = 'No steps yet. Add a step to define your workflow.';
+        stepsContainer.appendChild(empty);
+      } else {
+        stepNodes.forEach((node, idx) => {
+          const stepEl = this.createStepElement(node, idx + 1, editNodes, () => renderSteps());
+          stepsContainer.appendChild(stepEl);
+        });
+      }
+
+      // Add Step button
+      const addStepBtn = document.createElement('button');
+      addStepBtn.className = 'flow-add-step';
+      addStepBtn.textContent = '+ Add Step';
+      addStepBtn.addEventListener('click', () => {
+        this.showNodeSelector(addStepBtn, (nodeType) => {
+          const def = nodeTypeRegistry.get(nodeType);
+          if (!def) return;
+
+          // Build default config from schema
+          const defaultConfig: Record<string, unknown> = {};
+          for (const field of def.configSchema) {
+            if (field.defaultValue !== undefined) {
+              defaultConfig[field.name] = field.defaultValue;
+            }
+          }
+
+          const newNode: FlowNode = {
+            id: crypto.randomUUID(),
+            type: nodeType,
+            label: def.label,
+            position: { x: 0, y: (editNodes.length) * 100 },
+            config: defaultConfig,
+            disabled: false,
+          };
+          editNodes.push(newNode);
+          renderSteps();
+        });
+      });
+      stepsContainer.appendChild(addStepBtn);
+    };
+
+    renderSteps();
+    stepsGroup.appendChild(stepsContainer);
+    editor.appendChild(stepsGroup);
+
+    // ── Action Buttons ──
+    const actionsRow = document.createElement('div');
+    actionsRow.className = 'flow-actions';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'flow-btn flow-btn-primary';
+    saveBtn.textContent = 'Save';
+    saveBtn.addEventListener('click', () => {
+      // Auto-generate edges as a linear chain
+      const edges = this.generateLinearEdges(editNodes);
+
+      flowStore.update(flowId, {
+        name: editName,
+        description: editDescription,
+        nodes: editNodes,
+        edges,
+        variables: editVariables,
+      });
+      onBack();
+    });
+    actionsRow.appendChild(saveBtn);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'flow-btn flow-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', onBack);
+    actionsRow.appendChild(cancelBtn);
+
+    const runNowBtn = document.createElement('button');
+    runNowBtn.className = 'flow-btn flow-btn-accent';
+    runNowBtn.textContent = 'Run Now';
+    runNowBtn.addEventListener('click', async () => {
+      // Save first
+      const edges = this.generateLinearEdges(editNodes);
+      flowStore.update(flowId, {
+        name: editName,
+        description: editDescription,
+        nodes: editNodes,
+        edges,
+        variables: editVariables,
+      });
+
+      // Trigger execution via the global flow engine
+      const engine = (window as any).__FLOW_ENGINE__;
+      if (engine && engine.triggerFlow) {
+        try {
+          await engine.triggerFlow(flowId);
+          console.info('[Flows] Flow run initiated:', editName);
+        } catch (err) {
+          console.warn('[Flows] Run failed:', err);
+        }
+      }
+    });
+    actionsRow.appendChild(runNowBtn);
+
+    editor.appendChild(actionsRow);
+    container.appendChild(editor);
+  }
+
+  // ── Step Element ────────────────────────────────────────────────
+
+  private createStepElement(
+    node: FlowNode,
+    stepNumber: number,
+    allNodes: FlowNode[],
+    onChanged: () => void,
+  ): HTMLElement {
+    const step = document.createElement('div');
+    step.className = 'flow-step';
+
+    // Step number
+    const numEl = document.createElement('div');
+    numEl.className = 'flow-step-number';
+    numEl.textContent = String(stepNumber);
+    step.appendChild(numEl);
+
+    const stepBody = document.createElement('div');
+    stepBody.className = 'flow-step-body';
+
+    // Type selector
+    const typeRow = document.createElement('div');
+    typeRow.className = 'flow-step-type-row';
+
+    const typeSelect = document.createElement('select');
+    typeSelect.className = 'flow-select';
+
+    // Build grouped options (exclude trigger category)
+    const categories: NodeCategory[] = ['terminal', 'split', 'workspace', 'voice', 'quick-claude', 'control-flow', 'data'];
+    for (const cat of categories) {
+      const defs = nodeTypeRegistry.getByCategory(cat);
+      if (defs.length === 0) continue;
+
+      const group = document.createElement('optgroup');
+      group.label = NODE_CATEGORY_LABELS[cat];
+
+      for (const def of defs) {
+        const opt = document.createElement('option');
+        opt.value = def.type;
+        opt.textContent = `${def.icon} ${def.label}`;
+        group.appendChild(opt);
+      }
+      typeSelect.appendChild(group);
+    }
+
+    typeSelect.value = node.type;
+
+    typeSelect.addEventListener('change', () => {
+      const newDef = nodeTypeRegistry.get(typeSelect.value);
+      if (newDef) {
+        node.type = typeSelect.value;
+        node.label = newDef.label;
+        // Reset config to defaults
+        node.config = {};
+        for (const field of newDef.configSchema) {
+          if (field.defaultValue !== undefined) {
+            node.config[field.name] = field.defaultValue;
+          }
+        }
+      }
+      onChanged();
+    });
+
+    typeRow.appendChild(typeSelect);
+
+    // Remove button
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'flow-btn flow-btn-icon flow-btn-danger-icon';
+    removeBtn.title = 'Remove step';
+    removeBtn.textContent = '\u2715';
+    removeBtn.addEventListener('click', () => {
+      const idx = allNodes.indexOf(node);
+      if (idx !== -1) {
+        allNodes.splice(idx, 1);
+      }
+      onChanged();
+    });
+    typeRow.appendChild(removeBtn);
+
+    stepBody.appendChild(typeRow);
+
+    // Config fields
+    const def = nodeTypeRegistry.get(node.type);
+    if (def && def.configSchema.length > 0) {
+      const configContainer = document.createElement('div');
+      configContainer.className = 'flow-step-config';
+      this.renderConfigFields(configContainer, def.configSchema, node);
+      stepBody.appendChild(configContainer);
+    }
+
+    step.appendChild(stepBody);
+    return step;
+  }
+
+  // ── Config Field Rendering ──────────────────────────────────────
+
+  private renderConfigFields(
+    container: HTMLElement,
+    schema: ConfigField[],
+    node: FlowNode,
+  ): void {
+    for (const field of schema) {
+      const fieldGroup = document.createElement('div');
+      fieldGroup.className = 'flow-config-field';
+
+      const label = document.createElement('label');
+      label.className = 'flow-field-label';
+      label.textContent = field.label;
+      if (field.required) {
+        const req = document.createElement('span');
+        req.className = 'flow-field-required';
+        req.textContent = '*';
+        label.appendChild(req);
+      }
+      fieldGroup.appendChild(label);
+
+      switch (field.type) {
+        case 'string': {
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.className = 'flow-input';
+          input.value = String(node.config[field.name] ?? field.defaultValue ?? '');
+          input.placeholder = field.placeholder ?? '';
+          input.addEventListener('input', () => {
+            node.config[field.name] = input.value;
+          });
+          fieldGroup.appendChild(input);
+          break;
+        }
+
+        case 'number': {
+          const input = document.createElement('input');
+          input.type = 'number';
+          input.className = 'flow-input';
+          input.value = String(node.config[field.name] ?? field.defaultValue ?? '');
+          input.placeholder = field.placeholder ?? '';
+          input.addEventListener('input', () => {
+            node.config[field.name] = input.value ? Number(input.value) : undefined;
+          });
+          fieldGroup.appendChild(input);
+          break;
+        }
+
+        case 'boolean': {
+          const toggle = this.createToggle(
+            Boolean(node.config[field.name] ?? field.defaultValue ?? false),
+            (val) => {
+              node.config[field.name] = val;
+            },
+          );
+          fieldGroup.appendChild(toggle);
+          break;
+        }
+
+        case 'select': {
+          const select = document.createElement('select');
+          select.className = 'flow-select';
+
+          if (!field.required) {
+            const emptyOpt = document.createElement('option');
+            emptyOpt.value = '';
+            emptyOpt.textContent = '-- Select --';
+            select.appendChild(emptyOpt);
+          }
+
+          for (const opt of field.options ?? []) {
+            const option = document.createElement('option');
+            option.value = opt.value;
+            option.textContent = opt.label;
+            select.appendChild(option);
+          }
+
+          select.value = String(node.config[field.name] ?? field.defaultValue ?? '');
+          select.addEventListener('change', () => {
+            node.config[field.name] = select.value;
+          });
+          fieldGroup.appendChild(select);
+          break;
+        }
+
+        case 'keychord': {
+          this.renderChordPicker(fieldGroup, node, field.name);
+          break;
+        }
+      }
+
+      container.appendChild(fieldGroup);
+    }
+  }
+
+  // ── Chord Picker ────────────────────────────────────────────────
+
+  private renderChordPicker(
+    container: HTMLElement,
+    node: FlowNode,
+    configKey: string = 'chord',
+  ): void {
+    const chord = node.config[configKey] as KeyChord | undefined;
+    const displayText = chord && chord.key ? formatChord(chord) : 'Click to set hotkey';
+
+    const picker = document.createElement('button');
+    picker.className = 'flow-chord-picker';
+    picker.textContent = displayText;
+
+    let listening = false;
+
+    const keyHandler = (e: KeyboardEvent) => {
+      // Ignore modifier-only presses
+      if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const newChord = eventToChord(e);
+      node.config[configKey] = newChord;
+      picker.textContent = formatChord(newChord);
+      picker.classList.remove('capturing');
+      this.capturing = false;
+      listening = false;
+      document.removeEventListener('keydown', keyHandler, true);
+    };
+
+    picker.addEventListener('click', () => {
+      if (listening) {
+        // Cancel capture
+        picker.classList.remove('capturing');
+        picker.textContent = chord && chord.key ? formatChord(chord) : 'Click to set hotkey';
+        this.capturing = false;
+        listening = false;
+        document.removeEventListener('keydown', keyHandler, true);
+        return;
+      }
+
+      listening = true;
+      this.capturing = true;
+      picker.classList.add('capturing');
+      picker.textContent = 'Press a key combo...';
+      document.addEventListener('keydown', keyHandler, true);
+    });
+
+    container.appendChild(picker);
+  }
+
+  // ── Node Type Selector Dropdown ─────────────────────────────────
+
+  private showNodeSelector(
+    anchor: HTMLElement,
+    onSelect: (nodeType: string) => void,
+  ): void {
+    // Remove any existing selector
+    const existing = document.querySelector('.flow-node-selector');
+    if (existing) existing.remove();
+
+    const dropdown = document.createElement('div');
+    dropdown.className = 'flow-node-selector';
+
+    // Position near the anchor
+    const rect = anchor.getBoundingClientRect();
+    dropdown.style.position = 'fixed';
+    dropdown.style.left = `${rect.left}px`;
+    dropdown.style.top = `${rect.bottom + 4}px`;
+
+    const categories: NodeCategory[] = ['terminal', 'split', 'workspace', 'voice', 'quick-claude', 'control-flow', 'data'];
+
+    for (const cat of categories) {
+      const defs = nodeTypeRegistry.getByCategory(cat);
+      if (defs.length === 0) continue;
+
+      const catHeader = document.createElement('div');
+      catHeader.className = 'flow-node-selector-category';
+      catHeader.style.borderLeftColor = NODE_CATEGORY_COLORS[cat];
+      catHeader.textContent = NODE_CATEGORY_LABELS[cat];
+      dropdown.appendChild(catHeader);
+
+      for (const def of defs) {
+        const item = document.createElement('div');
+        item.className = 'flow-node-selector-item';
+        item.textContent = `${def.icon} ${def.label}`;
+        item.title = def.description;
+        item.addEventListener('click', () => {
+          onSelect(def.type);
+          dropdown.remove();
+        });
+        dropdown.appendChild(item);
+      }
+    }
+
+    document.body.appendChild(dropdown);
+
+    // Close on outside click
+    const closeHandler = (e: MouseEvent) => {
+      if (!dropdown.contains(e.target as Node)) {
+        dropdown.remove();
+        document.removeEventListener('click', closeHandler, true);
+      }
+    };
+    // Defer so the current click doesn't immediately close it
+    requestAnimationFrame(() => {
+      document.addEventListener('click', closeHandler, true);
+    });
+  }
+
+  // ── Import / Export ─────────────────────────────────────────────
+
+  private handleImport(
+    _container: HTMLElement,
+    onEdit: (flowId: string) => void,
+  ): void {
+    const modal = document.createElement('div');
+    modal.className = 'flow-import-modal';
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'flow-import-backdrop';
+    backdrop.addEventListener('click', () => {
+      modal.remove();
+      backdrop.remove();
+    });
+
+    const title = document.createElement('div');
+    title.className = 'flow-import-title';
+    title.textContent = 'Import Flow';
+    modal.appendChild(title);
+
+    const desc = document.createElement('div');
+    desc.className = 'settings-description';
+    desc.textContent = 'Paste a flow JSON below or load from a file.';
+    modal.appendChild(desc);
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'flow-import-textarea';
+    textarea.placeholder = '{ "name": "My Flow", ... }';
+    textarea.rows = 10;
+    modal.appendChild(textarea);
+
+    const errorEl = document.createElement('div');
+    errorEl.className = 'flow-import-error';
+    errorEl.style.display = 'none';
+    modal.appendChild(errorEl);
+
+    const btnRow = document.createElement('div');
+    btnRow.className = 'flow-actions';
+
+    const fileBtn = document.createElement('button');
+    fileBtn.className = 'flow-btn flow-btn-secondary';
+    fileBtn.textContent = 'Load File';
+    fileBtn.addEventListener('click', () => {
+      const fileInput = document.createElement('input');
+      fileInput.type = 'file';
+      fileInput.accept = '.json';
+      fileInput.addEventListener('change', () => {
+        const file = fileInput.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          textarea.value = reader.result as string;
+        };
+        reader.readAsText(file);
+      });
+      fileInput.click();
+    });
+    btnRow.appendChild(fileBtn);
+
+    const importBtn = document.createElement('button');
+    importBtn.className = 'flow-btn flow-btn-primary';
+    importBtn.textContent = 'Import';
+    importBtn.addEventListener('click', () => {
+      try {
+        const flow = flowStore.importFlow(textarea.value);
+        modal.remove();
+        backdrop.remove();
+        onEdit(flow.id);
+      } catch (err) {
+        errorEl.textContent = err instanceof Error ? err.message : String(err);
+        errorEl.style.display = 'block';
+      }
+    });
+    btnRow.appendChild(importBtn);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'flow-btn flow-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => {
+      modal.remove();
+      backdrop.remove();
+    });
+    btnRow.appendChild(cancelBtn);
+
+    modal.appendChild(btnRow);
+
+    document.body.appendChild(backdrop);
+    document.body.appendChild(modal);
+  }
+
+  private handleExport(flowId: string): void {
+    const json = flowStore.exportFlow(flowId);
+    if (!json) return;
+
+    // Copy to clipboard
+    navigator.clipboard.writeText(json).then(() => {
+      console.info('[Flows] Flow JSON copied to clipboard');
+    }).catch(() => {
+      // Fallback: open in a temporary textarea
+      const ta = document.createElement('textarea');
+      ta.value = json;
+      ta.style.position = 'fixed';
+      ta.style.left = '-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      console.info('[Flows] Flow JSON copied to clipboard (fallback)');
+    });
+  }
+
+  // ── Edge Generation ─────────────────────────────────────────────
+
+  /**
+   * Generate linear edges connecting each node to the next.
+   * For Phase 1, flows are a simple chain: n1 -> n2 -> n3 -> ...
+   */
+  private generateLinearEdges(nodes: FlowNode[]): FlowEdge[] {
+    const edges: FlowEdge[] = [];
+
+    for (let i = 0; i < nodes.length - 1; i++) {
+      const source = nodes[i];
+      const target = nodes[i + 1];
+
+      // Determine port names from definitions
+      const sourceDef = nodeTypeRegistry.get(source.type);
+      const targetDef = nodeTypeRegistry.get(target.type);
+
+      const sourcePort = sourceDef?.ports.find(p => p.direction === 'output')?.name ?? 'output';
+      const targetPort = targetDef?.ports.find(p => p.direction === 'input')?.name ?? 'input';
+
+      edges.push({
+        id: crypto.randomUUID(),
+        sourceNodeId: source.id,
+        sourcePort,
+        targetNodeId: target.id,
+        targetPort,
+      });
+    }
+
+    return edges;
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────
+
+  private createFieldGroup(labelText: string): HTMLElement {
+    const group = document.createElement('div');
+    group.className = 'flow-field-group';
+
+    const label = document.createElement('label');
+    label.className = 'flow-field-label';
+    label.textContent = labelText;
+    group.appendChild(label);
+
+    return group;
+  }
+
+  private createToggle(
+    checked: boolean,
+    onChange: (enabled: boolean) => void,
+  ): HTMLElement {
+    const toggle = document.createElement('label');
+    toggle.className = 'flow-toggle';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = checked;
+    input.addEventListener('change', () => {
+      onChange(input.checked);
+    });
+    toggle.appendChild(input);
+
+    const slider = document.createElement('span');
+    slider.className = 'flow-toggle-slider';
+    toggle.appendChild(slider);
+
+    return toggle;
+  }
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -3,6 +3,7 @@ import { ThemesTab } from './themes-tab';
 import { TerminalTab } from './terminal-tab';
 import { NotificationsTab } from './notifications-tab';
 import { PluginsTab } from './plugins-tab';
+import { FlowsTab } from './flows-tab';
 import { ShortcutsTab } from './shortcuts-tab';
 import { RemoteTab } from './remote-tab';
 
@@ -11,6 +12,7 @@ registerSettingsTab(new ThemesTab());
 registerSettingsTab(new TerminalTab());
 registerSettingsTab(new NotificationsTab());
 registerSettingsTab(new PluginsTab());
+registerSettingsTab(new FlowsTab());
 registerSettingsTab(new ShortcutsTab());
 registerSettingsTab(new RemoteTab());
 

--- a/src/flow-engine/dag.test.ts
+++ b/src/flow-engine/dag.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAdjacencyList,
+  buildInDegreeMap,
+  topologicalSort,
+  findTriggerNodes,
+  detectCycle,
+} from './dag';
+import type { FlowNode, FlowEdge } from './types';
+
+function node(id: string, type = 'terminal.execute'): FlowNode {
+  return { id, type, label: id, position: { x: 0, y: 0 }, config: {}, disabled: false };
+}
+
+function edge(sourceNodeId: string, targetNodeId: string): FlowEdge {
+  return { id: `${sourceNodeId}->${targetNodeId}`, sourceNodeId, sourcePort: 'out', targetNodeId, targetPort: 'in' };
+}
+
+describe('buildAdjacencyList', () => {
+  it('creates empty sets for nodes with no edges', () => {
+    const adj = buildAdjacencyList([node('a'), node('b')], []);
+    expect(adj.get('a')!.size).toBe(0);
+    expect(adj.get('b')!.size).toBe(0);
+  });
+
+  it('maps source nodes to their targets', () => {
+    const adj = buildAdjacencyList(
+      [node('a'), node('b'), node('c')],
+      [edge('a', 'b'), edge('a', 'c')],
+    );
+    expect([...adj.get('a')!]).toEqual(expect.arrayContaining(['b', 'c']));
+    expect(adj.get('b')!.size).toBe(0);
+  });
+});
+
+describe('buildInDegreeMap', () => {
+  it('returns zero for nodes with no incoming edges', () => {
+    const map = buildInDegreeMap([node('a'), node('b')], []);
+    expect(map.get('a')).toBe(0);
+    expect(map.get('b')).toBe(0);
+  });
+
+  it('counts incoming edges correctly', () => {
+    const map = buildInDegreeMap(
+      [node('a'), node('b'), node('c')],
+      [edge('a', 'c'), edge('b', 'c')],
+    );
+    expect(map.get('a')).toBe(0);
+    expect(map.get('b')).toBe(0);
+    expect(map.get('c')).toBe(2);
+  });
+});
+
+describe('topologicalSort', () => {
+  it('sorts a linear chain into sequential layers', () => {
+    const nodes = [node('a'), node('b'), node('c')];
+    const edges = [edge('a', 'b'), edge('b', 'c')];
+    const layers = topologicalSort(nodes, edges);
+    expect(layers).toEqual([['a'], ['b'], ['c']]);
+  });
+
+  it('groups independent nodes into the same layer', () => {
+    // a -> b, a -> c (b and c are in the same layer)
+    const nodes = [node('a'), node('b'), node('c')];
+    const edges = [edge('a', 'b'), edge('a', 'c')];
+    const layers = topologicalSort(nodes, edges);
+    expect(layers[0]).toEqual(['a']);
+    expect(layers[1]).toEqual(expect.arrayContaining(['b', 'c']));
+    expect(layers[1]).toHaveLength(2);
+  });
+
+  it('handles diamond DAG correctly', () => {
+    // a -> b, a -> c, b -> d, c -> d
+    const nodes = [node('a'), node('b'), node('c'), node('d')];
+    const edges = [edge('a', 'b'), edge('a', 'c'), edge('b', 'd'), edge('c', 'd')];
+    const layers = topologicalSort(nodes, edges);
+    expect(layers).toHaveLength(3);
+    expect(layers[0]).toEqual(['a']);
+    expect(layers[1]).toEqual(expect.arrayContaining(['b', 'c']));
+    expect(layers[2]).toEqual(['d']);
+  });
+
+  it('handles disconnected nodes', () => {
+    const nodes = [node('a'), node('b')];
+    const layers = topologicalSort(nodes, []);
+    expect(layers).toHaveLength(1);
+    expect(layers[0]).toEqual(expect.arrayContaining(['a', 'b']));
+  });
+
+  it('throws on cycle', () => {
+    const nodes = [node('a'), node('b')];
+    const edges = [edge('a', 'b'), edge('b', 'a')];
+    expect(() => topologicalSort(nodes, edges)).toThrow(/Cycle detected/);
+  });
+});
+
+describe('findTriggerNodes', () => {
+  it('returns trigger-type nodes with no incoming edges', () => {
+    const nodes = [node('t', 'trigger.hotkey'), node('a'), node('b')];
+    const edges = [edge('t', 'a'), edge('a', 'b')];
+    const triggers = findTriggerNodes(nodes, edges);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].id).toBe('t');
+  });
+
+  it('excludes trigger nodes that have incoming edges', () => {
+    const nodes = [node('a'), node('t', 'trigger.hotkey')];
+    const edges = [edge('a', 't')];
+    const triggers = findTriggerNodes(nodes, edges);
+    expect(triggers).toHaveLength(0);
+  });
+
+  it('excludes non-trigger nodes', () => {
+    const nodes = [node('a', 'terminal.create')];
+    const triggers = findTriggerNodes(nodes, []);
+    expect(triggers).toHaveLength(0);
+  });
+});
+
+describe('detectCycle', () => {
+  it('returns false for acyclic graph', () => {
+    const nodes = [node('a'), node('b'), node('c')];
+    const edges = [edge('a', 'b'), edge('b', 'c')];
+    expect(detectCycle(nodes, edges)).toBe(false);
+  });
+
+  it('returns true for direct cycle', () => {
+    const nodes = [node('a'), node('b')];
+    const edges = [edge('a', 'b'), edge('b', 'a')];
+    expect(detectCycle(nodes, edges)).toBe(true);
+  });
+
+  it('returns true for indirect cycle', () => {
+    const nodes = [node('a'), node('b'), node('c')];
+    const edges = [edge('a', 'b'), edge('b', 'c'), edge('c', 'a')];
+    expect(detectCycle(nodes, edges)).toBe(true);
+  });
+
+  it('returns false for empty graph', () => {
+    expect(detectCycle([], [])).toBe(false);
+  });
+});

--- a/src/flow-engine/dag.ts
+++ b/src/flow-engine/dag.ts
@@ -1,0 +1,166 @@
+import type { FlowNode, FlowEdge } from './types';
+
+// ── Adjacency & In-Degree ────────────────────────────────────────────
+
+/**
+ * Build a forward adjacency list: for each node, the set of nodes it
+ * points to (its direct dependents).
+ */
+export function buildAdjacencyList(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+): Map<string, Set<string>> {
+  const adj = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    adj.set(node.id, new Set());
+  }
+  for (const edge of edges) {
+    const targets = adj.get(edge.sourceNodeId);
+    if (targets) {
+      targets.add(edge.targetNodeId);
+    }
+  }
+  return adj;
+}
+
+/**
+ * Build an in-degree map: for each node, the count of incoming edges.
+ */
+export function buildInDegreeMap(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+): Map<string, number> {
+  const inDegree = new Map<string, number>();
+  for (const node of nodes) {
+    inDegree.set(node.id, 0);
+  }
+  for (const edge of edges) {
+    const current = inDegree.get(edge.targetNodeId);
+    if (current !== undefined) {
+      inDegree.set(edge.targetNodeId, current + 1);
+    }
+  }
+  return inDegree;
+}
+
+// ── Topological Sort (Kahn's Algorithm — layered) ────────────────────
+
+/**
+ * Perform a layered topological sort using Kahn's algorithm.
+ *
+ * Returns an array of layers, where each layer is an array of node IDs
+ * whose dependencies are all satisfied by previous layers. Nodes within
+ * the same layer can be executed concurrently.
+ *
+ * Throws if the graph contains a cycle.
+ */
+export function topologicalSort(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+): string[][] {
+  const adj = buildAdjacencyList(nodes, edges);
+  const inDegree = buildInDegreeMap(nodes, edges);
+
+  // Seed the first frontier with all zero-in-degree nodes
+  let frontier: string[] = [];
+  for (const [nodeId, degree] of inDegree) {
+    if (degree === 0) {
+      frontier.push(nodeId);
+    }
+  }
+
+  const layers: string[][] = [];
+  let visited = 0;
+
+  while (frontier.length > 0) {
+    layers.push([...frontier]);
+    visited += frontier.length;
+
+    const nextFrontier: string[] = [];
+    for (const nodeId of frontier) {
+      const targets = adj.get(nodeId);
+      if (!targets) continue;
+      for (const target of targets) {
+        const newDegree = inDegree.get(target)! - 1;
+        inDegree.set(target, newDegree);
+        if (newDegree === 0) {
+          nextFrontier.push(target);
+        }
+      }
+    }
+    frontier = nextFrontier;
+  }
+
+  if (visited !== nodes.length) {
+    throw new Error(
+      `Cycle detected in flow graph: sorted ${visited} of ${nodes.length} nodes`,
+    );
+  }
+
+  return layers;
+}
+
+// ── Trigger Detection ────────────────────────────────────────────────
+
+/**
+ * Find all trigger nodes — nodes whose category is 'trigger' that have
+ * no incoming edges.
+ */
+export function findTriggerNodes(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+): FlowNode[] {
+  const nodesWithIncoming = new Set<string>();
+  for (const edge of edges) {
+    nodesWithIncoming.add(edge.targetNodeId);
+  }
+  return nodes.filter(
+    (node) => node.type.startsWith('trigger.') && !nodesWithIncoming.has(node.id),
+  );
+}
+
+// ── Cycle Detection ──────────────────────────────────────────────────
+
+/**
+ * Detect whether the DAG contains a cycle using DFS with three-color
+ * marking (white/gray/black).
+ *
+ * Returns true if a cycle exists.
+ */
+export function detectCycle(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+): boolean {
+  const adj = buildAdjacencyList(nodes, edges);
+
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+
+  const color = new Map<string, number>();
+  for (const node of nodes) {
+    color.set(node.id, WHITE);
+  }
+
+  function dfs(nodeId: string): boolean {
+    color.set(nodeId, GRAY);
+    const neighbors = adj.get(nodeId);
+    if (neighbors) {
+      for (const neighbor of neighbors) {
+        const c = color.get(neighbor);
+        if (c === GRAY) return true; // back edge → cycle
+        if (c === WHITE && dfs(neighbor)) return true;
+      }
+    }
+    color.set(nodeId, BLACK);
+    return false;
+  }
+
+  for (const node of nodes) {
+    if (color.get(node.id) === WHITE) {
+      if (dfs(node.id)) return true;
+    }
+  }
+
+  return false;
+}

--- a/src/flow-engine/flow-executor.test.ts
+++ b/src/flow-engine/flow-executor.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { FlowExecutor } from './flow-executor';
+import { NodeTypeRegistry } from './node-type-registry';
+import type { Flow, FlowNode, FlowEdge, NodeTypeDefinition } from './types';
+
+function makeNode(id: string, type: string, config: Record<string, unknown> = {}): FlowNode {
+  return { id, type, label: id, position: { x: 0, y: 0 }, config, disabled: false };
+}
+
+function makeEdge(srcId: string, srcPort: string, tgtId: string, tgtPort: string): FlowEdge {
+  return { id: `${srcId}->${tgtId}`, sourceNodeId: srcId, sourcePort: srcPort, targetNodeId: tgtId, targetPort: tgtPort };
+}
+
+function makeFlow(nodes: FlowNode[], edges: FlowEdge[]): Flow {
+  return {
+    id: 'test-flow',
+    name: 'Test',
+    description: '',
+    version: 1,
+    schemaVersion: 1,
+    tags: [],
+    enabled: true,
+    nodes,
+    edges,
+    variables: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function makeNodeDef(type: string, executeFn: NodeTypeDefinition['execute']): NodeTypeDefinition {
+  return {
+    type,
+    category: 'terminal',
+    label: type,
+    description: '',
+    icon: '',
+    ports: [],
+    configSchema: [],
+    execute: executeFn,
+  };
+}
+
+describe('FlowExecutor', () => {
+  let registry: NodeTypeRegistry;
+  let executor: FlowExecutor;
+
+  beforeEach(() => {
+    registry = new NodeTypeRegistry();
+    executor = new FlowExecutor(registry);
+  });
+
+  it('executes a single-node flow', async () => {
+    const fn = vi.fn().mockResolvedValue({ result: 'ok' });
+    registry.register(makeNodeDef('test.action', fn));
+
+    const flow = makeFlow(
+      [makeNode('n1', 'test.action')],
+      [],
+    );
+
+    const run = await executor.startRun(flow);
+    expect(run.status).toBe('completed');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const state = run.nodeStates.get('n1');
+    expect(state?.status).toBe('completed');
+    expect(state?.outputs).toEqual({ result: 'ok' });
+  });
+
+  it('executes a linear chain passing outputs through edges', async () => {
+    registry.register(makeNodeDef('step.produce', async () => ({ value: 42 })));
+    registry.register(makeNodeDef('step.consume', async (inputs) => ({ doubled: (inputs.value as number) * 2 })));
+
+    const flow = makeFlow(
+      [makeNode('n1', 'step.produce'), makeNode('n2', 'step.consume')],
+      [makeEdge('n1', 'value', 'n2', 'value')],
+    );
+
+    const run = await executor.startRun(flow);
+    expect(run.status).toBe('completed');
+
+    const n2State = run.nodeStates.get('n2');
+    expect(n2State?.outputs).toEqual({ doubled: 84 });
+  });
+
+  it('marks remaining nodes as skipped when a node fails', async () => {
+    registry.register(makeNodeDef('step.ok', async () => ({})));
+    registry.register(makeNodeDef('step.fail', async () => { throw new Error('boom'); }));
+    registry.register(makeNodeDef('step.after', async () => ({ reached: true })));
+
+    const flow = makeFlow(
+      [makeNode('n1', 'step.ok'), makeNode('n2', 'step.fail'), makeNode('n3', 'step.after')],
+      [makeEdge('n1', 'out', 'n2', 'in'), makeEdge('n2', 'out', 'n3', 'in')],
+    );
+
+    const run = await executor.startRun(flow);
+    expect(run.status).toBe('failed');
+    expect(run.nodeStates.get('n1')?.status).toBe('completed');
+    expect(run.nodeStates.get('n2')?.status).toBe('failed');
+    expect(run.nodeStates.get('n2')?.error).toBe('boom');
+    expect(run.nodeStates.get('n3')?.status).toBe('skipped');
+  });
+
+  it('skips disabled nodes', async () => {
+    const fn = vi.fn().mockResolvedValue({});
+    registry.register(makeNodeDef('step.a', fn));
+
+    const disabledNode = makeNode('n1', 'step.a');
+    disabledNode.disabled = true;
+
+    const flow = makeFlow([disabledNode], []);
+    const run = await executor.startRun(flow);
+
+    expect(run.status).toBe('completed');
+    expect(fn).not.toHaveBeenCalled();
+    expect(run.nodeStates.get('n1')?.status).toBe('skipped');
+  });
+
+  it('handles unknown node types gracefully', async () => {
+    // Don't register any node type
+    const flow = makeFlow([makeNode('n1', 'unknown.type')], []);
+    const run = await executor.startRun(flow);
+
+    expect(run.status).toBe('failed');
+    expect(run.nodeStates.get('n1')?.status).toBe('failed');
+    expect(run.nodeStates.get('n1')?.error).toContain('Unknown node type');
+  });
+
+  it('supports cancellation via cancelRun', async () => {
+    let resolveNode: () => void;
+    const hangingPromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveNode = () => resolve({});
+    });
+
+    registry.register(makeNodeDef('step.hang', async (_inputs, _config, context) => {
+      return new Promise((resolve, reject) => {
+        const onAbort = () => reject(new Error('cancelled'));
+        context.abortSignal.addEventListener('abort', onAbort, { once: true });
+        hangingPromise.then(resolve);
+      });
+    }));
+
+    const flow = makeFlow(
+      [makeNode('n1', 'step.hang'), makeNode('n2', 'step.hang')],
+      [makeEdge('n1', 'out', 'n2', 'in')],
+    );
+
+    const runPromise = executor.startRun(flow);
+
+    // Give the executor a tick to start
+    await new Promise((r) => setTimeout(r, 10));
+    executor.cancelRun((await executor.getActiveRuns())[0]?.id ?? '');
+
+    // Resolve the hanging promise so the test can complete
+    resolveNode!();
+
+    const run = await runPromise;
+    // The run should be either cancelled or failed (depending on timing)
+    expect(['cancelled', 'failed']).toContain(run.status);
+  });
+
+  it('notifies subscribers on state changes', async () => {
+    const fn = vi.fn();
+    registry.register(makeNodeDef('step.a', async () => ({})));
+
+    executor.onRunUpdate(fn);
+
+    const flow = makeFlow([makeNode('n1', 'step.a')], []);
+    await executor.startRun(flow);
+
+    // Should have been called at least: initial (running), node running, node completed, run completed
+    expect(fn.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('passes trigger outputs to trigger nodes', async () => {
+    let receivedInputs: Record<string, unknown> = {};
+    registry.register({
+      ...makeNodeDef('trigger.test', async (inputs) => {
+        receivedInputs = inputs;
+        return {};
+      }),
+      category: 'trigger',
+    });
+
+    const flow = makeFlow([makeNode('n1', 'trigger.test')], []);
+    await executor.startRun(flow, { hotkey: 'Ctrl+T' });
+
+    expect(receivedInputs).toEqual({ hotkey: 'Ctrl+T' });
+  });
+
+  it('executes parallel nodes in the same layer', async () => {
+    const order: string[] = [];
+
+    registry.register(makeNodeDef('step.root', async () => {
+      order.push('root');
+      return {};
+    }));
+    registry.register(makeNodeDef('step.left', async () => {
+      order.push('left');
+      return {};
+    }));
+    registry.register(makeNodeDef('step.right', async () => {
+      order.push('right');
+      return {};
+    }));
+
+    // root -> left, root -> right (left and right are in the same layer)
+    const flow = makeFlow(
+      [makeNode('root', 'step.root'), makeNode('left', 'step.left'), makeNode('right', 'step.right')],
+      [makeEdge('root', 'out', 'left', 'in'), makeEdge('root', 'out', 'right', 'in')],
+    );
+
+    const run = await executor.startRun(flow);
+    expect(run.status).toBe('completed');
+    expect(order[0]).toBe('root');
+    expect(order).toContain('left');
+    expect(order).toContain('right');
+  });
+});

--- a/src/flow-engine/flow-executor.ts
+++ b/src/flow-engine/flow-executor.ts
@@ -1,0 +1,296 @@
+import type {
+  Flow,
+  FlowRun,
+  FlowRunStatus,
+  NodeRunState,
+  NodeRunStatus,
+  NodeExecutionContext,
+} from './types';
+import { topologicalSort } from './dag';
+import type { NodeTypeRegistry } from './node-type-registry';
+
+// ── Flow Executor ────────────────────────────────────────────────────
+
+type RunSubscriber = (run: FlowRun) => void;
+
+/**
+ * DAG-walking executor for Godly Flows.
+ *
+ * Executes a flow layer-by-layer (as determined by topological sort).
+ * Within each layer, nodes whose dependencies are all satisfied run
+ * concurrently. For Phase 1 most flows are linear, but the executor
+ * already supports fan-out parallelism within layers.
+ *
+ * Each run gets its own AbortController for cancellation. Node outputs
+ * are threaded to downstream nodes by following edge connections.
+ */
+export class FlowExecutor {
+  private activeRuns: Map<string, FlowRun> = new Map();
+  private abortControllers: Map<string, AbortController> = new Map();
+  private subscribers: Set<RunSubscriber> = new Set();
+
+  constructor(private registry: NodeTypeRegistry) {}
+
+  // ── Run Lifecycle ────────────────────────────────────────────────
+
+  /**
+   * Start executing a flow.
+   *
+   * @param flow          The flow definition to execute.
+   * @param triggerOutputs Optional outputs to seed trigger nodes with
+   *                       (e.g. the hotkey that triggered the flow).
+   * @returns The completed FlowRun.
+   */
+  async startRun(
+    flow: Flow,
+    triggerOutputs?: Record<string, unknown>,
+  ): Promise<FlowRun> {
+    const runId = crypto.randomUUID();
+    const abortController = new AbortController();
+
+    // Build initial node states — skip disabled nodes upfront
+    const nodeStates = new Map<string, NodeRunState>();
+    for (const node of flow.nodes) {
+      const status: NodeRunStatus = node.disabled ? 'skipped' : 'pending';
+      nodeStates.set(node.id, {
+        nodeId: node.id,
+        status,
+        outputs: {},
+      });
+    }
+
+    const run: FlowRun = {
+      id: runId,
+      flowId: flow.id,
+      status: 'running',
+      nodeStates,
+      startedAt: Date.now(),
+    };
+
+    this.activeRuns.set(runId, run);
+    this.abortControllers.set(runId, abortController);
+    this.notifySubscribers(run);
+
+    try {
+      // Filter to only enabled nodes for DAG processing
+      const enabledNodes = flow.nodes.filter((n) => !n.disabled);
+      const enabledEdges = flow.edges.filter(
+        (e) =>
+          enabledNodes.some((n) => n.id === e.sourceNodeId) &&
+          enabledNodes.some((n) => n.id === e.targetNodeId),
+      );
+
+      const layers = topologicalSort(enabledNodes, enabledEdges);
+
+      // Execute layer by layer
+      for (const layer of layers) {
+        if (abortController.signal.aborted) {
+          this.markRemainingSkipped(run, nodeStates);
+          this.finalizeRun(run, 'cancelled');
+          return run;
+        }
+
+        // Execute all nodes in this layer concurrently
+        const layerPromises = layer.map((nodeId) =>
+          this.executeNode(nodeId, flow, run, nodeStates, triggerOutputs, abortController),
+        );
+
+        const results = await Promise.allSettled(layerPromises);
+
+        // Check for failures — if any node in the layer failed, abort the run
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            // This shouldn't happen since executeNode catches internally,
+            // but handle it defensively
+            this.markRemainingSkipped(run, nodeStates);
+            this.finalizeRun(run, 'failed', String(result.reason));
+            return run;
+          }
+        }
+
+        // Check if any node entered failed state
+        const hasFailure = layer.some(
+          (nodeId) => nodeStates.get(nodeId)?.status === 'failed',
+        );
+        if (hasFailure) {
+          this.markRemainingSkipped(run, nodeStates);
+          const failedNode = layer.find(
+            (nodeId) => nodeStates.get(nodeId)?.status === 'failed',
+          );
+          const failedState = failedNode ? nodeStates.get(failedNode) : undefined;
+          this.finalizeRun(run, 'failed', failedState?.error);
+          return run;
+        }
+      }
+
+      this.finalizeRun(run, 'completed');
+    } catch (err) {
+      this.markRemainingSkipped(run, nodeStates);
+      this.finalizeRun(run, 'failed', err instanceof Error ? err.message : String(err));
+    }
+
+    return run;
+  }
+
+  /** Cancel an active run via its AbortController. */
+  cancelRun(runId: string): void {
+    const controller = this.abortControllers.get(runId);
+    if (controller) {
+      controller.abort();
+    }
+  }
+
+  /** Return all currently active (running) runs. */
+  getActiveRuns(): FlowRun[] {
+    return Array.from(this.activeRuns.values()).filter(
+      (run) => run.status === 'running',
+    );
+  }
+
+  /** Look up a run by ID (active or recently completed). */
+  getRun(runId: string): FlowRun | undefined {
+    return this.activeRuns.get(runId);
+  }
+
+  // ── Subscriptions ────────────────────────────────────────────────
+
+  /**
+   * Subscribe to run state changes (for UI visualization).
+   * Returns an unsubscribe function.
+   */
+  onRunUpdate(fn: RunSubscriber): () => void {
+    this.subscribers.add(fn);
+    return () => {
+      this.subscribers.delete(fn);
+    };
+  }
+
+  // ── Internal: Node Execution ─────────────────────────────────────
+
+  private async executeNode(
+    nodeId: string,
+    flow: Flow,
+    run: FlowRun,
+    nodeStates: Map<string, NodeRunState>,
+    triggerOutputs: Record<string, unknown> | undefined,
+    abortController: AbortController,
+  ): Promise<void> {
+    const node = flow.nodes.find((n) => n.id === nodeId);
+    if (!node) return;
+
+    const state = nodeStates.get(nodeId);
+    if (!state || state.status !== 'pending') return;
+
+    const definition = this.registry.get(node.type);
+    if (!definition) {
+      state.status = 'failed';
+      state.error = `Unknown node type: ${node.type}`;
+      state.startedAt = Date.now();
+      state.completedAt = Date.now();
+      this.notifySubscribers(run);
+      return;
+    }
+
+    // Mark as running
+    state.status = 'running';
+    state.startedAt = Date.now();
+    this.notifySubscribers(run);
+
+    // Resolve inputs from upstream nodes
+    let inputs: Record<string, unknown>;
+    if (definition.category === 'trigger' && triggerOutputs) {
+      // Trigger nodes receive the trigger context as their inputs
+      inputs = triggerOutputs;
+    } else {
+      inputs = this.resolveNodeInputs(nodeId, flow, nodeStates);
+    }
+
+    // Build execution context
+    const context: NodeExecutionContext = {
+      flowId: flow.id,
+      runId: run.id,
+      variables: new Map(flow.variables.map((v) => [v.name, v.defaultValue])),
+      abortSignal: abortController.signal,
+    };
+
+    try {
+      const outputs = await definition.execute(inputs, node.config, context);
+      state.status = 'completed';
+      state.outputs = outputs;
+      state.completedAt = Date.now();
+    } catch (err) {
+      state.status = 'failed';
+      state.error = err instanceof Error ? err.message : String(err);
+      state.completedAt = Date.now();
+    }
+
+    this.notifySubscribers(run);
+  }
+
+  /**
+   * Resolve inputs for a node by walking edges backwards to find source
+   * node outputs.
+   *
+   * For each incoming edge, the source node's output port value is mapped
+   * to the target node's input port name.
+   */
+  private resolveNodeInputs(
+    nodeId: string,
+    flow: Flow,
+    nodeStates: Map<string, NodeRunState>,
+  ): Record<string, unknown> {
+    const inputs: Record<string, unknown> = {};
+
+    for (const edge of flow.edges) {
+      if (edge.targetNodeId !== nodeId) continue;
+
+      const sourceState = nodeStates.get(edge.sourceNodeId);
+      if (sourceState && sourceState.status === 'completed') {
+        const outputValue = sourceState.outputs[edge.sourcePort];
+        inputs[edge.targetPort] = outputValue;
+      }
+    }
+
+    return inputs;
+  }
+
+  // ── Internal: Run State Management ───────────────────────────────
+
+  /**
+   * Mark all remaining pending nodes as skipped (used when a node
+   * fails or the run is cancelled).
+   */
+  private markRemainingSkipped(
+    run: FlowRun,
+    nodeStates: Map<string, NodeRunState>,
+  ): void {
+    for (const state of nodeStates.values()) {
+      if (state.status === 'pending') {
+        state.status = 'skipped';
+      }
+    }
+    this.notifySubscribers(run);
+  }
+
+  /** Finalize a run with a terminal status. */
+  private finalizeRun(
+    run: FlowRun,
+    status: FlowRunStatus,
+    error?: string,
+  ): void {
+    run.status = status;
+    run.completedAt = Date.now();
+    if (error) {
+      run.error = error;
+    }
+
+    // Clean up abort controller
+    this.abortControllers.delete(run.id);
+
+    this.notifySubscribers(run);
+  }
+
+  private notifySubscribers(run: FlowRun): void {
+    for (const fn of this.subscribers) fn(run);
+  }
+}

--- a/src/flow-engine/flow-store.test.ts
+++ b/src/flow-engine/flow-store.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { FlowStore } from './flow-store';
+import type { Flow } from './types';
+
+// Mock localStorage
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+});
+
+describe('FlowStore', () => {
+  let store: FlowStore;
+
+  beforeEach(() => {
+    storage.clear();
+    store = new FlowStore();
+  });
+
+  describe('create', () => {
+    it('creates a flow with auto-generated fields', () => {
+      const flow = store.create({
+        name: 'Test Flow',
+        description: 'A test',
+        tags: ['test'],
+        enabled: true,
+        nodes: [],
+        edges: [],
+        variables: [],
+      });
+
+      expect(flow.id).toBeTruthy();
+      expect(flow.name).toBe('Test Flow');
+      expect(flow.version).toBe(1);
+      expect(flow.schemaVersion).toBe(1);
+      expect(flow.createdAt).toBeGreaterThan(0);
+      expect(flow.updatedAt).toBe(flow.createdAt);
+    });
+
+    it('persists to localStorage', () => {
+      store.create({
+        name: 'Persist',
+        description: '',
+        tags: [],
+        enabled: true,
+        nodes: [],
+        edges: [],
+        variables: [],
+      });
+
+      const raw = storage.get('godly-flows');
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe('Persist');
+    });
+  });
+
+  describe('getAll / getById', () => {
+    it('returns all flows sorted by updatedAt desc', () => {
+      const f1 = store.create({ name: 'A', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      // Update f1 so its updatedAt is later
+      store.update(f1.id, { description: 'updated' });
+      store.create({ name: 'B', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+
+      const all = store.getAll();
+      expect(all).toHaveLength(2);
+      // f1 was updated after f2 was created, so f1 is first
+      expect(all[0].id).toBe(f1.id);
+    });
+
+    it('retrieves flow by ID', () => {
+      const flow = store.create({ name: 'Find Me', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      expect(store.getById(flow.id)?.name).toBe('Find Me');
+    });
+
+    it('returns undefined for unknown ID', () => {
+      expect(store.getById('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('updates name and bumps version', () => {
+      const flow = store.create({ name: 'Original', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      const updated = store.update(flow.id, { name: 'Updated' });
+
+      expect(updated?.name).toBe('Updated');
+      expect(updated?.version).toBe(2);
+      expect(updated?.updatedAt).toBeGreaterThanOrEqual(flow.updatedAt);
+    });
+
+    it('preserves identity fields', () => {
+      const flow = store.create({ name: 'Test', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      const updated = store.update(flow.id, {
+        id: 'hacked',
+        schemaVersion: 99 as any,
+        createdAt: 0,
+      } as Partial<Flow>);
+
+      expect(updated?.id).toBe(flow.id);
+      expect(updated?.schemaVersion).toBe(1);
+      expect(updated?.createdAt).toBe(flow.createdAt);
+    });
+
+    it('returns undefined for unknown ID', () => {
+      expect(store.update('nonexistent', { name: 'Nope' })).toBeUndefined();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes flow and returns true', () => {
+      const flow = store.create({ name: 'Delete Me', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      expect(store.delete(flow.id)).toBe(true);
+      expect(store.getById(flow.id)).toBeUndefined();
+      expect(store.getAll()).toHaveLength(0);
+    });
+
+    it('returns false for unknown ID', () => {
+      expect(store.delete('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('duplicate', () => {
+    it('creates a copy with new ID and "(copy)" suffix', () => {
+      const original = store.create({ name: 'Original', description: 'desc', tags: ['a'], enabled: true, nodes: [], edges: [], variables: [] });
+      const copy = store.duplicate(original.id);
+
+      expect(copy).toBeTruthy();
+      expect(copy!.id).not.toBe(original.id);
+      expect(copy!.name).toBe('Original (copy)');
+      expect(copy!.version).toBe(1);
+      expect(store.getAll()).toHaveLength(2);
+    });
+
+    it('returns undefined for unknown ID', () => {
+      expect(store.duplicate('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('setEnabled', () => {
+    it('toggles enabled state', () => {
+      const flow = store.create({ name: 'Toggle', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      store.setEnabled(flow.id, false);
+      expect(store.getById(flow.id)?.enabled).toBe(false);
+    });
+  });
+
+  describe('import / export', () => {
+    it('exports as pretty-printed JSON', () => {
+      const flow = store.create({ name: 'Export', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      const json = store.exportFlow(flow.id);
+      expect(json).toBeTruthy();
+      const parsed = JSON.parse(json!);
+      expect(parsed.name).toBe('Export');
+    });
+
+    it('imports valid JSON with new ID', () => {
+      const original = store.create({ name: 'Original', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      const json = store.exportFlow(original.id)!;
+
+      const imported = store.importFlow(json);
+      expect(imported.id).not.toBe(original.id);
+      expect(imported.name).toBe('Original');
+      expect(imported.version).toBe(1);
+      expect(store.getAll()).toHaveLength(2);
+    });
+
+    it('rejects invalid JSON', () => {
+      expect(() => store.importFlow('not json')).toThrow(/Invalid JSON/);
+    });
+
+    it('rejects wrong schema version', () => {
+      const json = JSON.stringify({ schemaVersion: 99, name: 'Bad', nodes: [], edges: [] });
+      expect(() => store.importFlow(json)).toThrow(/Unsupported schema version/);
+    });
+
+    it('rejects missing required fields', () => {
+      const json = JSON.stringify({ schemaVersion: 1 });
+      expect(() => store.importFlow(json)).toThrow(/missing required fields/);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('notifies on create', () => {
+      const fn = vi.fn();
+      store.subscribe(fn);
+      store.create({ name: 'Sub', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribe stops notifications', () => {
+      const fn = vi.fn();
+      const unsub = store.subscribe(fn);
+      unsub();
+      store.create({ name: 'Sub', description: '', tags: [], enabled: true, nodes: [], edges: [], variables: [] });
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistence', () => {
+    it('loads flows from localStorage on construction', () => {
+      // Pre-seed localStorage
+      const flowData = [{
+        id: 'pre-existing',
+        name: 'Loaded',
+        description: '',
+        version: 1,
+        schemaVersion: 1,
+        tags: [],
+        enabled: true,
+        nodes: [],
+        edges: [],
+        variables: [],
+        createdAt: 1000,
+        updatedAt: 1000,
+      }];
+      storage.set('godly-flows', JSON.stringify(flowData));
+
+      const freshStore = new FlowStore();
+      expect(freshStore.getById('pre-existing')?.name).toBe('Loaded');
+    });
+  });
+});

--- a/src/flow-engine/flow-store.ts
+++ b/src/flow-engine/flow-store.ts
@@ -1,0 +1,269 @@
+import type { Flow } from './types';
+
+// ── Persistence key ──────────────────────────────────────────────────
+
+const STORAGE_KEY = 'godly-flows';
+const CURRENT_SCHEMA_VERSION = 1;
+
+// ── Serialization helpers ────────────────────────────────────────────
+
+/** Shape of a Flow as stored in JSON (identical to Flow but typed loosely for parsing). */
+interface StoredFlow {
+  id: string;
+  name: string;
+  description: string;
+  version: number;
+  schemaVersion: number;
+  tags: string[];
+  enabled: boolean;
+  nodes: Flow['nodes'];
+  edges: Flow['edges'];
+  variables: Flow['variables'];
+  createdAt: number;
+  updatedAt: number;
+  author?: string;
+}
+
+// ── Store ────────────────────────────────────────────────────────────
+
+type Subscriber = () => void;
+
+/**
+ * CRUD store for Godly Flows with localStorage persistence.
+ *
+ * Follows the same observable/subscribe pattern used by KeybindingStore
+ * and other stores in the project.
+ */
+export class FlowStore {
+  private flows: Map<string, Flow> = new Map();
+  private subscribers: Set<Subscriber> = new Set();
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  // ── Queries ──────────────────────────────────────────────────────
+
+  /** Return all flows, ordered by updatedAt descending. */
+  getAll(): Flow[] {
+    return Array.from(this.flows.values()).sort(
+      (a, b) => b.updatedAt - a.updatedAt,
+    );
+  }
+
+  /** Look up a flow by ID. */
+  getById(id: string): Flow | undefined {
+    return this.flows.get(id);
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────
+
+  /**
+   * Create a new flow. Caller provides everything except auto-generated
+   * fields (id, version, schemaVersion, timestamps).
+   */
+  create(
+    partial: Omit<Flow, 'id' | 'version' | 'schemaVersion' | 'createdAt' | 'updatedAt'>,
+  ): Flow {
+    const now = Date.now();
+    const flow: Flow = {
+      ...partial,
+      id: crypto.randomUUID(),
+      version: 1,
+      schemaVersion: CURRENT_SCHEMA_VERSION as 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.flows.set(flow.id, flow);
+    this.saveToStorage();
+    this.notify();
+    return flow;
+  }
+
+  /**
+   * Partially update an existing flow. Bumps `version` and `updatedAt`
+   * automatically. Returns the updated flow, or undefined if not found.
+   */
+  update(id: string, partial: Partial<Flow>): Flow | undefined {
+    const existing = this.flows.get(id);
+    if (!existing) return undefined;
+
+    const updated: Flow = {
+      ...existing,
+      ...partial,
+      // Preserve identity fields — callers cannot change these
+      id: existing.id,
+      schemaVersion: existing.schemaVersion,
+      createdAt: existing.createdAt,
+      // Bump metadata
+      version: existing.version + 1,
+      updatedAt: Date.now(),
+    };
+
+    this.flows.set(id, updated);
+    this.saveToStorage();
+    this.notify();
+    return updated;
+  }
+
+  /** Delete a flow by ID. Returns true if it existed. */
+  delete(id: string): boolean {
+    const existed = this.flows.delete(id);
+    if (existed) {
+      this.saveToStorage();
+      this.notify();
+    }
+    return existed;
+  }
+
+  /**
+   * Duplicate an existing flow with a new ID, reset version, and
+   * " (copy)" appended to the name. Returns the new flow, or undefined
+   * if the source flow was not found.
+   */
+  duplicate(id: string): Flow | undefined {
+    const source = this.flows.get(id);
+    if (!source) return undefined;
+
+    const now = Date.now();
+    const copy: Flow = {
+      ...structuredClone(source),
+      id: crypto.randomUUID(),
+      name: `${source.name} (copy)`,
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.flows.set(copy.id, copy);
+    this.saveToStorage();
+    this.notify();
+    return copy;
+  }
+
+  // ── Enable / Disable ─────────────────────────────────────────────
+
+  /** Toggle a flow's enabled state. */
+  setEnabled(id: string, enabled: boolean): void {
+    const flow = this.flows.get(id);
+    if (!flow) return;
+    this.update(id, { enabled });
+  }
+
+  // ── Import / Export ──────────────────────────────────────────────
+
+  /** Serialize a flow to a JSON string for sharing/backup. */
+  exportFlow(id: string): string | undefined {
+    const flow = this.flows.get(id);
+    if (!flow) return undefined;
+    return JSON.stringify(flow, null, 2);
+  }
+
+  /**
+   * Import a flow from a JSON string.
+   *
+   * Validates that `schemaVersion` matches the current version, assigns
+   * a new UUID (to avoid collisions), and resets timestamps.
+   *
+   * Throws if the JSON is malformed or the schema version is unsupported.
+   */
+  importFlow(json: string): Flow {
+    let parsed: StoredFlow;
+    try {
+      parsed = JSON.parse(json) as StoredFlow;
+    } catch {
+      throw new Error('Invalid JSON: could not parse flow data');
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('Invalid flow data: expected an object');
+    }
+
+    if (parsed.schemaVersion !== CURRENT_SCHEMA_VERSION) {
+      throw new Error(
+        `Unsupported schema version: expected ${CURRENT_SCHEMA_VERSION}, got ${parsed.schemaVersion}`,
+      );
+    }
+
+    if (!parsed.name || !Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
+      throw new Error('Invalid flow data: missing required fields (name, nodes, edges)');
+    }
+
+    const now = Date.now();
+    const flow: Flow = {
+      name: parsed.name,
+      description: parsed.description ?? '',
+      tags: Array.isArray(parsed.tags) ? parsed.tags : [],
+      enabled: parsed.enabled ?? true,
+      nodes: parsed.nodes,
+      edges: parsed.edges,
+      variables: Array.isArray(parsed.variables) ? parsed.variables : [],
+      author: parsed.author,
+      // Generated fields
+      id: crypto.randomUUID(),
+      version: 1,
+      schemaVersion: CURRENT_SCHEMA_VERSION as 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.flows.set(flow.id, flow);
+    this.saveToStorage();
+    this.notify();
+    return flow;
+  }
+
+  // ── Observable ───────────────────────────────────────────────────
+
+  /** Subscribe to store changes. Returns an unsubscribe function. */
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.add(fn);
+    return () => {
+      this.subscribers.delete(fn);
+    };
+  }
+
+  private notify(): void {
+    for (const fn of this.subscribers) fn();
+  }
+
+  // ── Persistence ──────────────────────────────────────────────────
+
+  private saveToStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const data = Array.from(this.flows.values());
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      // No localStorage available — silently skip
+    }
+  }
+
+  private loadFromStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const data: StoredFlow[] = JSON.parse(raw);
+      if (!Array.isArray(data)) return;
+
+      for (const stored of data) {
+        if (
+          stored &&
+          typeof stored === 'object' &&
+          typeof stored.id === 'string' &&
+          stored.schemaVersion === CURRENT_SCHEMA_VERSION
+        ) {
+          this.flows.set(stored.id, stored as Flow);
+        }
+      }
+    } catch {
+      // Corrupt data — start fresh
+      console.warn('[FlowStore] Failed to load flows from localStorage, starting fresh');
+    }
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────
+
+export const flowStore = new FlowStore();

--- a/src/flow-engine/flow-trigger-manager.ts
+++ b/src/flow-engine/flow-trigger-manager.ts
@@ -1,0 +1,115 @@
+import type { Flow, FlowNode } from './types';
+import { chordToString, eventToChord, type KeyChord } from '../state/keybinding-store';
+
+// ── Flow Trigger Manager ────────────────────────────────────────────
+
+/**
+ * Manages hotkey triggers for flows. When a flow has a `trigger.hotkey`
+ * node, its chord is registered with a global keydown listener. When a
+ * matching key combo is pressed, the provided `onTrigger` callback is
+ * invoked with the flow's ID.
+ */
+export class FlowTriggerManager {
+  /** chordString -> { flowId, chord } */
+  private hotkeys: Map<string, { flowId: string; chord: KeyChord }> = new Map();
+  private onTrigger: ((flowId: string) => void) | null = null;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+
+  /**
+   * Start listening for hotkey triggers. Must be called once during
+   * initialization.
+   */
+  start(onTrigger: (flowId: string) => void): void {
+    this.onTrigger = onTrigger;
+
+    this.keydownHandler = (e: KeyboardEvent) => {
+      // Ignore bare modifier-only key presses
+      if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+
+      const chord = eventToChord(e);
+      const chordStr = chordToString(chord);
+      const entry = this.hotkeys.get(chordStr);
+
+      if (entry && this.onTrigger) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.onTrigger(entry.flowId);
+      }
+    };
+
+    document.addEventListener('keydown', this.keydownHandler, { capture: true });
+  }
+
+  /** Stop listening and clear all registered hotkeys. */
+  stop(): void {
+    if (this.keydownHandler) {
+      document.removeEventListener('keydown', this.keydownHandler, { capture: true });
+      this.keydownHandler = null;
+    }
+    this.hotkeys.clear();
+    this.onTrigger = null;
+  }
+
+  /**
+   * Register all trigger.hotkey nodes from a flow. Extracts the chord
+   * from the node's config and stores it in the hotkey map.
+   */
+  registerFlow(flow: Flow): void {
+    if (!flow.enabled) return;
+
+    for (const node of flow.nodes) {
+      if (node.type === 'trigger.hotkey' && !node.disabled) {
+        const chord = this.extractChord(node);
+        if (chord) {
+          const chordStr = chordToString(chord);
+          this.hotkeys.set(chordStr, { flowId: flow.id, chord });
+        }
+      }
+    }
+  }
+
+  /** Remove all hotkey registrations for a given flow. */
+  unregisterFlow(flowId: string): void {
+    const toRemove: string[] = [];
+    for (const [chordStr, entry] of this.hotkeys) {
+      if (entry.flowId === flowId) {
+        toRemove.push(chordStr);
+      }
+    }
+    for (const key of toRemove) {
+      this.hotkeys.delete(key);
+    }
+  }
+
+  /** Clear and re-register all enabled flows. */
+  refreshAll(flows: Flow[]): void {
+    this.hotkeys.clear();
+    for (const flow of flows) {
+      this.registerFlow(flow);
+    }
+  }
+
+  // ── Internal ────────────────────────────────────────────────────
+
+  /**
+   * Extract a KeyChord from a trigger.hotkey node's config.
+   * Expected config shape: { chord: { ctrlKey, shiftKey, altKey, key } }
+   */
+  private extractChord(node: FlowNode): KeyChord | null {
+    const config = node.config;
+    if (!config || typeof config !== 'object') return null;
+
+    const chord = config.chord;
+    if (!chord || typeof chord !== 'object') return null;
+
+    const c = chord as Record<string, unknown>;
+    if (typeof c.key !== 'string' || !c.key) return null;
+
+    return {
+      ctrlKey: Boolean(c.ctrlKey),
+      shiftKey: Boolean(c.shiftKey),
+      altKey: Boolean(c.altKey),
+      key: (c.key as string).toLowerCase(),
+    };
+  }
+}

--- a/src/flow-engine/index.ts
+++ b/src/flow-engine/index.ts
@@ -1,0 +1,72 @@
+import { flowStore } from './flow-store';
+import { FlowExecutor } from './flow-executor';
+import { FlowTriggerManager } from './flow-trigger-manager';
+import { nodeTypeRegistry } from './node-type-registry';
+import { registerAllNodes } from './nodes/index';
+
+// ── Flow Engine Initialization ──────────────────────────────────────
+
+let executor: FlowExecutor | null = null;
+let triggerManager: FlowTriggerManager | null = null;
+
+/**
+ * Initialize the flow engine. Must be called once during app startup,
+ * after plugins are loaded.
+ *
+ * 1. Registers all built-in node types
+ * 2. Creates the executor
+ * 3. Sets up the trigger manager with hotkey listeners
+ * 4. Subscribes to store changes for trigger refresh
+ * 5. Exposes the engine on `window.__FLOW_ENGINE__` for MCP access
+ */
+export function initFlowEngine(): void {
+  // 1. Register all node types
+  registerAllNodes();
+
+  // 2. Create executor
+  executor = new FlowExecutor(nodeTypeRegistry);
+
+  // 3. Create trigger manager and start listening
+  triggerManager = new FlowTriggerManager();
+  triggerManager.start((flowId) => {
+    const flow = flowStore.getById(flowId);
+    if (flow && flow.enabled) {
+      executor!.startRun(flow).catch((err) =>
+        console.warn('[Flows] Hotkey-triggered run failed:', err),
+      );
+    }
+  });
+
+  // 4. Register all current flows for hotkey triggers
+  triggerManager.refreshAll(flowStore.getAll());
+
+  // 5. Subscribe to store changes to keep triggers in sync
+  flowStore.subscribe(() => {
+    triggerManager!.refreshAll(flowStore.getAll());
+  });
+
+  // 6. Expose for MCP execute_js access
+  (window as any).__FLOW_ENGINE__ = {
+    flowStore,
+    executor,
+    triggerManager,
+    nodeTypeRegistry,
+    triggerFlow: async (flowId: string, params?: Record<string, unknown>) => {
+      const flow = flowStore.getById(flowId);
+      if (!flow) throw new Error(`Flow not found: ${flowId}`);
+      return executor!.startRun(flow, params);
+    },
+  };
+
+  console.info('[Flows] Flow engine initialized');
+}
+
+/** Get the flow executor instance (null before init). */
+export function getFlowExecutor(): FlowExecutor | null {
+  return executor;
+}
+
+/** Get the flow trigger manager instance (null before init). */
+export function getFlowTriggerManager(): FlowTriggerManager | null {
+  return triggerManager;
+}

--- a/src/flow-engine/node-type-registry.test.ts
+++ b/src/flow-engine/node-type-registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NodeTypeRegistry } from './node-type-registry';
+import type { NodeTypeDefinition } from './types';
+
+function makeDef(type: string, category: NodeTypeDefinition['category'] = 'terminal'): NodeTypeDefinition {
+  return {
+    type,
+    category,
+    label: type,
+    description: '',
+    icon: '',
+    ports: [],
+    configSchema: [],
+    execute: async () => ({}),
+  };
+}
+
+describe('NodeTypeRegistry', () => {
+  let registry: NodeTypeRegistry;
+
+  beforeEach(() => {
+    registry = new NodeTypeRegistry();
+  });
+
+  it('registers and retrieves a definition', () => {
+    const def = makeDef('terminal.create');
+    registry.register(def);
+    expect(registry.get('terminal.create')).toBe(def);
+  });
+
+  it('returns undefined for unregistered type', () => {
+    expect(registry.get('nonexistent')).toBeUndefined();
+  });
+
+  it('has() checks existence', () => {
+    registry.register(makeDef('test.node'));
+    expect(registry.has('test.node')).toBe(true);
+    expect(registry.has('nope')).toBe(false);
+  });
+
+  it('getAll() returns all definitions', () => {
+    registry.register(makeDef('a'));
+    registry.register(makeDef('b'));
+    expect(registry.getAll()).toHaveLength(2);
+  });
+
+  it('getByCategory() filters by category', () => {
+    registry.register(makeDef('t.hotkey', 'trigger'));
+    registry.register(makeDef('term.create', 'terminal'));
+    registry.register(makeDef('term.close', 'terminal'));
+
+    expect(registry.getByCategory('trigger')).toHaveLength(1);
+    expect(registry.getByCategory('terminal')).toHaveLength(2);
+    expect(registry.getByCategory('data')).toHaveLength(0);
+  });
+
+  it('overwrites existing definition with same type', () => {
+    const def1 = makeDef('test.node');
+    const def2 = makeDef('test.node');
+    def2.label = 'Updated';
+
+    registry.register(def1);
+    registry.register(def2);
+
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.get('test.node')?.label).toBe('Updated');
+  });
+});

--- a/src/flow-engine/node-type-registry.ts
+++ b/src/flow-engine/node-type-registry.ts
@@ -1,0 +1,52 @@
+import type { NodeCategory, NodeTypeDefinition } from './types';
+
+// ── Node Type Registry ───────────────────────────────────────────────
+
+/**
+ * Singleton registry that maps node type strings (e.g. "terminal.create")
+ * to their full NodeTypeDefinition, including ports, config schema, and
+ * execute function.
+ *
+ * Node implementations call `nodeTypeRegistry.register(definition)` at
+ * module load time. The flow executor and editor UI read definitions
+ * from the registry at runtime.
+ */
+export class NodeTypeRegistry {
+  private definitions: Map<string, NodeTypeDefinition> = new Map();
+
+  /**
+   * Register a node type definition. Overwrites any existing definition
+   * with the same `type` string (allows hot-reload during development).
+   */
+  register(definition: NodeTypeDefinition): void {
+    if (!definition.type) {
+      console.warn('[NodeTypeRegistry] Skipping registration: definition has no type');
+      return;
+    }
+    this.definitions.set(definition.type, definition);
+  }
+
+  /** Look up a definition by its type string. */
+  get(type: string): NodeTypeDefinition | undefined {
+    return this.definitions.get(type);
+  }
+
+  /** Return all registered definitions. */
+  getAll(): NodeTypeDefinition[] {
+    return Array.from(this.definitions.values());
+  }
+
+  /** Return all definitions belonging to a specific category. */
+  getByCategory(category: NodeCategory): NodeTypeDefinition[] {
+    return this.getAll().filter((def) => def.category === category);
+  }
+
+  /** Check whether a type string has a registered definition. */
+  has(type: string): boolean {
+    return this.definitions.has(type);
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────
+
+export const nodeTypeRegistry = new NodeTypeRegistry();

--- a/src/flow-engine/nodes/data-nodes.ts
+++ b/src/flow-engine/nodes/data-nodes.ts
@@ -1,0 +1,101 @@
+import type { NodeTypeDefinition } from '../types';
+
+// ── Data Nodes ─────────────────────────────────────────────────────
+//
+// Data manipulation and transformation nodes.
+
+export const dataNodes: NodeTypeDefinition[] = [
+  // data.constant — emits a fixed value
+  {
+    type: 'data.constant',
+    category: 'data',
+    label: 'Constant',
+    description: 'Emits a fixed constant value (string, number, or boolean).',
+    icon: 'hash',
+    ports: [
+      {
+        name: 'value',
+        label: 'Value',
+        direction: 'output',
+        valueType: 'any',
+        required: false,
+      },
+    ],
+    configSchema: [
+      {
+        name: 'value',
+        label: 'Value',
+        type: 'string',
+        required: true,
+        placeholder: 'Enter a value...',
+      },
+      {
+        name: 'valueType',
+        label: 'Type',
+        type: 'select',
+        required: true,
+        defaultValue: 'string',
+        options: [
+          { label: 'String', value: 'string' },
+          { label: 'Number', value: 'number' },
+          { label: 'Boolean', value: 'boolean' },
+        ],
+      },
+    ],
+    execute: async (_inputs, config) => {
+      const rawValue = config.value as string;
+      const valueType = (config.valueType as string) ?? 'string';
+
+      let value: unknown = rawValue;
+      if (valueType === 'number') {
+        value = Number(rawValue);
+      } else if (valueType === 'boolean') {
+        value = rawValue === 'true' || rawValue === '1';
+      }
+
+      return { value };
+    },
+  },
+
+  // data.template — string interpolation with {{portName}} placeholders
+  {
+    type: 'data.template',
+    category: 'data',
+    label: 'Template',
+    description:
+      'String interpolation. Replaces {{portName}} placeholders with input values.',
+    icon: 'code',
+    ports: [
+      {
+        name: 'result',
+        label: 'Result',
+        direction: 'output',
+        valueType: 'string',
+        required: false,
+      },
+    ],
+    configSchema: [
+      {
+        name: 'template',
+        label: 'Template',
+        type: 'string',
+        required: true,
+        placeholder: 'Hello, {{name}}! You have {{count}} items.',
+      },
+    ],
+    execute: async (inputs, config) => {
+      const template = (config.template as string) ?? '';
+
+      // Replace all {{key}} placeholders with corresponding input values
+      const result = template.replace(
+        /\{\{(\w+)\}\}/g,
+        (_match, key: string) => {
+          const val = inputs[key];
+          return val !== undefined && val !== null ? String(val) : '';
+        },
+      );
+
+      return { result };
+    },
+  },
+];

--- a/src/flow-engine/nodes/index.ts
+++ b/src/flow-engine/nodes/index.ts
@@ -1,0 +1,16 @@
+import { nodeTypeRegistry } from '../node-type-registry';
+import { triggerNodes } from './trigger-nodes';
+import { terminalNodes } from './terminal-nodes';
+import { dataNodes } from './data-nodes';
+
+/**
+ * Register all built-in node type definitions with the global registry.
+ * Call this once at application startup before any flow execution.
+ */
+export function registerAllNodes(): void {
+  for (const nodes of [triggerNodes, terminalNodes, dataNodes]) {
+    for (const node of nodes) {
+      nodeTypeRegistry.register(node);
+    }
+  }
+}

--- a/src/flow-engine/nodes/terminal-nodes.ts
+++ b/src/flow-engine/nodes/terminal-nodes.ts
@@ -1,0 +1,356 @@
+import type { ShellType } from '../../state/store';
+import type { NodeTypeDefinition } from '../types';
+
+// ── Terminal Nodes ─────────────────────────────────────────────────
+//
+// Terminal operation nodes wrapping existing Tauri invoke() calls and
+// store methods.
+
+export const terminalNodes: NodeTypeDefinition[] = [
+  // terminal.create — creates a new terminal session
+  {
+    type: 'terminal.create',
+    category: 'terminal',
+    label: 'Create Terminal',
+    description: 'Creates a new terminal in a workspace.',
+    icon: 'plus-square',
+    ports: [
+      {
+        name: 'workspaceId',
+        label: 'Workspace ID',
+        direction: 'input',
+        valueType: 'workspace-id',
+        required: true,
+      },
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'output',
+        valueType: 'terminal-id',
+        required: false,
+      },
+    ],
+    configSchema: [
+      {
+        name: 'shellType',
+        label: 'Shell Type',
+        type: 'select',
+        required: false,
+        options: [
+          { label: 'Default', value: '' },
+          { label: 'PowerShell (Windows)', value: 'windows' },
+          { label: 'PowerShell Core', value: 'pwsh' },
+          { label: 'CMD', value: 'cmd' },
+          { label: 'WSL', value: 'wsl' },
+        ],
+      },
+    ],
+    execute: async (inputs, config) => {
+      const { terminalService } = await import('../../services/terminal-service');
+      const workspaceId = inputs.workspaceId as string;
+
+      // Map config shell type string to ShellType object
+      let shellTypeOverride: ShellType | undefined;
+      const shellValue = config.shellType as string | undefined;
+      if (shellValue && shellValue !== '') {
+        shellTypeOverride = { type: shellValue } as ShellType;
+      }
+
+      const result = await terminalService.createTerminal(workspaceId, {
+        shellTypeOverride,
+      });
+
+      return { terminalId: result.id };
+    },
+  },
+
+  // terminal.close — closes an existing terminal session
+  {
+    type: 'terminal.close',
+    category: 'terminal',
+    label: 'Close Terminal',
+    description: 'Closes a terminal session.',
+    icon: 'x-square',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+    ],
+    configSchema: [],
+    execute: async (inputs) => {
+      const { terminalService } = await import('../../services/terminal-service');
+      const terminalId = inputs.terminalId as string;
+      await terminalService.closeTerminal(terminalId);
+      return {};
+    },
+  },
+
+  // terminal.write — writes raw data to a terminal
+  {
+    type: 'terminal.write',
+    category: 'terminal',
+    label: 'Write to Terminal',
+    description: 'Writes raw data to a terminal (no newline appended).',
+    icon: 'edit',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+      {
+        name: 'data',
+        label: 'Data',
+        direction: 'input',
+        valueType: 'string',
+        required: true,
+      },
+    ],
+    configSchema: [],
+    execute: async (inputs) => {
+      const { terminalService } = await import('../../services/terminal-service');
+      const terminalId = inputs.terminalId as string;
+      const data = inputs.data as string;
+      await terminalService.writeToTerminal(terminalId, data);
+      return {};
+    },
+  },
+
+  // terminal.read — reads the current visible terminal grid text
+  {
+    type: 'terminal.read',
+    category: 'terminal',
+    label: 'Read Terminal',
+    description: 'Reads the current visible terminal grid content as plain text.',
+    icon: 'file-text',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+      {
+        name: 'content',
+        label: 'Content',
+        direction: 'output',
+        valueType: 'string',
+        required: false,
+      },
+    ],
+    configSchema: [],
+    execute: async (inputs) => {
+      const { invoke } = await import('@tauri-apps/api/core');
+      const terminalId = inputs.terminalId as string;
+
+      // Get grid dimensions first
+      const [rows, cols] = await invoke<[number, number]>('get_grid_dimensions', {
+        terminalId,
+      });
+
+      // Read the full visible grid text (row 0 to last row, col 0 to last col)
+      const text = await invoke<string>('get_grid_text', {
+        terminalId,
+        startRow: 0,
+        startCol: 0,
+        endRow: rows - 1,
+        endCol: cols,
+        scrollbackOffset: 0,
+      });
+
+      return { content: text };
+    },
+  },
+
+  // terminal.execute — writes a command + carriage return (fire and forget)
+  {
+    type: 'terminal.execute',
+    category: 'terminal',
+    label: 'Execute Command',
+    description: 'Writes a command followed by Enter to a terminal.',
+    icon: 'terminal',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+      {
+        name: 'command',
+        label: 'Command',
+        direction: 'input',
+        valueType: 'string',
+        required: true,
+      },
+    ],
+    configSchema: [],
+    execute: async (inputs) => {
+      const { terminalService } = await import('../../services/terminal-service');
+      const terminalId = inputs.terminalId as string;
+      const command = inputs.command as string;
+      await terminalService.writeToTerminal(terminalId, command + '\r');
+      return {};
+    },
+  },
+
+  // terminal.focus — focuses a terminal in the UI
+  {
+    type: 'terminal.focus',
+    category: 'terminal',
+    label: 'Focus Terminal',
+    description: 'Sets a terminal as the active terminal in the UI.',
+    icon: 'maximize',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+    ],
+    configSchema: [],
+    execute: async (inputs) => {
+      const { store } = await import('../../state/store');
+      const terminalId = inputs.terminalId as string;
+      store.setActiveTerminal(terminalId);
+      return {};
+    },
+  },
+
+  // terminal.rename — renames a terminal tab
+  {
+    type: 'terminal.rename',
+    category: 'terminal',
+    label: 'Rename Terminal',
+    description: 'Renames a terminal tab label.',
+    icon: 'tag',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+      {
+        name: 'name',
+        label: 'Name',
+        direction: 'input',
+        valueType: 'string',
+        required: true,
+      },
+    ],
+    configSchema: [],
+    execute: async (inputs) => {
+      const { terminalService } = await import('../../services/terminal-service');
+      const terminalId = inputs.terminalId as string;
+      const name = inputs.name as string;
+      await terminalService.renameTerminal(terminalId, name);
+      return {};
+    },
+  },
+
+  // terminal.waitForText — polls terminal grid until text appears or timeout
+  {
+    type: 'terminal.waitForText',
+    category: 'terminal',
+    label: 'Wait for Text',
+    description: 'Polls the terminal grid until the specified text appears or timeout is reached.',
+    icon: 'clock',
+    ports: [
+      {
+        name: 'terminalId',
+        label: 'Terminal ID',
+        direction: 'input',
+        valueType: 'terminal-id',
+        required: true,
+      },
+      {
+        name: 'text',
+        label: 'Text to Find',
+        direction: 'input',
+        valueType: 'string',
+        required: true,
+      },
+      {
+        name: 'found',
+        label: 'Found',
+        direction: 'output',
+        valueType: 'boolean',
+        required: false,
+      },
+    ],
+    configSchema: [
+      {
+        name: 'timeoutMs',
+        label: 'Timeout (ms)',
+        type: 'number',
+        required: false,
+        defaultValue: 10000,
+        placeholder: '10000',
+      },
+      {
+        name: 'pollIntervalMs',
+        label: 'Poll Interval (ms)',
+        type: 'number',
+        required: false,
+        defaultValue: 500,
+        placeholder: '500',
+      },
+    ],
+    execute: async (inputs, config, context) => {
+      const { invoke } = await import('@tauri-apps/api/core');
+      const terminalId = inputs.terminalId as string;
+      const searchText = inputs.text as string;
+      const timeoutMs = (config.timeoutMs as number) ?? 10000;
+      const pollIntervalMs = (config.pollIntervalMs as number) ?? 500;
+
+      const deadline = Date.now() + timeoutMs;
+
+      while (Date.now() < deadline) {
+        if (context.abortSignal.aborted) {
+          return { found: false };
+        }
+
+        // Read full grid content
+        const [rows, cols] = await invoke<[number, number]>('get_grid_dimensions', {
+          terminalId,
+        });
+        const text = await invoke<string>('get_grid_text', {
+          terminalId,
+          startRow: 0,
+          startCol: 0,
+          endRow: rows - 1,
+          endCol: cols,
+          scrollbackOffset: 0,
+        });
+
+        if (text.includes(searchText)) {
+          return { found: true };
+        }
+
+        // Wait for the poll interval, but abort early if signaled
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, pollIntervalMs);
+          const onAbort = () => {
+            clearTimeout(timer);
+            resolve();
+          };
+          context.abortSignal.addEventListener('abort', onAbort, { once: true });
+        });
+      }
+
+      return { found: false };
+    },
+  },
+];

--- a/src/flow-engine/nodes/trigger-nodes.ts
+++ b/src/flow-engine/nodes/trigger-nodes.ts
@@ -1,0 +1,60 @@
+import type { NodeTypeDefinition } from '../types';
+
+// ── Trigger Nodes ──────────────────────────────────────────────────
+//
+// Triggers have no input ports and start a flow execution.
+
+export const triggerNodes: NodeTypeDefinition[] = [
+  // trigger.hotkey — fires when a configured key chord is pressed
+  {
+    type: 'trigger.hotkey',
+    category: 'trigger',
+    label: 'Hotkey Trigger',
+    description: 'Fires when a keyboard shortcut is pressed.',
+    icon: 'keyboard',
+    ports: [
+      {
+        name: 'flow',
+        label: 'Flow',
+        direction: 'output',
+        valueType: 'void',
+        required: false,
+      },
+    ],
+    configSchema: [
+      {
+        name: 'chord',
+        label: 'Key Chord',
+        type: 'keychord',
+        required: true,
+      },
+    ],
+    execute: async () => {
+      // No-op — trigger nodes just start the flow, they don't produce data.
+      return {};
+    },
+  },
+
+  // trigger.manual — triggered via UI "Run" button, no configuration
+  {
+    type: 'trigger.manual',
+    category: 'trigger',
+    label: 'Manual Trigger',
+    description: 'Triggered manually via the Run button in the flow editor.',
+    icon: 'play',
+    ports: [
+      {
+        name: 'flow',
+        label: 'Flow',
+        direction: 'output',
+        valueType: 'void',
+        required: false,
+      },
+    ],
+    configSchema: [],
+    execute: async () => {
+      // No-op — manual triggers just start the flow.
+      return {};
+    },
+  },
+];

--- a/src/flow-engine/types.ts
+++ b/src/flow-engine/types.ts
@@ -1,0 +1,153 @@
+// ── Core Flow Types ──────────────────────────────────────────────────
+
+export interface Flow {
+  id: string;
+  name: string;
+  description: string;
+  version: number;
+  schemaVersion: 1;
+  tags: string[];
+  enabled: boolean;
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+  variables: FlowVariable[];
+  createdAt: number;
+  updatedAt: number;
+  author?: string;
+}
+
+export interface FlowNode {
+  id: string;
+  type: string;
+  label: string;
+  position: { x: number; y: number };
+  config: Record<string, unknown>;
+  disabled: boolean;
+}
+
+export interface FlowEdge {
+  id: string;
+  sourceNodeId: string;
+  sourcePort: string;
+  targetNodeId: string;
+  targetPort: string;
+}
+
+export interface FlowVariable {
+  name: string;
+  type: 'string' | 'number' | 'boolean';
+  defaultValue: unknown;
+}
+
+// ── Port System ─────────────────────────────────────────────────────
+
+export type PortValueType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'terminal-id'
+  | 'workspace-id'
+  | 'any'
+  | 'void';
+
+export interface PortDefinition {
+  name: string;
+  label: string;
+  direction: 'input' | 'output';
+  valueType: PortValueType;
+  required: boolean;
+  defaultValue?: unknown;
+}
+
+// ── Node Type System ────────────────────────────────────────────────
+
+export type NodeCategory =
+  | 'trigger'
+  | 'terminal'
+  | 'split'
+  | 'workspace'
+  | 'voice'
+  | 'quick-claude'
+  | 'control-flow'
+  | 'data';
+
+export interface ConfigField {
+  name: string;
+  label: string;
+  type: 'string' | 'number' | 'boolean' | 'select' | 'keychord';
+  required: boolean;
+  defaultValue?: unknown;
+  options?: { label: string; value: string }[];
+  placeholder?: string;
+}
+
+export interface NodeExecutionContext {
+  flowId: string;
+  runId: string;
+  variables: Map<string, unknown>;
+  abortSignal: AbortSignal;
+}
+
+export interface NodeTypeDefinition {
+  type: string;
+  category: NodeCategory;
+  label: string;
+  description: string;
+  icon: string;
+  ports: PortDefinition[];
+  configSchema: ConfigField[];
+  execute: (
+    inputs: Record<string, unknown>,
+    config: Record<string, unknown>,
+    context: NodeExecutionContext,
+  ) => Promise<Record<string, unknown>>;
+}
+
+// ── Execution Types ─────────────────────────────────────────────────
+
+export type NodeRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+export interface NodeRunState {
+  nodeId: string;
+  status: NodeRunStatus;
+  outputs: Record<string, unknown>;
+  error?: string;
+  startedAt?: number;
+  completedAt?: number;
+}
+
+export type FlowRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface FlowRun {
+  id: string;
+  flowId: string;
+  status: FlowRunStatus;
+  nodeStates: Map<string, NodeRunState>;
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+}
+
+// ── Category Colors ─────────────────────────────────────────────────
+
+export const NODE_CATEGORY_COLORS: Record<NodeCategory, string> = {
+  'trigger': '#9ece6a',
+  'terminal': '#7aa2f7',
+  'split': '#7dcfff',
+  'workspace': '#bb9af7',
+  'voice': '#e0af68',
+  'quick-claude': '#ff9e64',
+  'control-flow': '#c0caf5',
+  'data': '#89b4fa',
+};
+
+export const NODE_CATEGORY_LABELS: Record<NodeCategory, string> = {
+  'trigger': 'Triggers',
+  'terminal': 'Terminal',
+  'split': 'Split / Layout',
+  'workspace': 'Workspace',
+  'voice': 'Voice',
+  'quick-claude': 'Quick Claude',
+  'control-flow': 'Control Flow',
+  'data': 'Data',
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { App } from './components/App';
 import { store } from './state/store';
 import { initLogger } from './utils/Logger';
 import { initPlugins } from './plugins/index';
+import { initFlowEngine } from './flow-engine/index';
 
 initLogger();
 
@@ -31,4 +32,5 @@ if (!container) {
 const app = new App(container);
 app.init().then(async () => {
   await initPlugins();
+  initFlowEngine();
 }).catch(console.error);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2329,3 +2329,496 @@ body.dragging-active * {
   0%, 60% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+/* ── Flows Tab ─────────────────────────────────────────── */
+
+.flow-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.flow-header-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.flow-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.flow-card {
+  padding: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  transition: border-color 0.15s ease;
+}
+
+.flow-card:hover {
+  border-color: var(--accent);
+}
+
+.flow-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.flow-card-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-active);
+}
+
+.flow-chord-badge {
+  font-family: 'Cascadia Code', Consolas, monospace;
+  font-size: 10px;
+  padding: 2px 6px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+}
+
+.flow-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.flow-card-description {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+  line-height: 1.4;
+}
+
+.flow-card-meta {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+/* ── Flow Editor ───────────────────────────────────────── */
+
+.flow-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.flow-editor-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.flow-editor-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-active);
+}
+
+.flow-field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.flow-field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.flow-field-required {
+  color: var(--danger);
+  margin-left: 2px;
+}
+
+.flow-input {
+  width: 100%;
+  padding: 6px 10px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.flow-input:focus {
+  border-color: var(--accent);
+}
+
+.flow-input::placeholder {
+  color: var(--text-secondary);
+}
+
+.flow-select {
+  width: 100%;
+  padding: 6px 10px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.flow-select:focus {
+  border-color: var(--accent);
+}
+
+.flow-trigger-config {
+  margin-top: 6px;
+}
+
+/* ── Flow Steps ────────────────────────────────────────── */
+
+.flow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.flow-step {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.flow-step-number {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.flow-step-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.flow-step-type-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.flow-step-type-row .flow-select {
+  flex: 1;
+}
+
+.flow-step-config {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.flow-config-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.flow-config-field .flow-field-label {
+  font-size: 11px;
+}
+
+.flow-add-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  background: transparent;
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.flow-add-step:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ── Flow Chord Picker ─────────────────────────────────── */
+
+.flow-chord-picker {
+  font-family: 'Cascadia Code', Consolas, monospace;
+  font-size: 12px;
+  padding: 4px 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.flow-chord-picker:hover {
+  border-color: var(--accent);
+}
+
+.flow-chord-picker.capturing {
+  border-color: var(--accent);
+  color: var(--text-secondary);
+  animation: pulse-border 1s ease-in-out infinite;
+}
+
+/* ── Flow Action Buttons ───────────────────────────────── */
+
+.flow-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.flow-btn {
+  font-size: 12px;
+  padding: 5px 14px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.flow-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.flow-btn-primary {
+  background: var(--accent);
+  color: white;
+}
+
+.flow-btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.flow-btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.flow-btn-secondary:hover:not(:disabled) {
+  background: var(--bg-active);
+}
+
+.flow-btn-accent {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.flow-btn-accent:hover:not(:disabled) {
+  background: rgba(122, 162, 247, 0.1);
+}
+
+.flow-btn-icon {
+  padding: 3px 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 4px;
+}
+
+.flow-btn-icon:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.flow-btn-danger-icon {
+  color: var(--text-secondary);
+}
+
+.flow-btn-danger-icon:hover {
+  color: var(--danger);
+  background: rgba(247, 118, 142, 0.1);
+}
+
+/* ── Flow Toggle Switch ────────────────────────────────── */
+
+.flow-toggle {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.flow-toggle input {
+  display: none;
+}
+
+.flow-toggle-slider {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  background: var(--bg-tertiary);
+  border-radius: 9px;
+  transition: background 0.2s ease;
+}
+
+.flow-toggle-slider::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  background: var(--text-secondary);
+  border-radius: 50%;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.flow-toggle input:checked + .flow-toggle-slider {
+  background: var(--accent);
+}
+
+.flow-toggle input:checked + .flow-toggle-slider::after {
+  transform: translateX(14px);
+  background: white;
+}
+
+/* ── Flow Node Selector Dropdown ───────────────────────── */
+
+.flow-node-selector {
+  z-index: 10001;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 6px 0;
+  min-width: 220px;
+  max-height: 300px;
+  overflow-y: auto;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+.flow-node-selector-category {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  padding: 6px 12px 3px;
+  border-left: 3px solid transparent;
+  margin-top: 4px;
+}
+
+.flow-node-selector-category:first-child {
+  margin-top: 0;
+}
+
+.flow-node-selector-item {
+  padding: 5px 12px 5px 18px;
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.flow-node-selector-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-active);
+}
+
+/* ── Flow Empty State ──────────────────────────────────── */
+
+.flow-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 32px 16px;
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+}
+
+.flow-empty-small {
+  padding: 16px;
+  font-size: 12px;
+}
+
+/* ── Flow Import Modal ─────────────────────────────────── */
+
+.flow-import-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10001;
+}
+
+.flow-import-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 20px;
+  min-width: 420px;
+  max-width: 520px;
+  z-index: 10002;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+.flow-import-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-active);
+  margin-bottom: 8px;
+}
+
+.flow-import-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: 'Cascadia Code', Consolas, monospace;
+  resize: vertical;
+  outline: none;
+  margin-bottom: 8px;
+}
+
+.flow-import-textarea:focus {
+  border-color: var(--accent);
+}
+
+.flow-import-error {
+  font-size: 12px;
+  color: var(--danger);
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary

Introduces a visual node-graph automation system that lets users compose terminal operations into reusable, triggerable workflows without writing code.

**Phase 1 delivers the core engine and a form-based UI:**

- **Flow Engine**: DAG-based executor with layered topological sort, `Promise.all` parallelism within layers, cancellation via AbortController
- **Flow Store**: localStorage-backed CRUD with JSON import/export, observable subscribe pattern
- **12 Node Types**: Triggers (hotkey, manual), Terminal (create, close, write, read, execute, focus, rename, waitForText), Data (constant, template)
- **Hotkey Triggers**: FlowTriggerManager registers global keydown listener, fires flows on matching chord
- **Settings Tab**: Flow list with enable/disable toggles, step-based editor with config forms, chord picker, import/export
- **MCP Access**: Exposed via `window.__FLOW_ENGINE__` for Claude Code integration

### Architecture

```
Flow Store (localStorage) ←→ Flow Editor UI (Settings tab)
        ↓
Flow Trigger Manager (keydown listener)
        ↓
Flow Executor (DAG walker)
        ↓
Node Type Registry → Node execute() → invoke() / store methods
```

### Files Added/Modified

- `src/flow-engine/` — 10 new files (types, store, executor, DAG, registry, trigger manager, nodes, init)
- `src/components/settings/flows-tab.ts` — Settings tab UI
- `src/components/settings/index.ts` — Register Flows tab
- `src/main.ts` — Call `initFlowEngine()` after plugins
- `src/styles/main.css` — Flow editor CSS

## Test plan

- [x] 52 unit tests pass: DAG topological sort, cycle detection, store CRUD/persistence/import/export, executor lifecycle (linear chain, failure cascading, disabled nodes, cancellation, parallel layers), registry operations
- [x] All 1132 existing frontend tests still pass
- [x] TypeScript strict check passes
- [ ] Manual: Create "On Ctrl+Shift+1 → create terminal → run npm test" flow, press hotkey, verify terminal spawns and command executes
- [ ] Manual: Import/export a flow JSON, verify round-trip fidelity

fixes #459