### PR TITLE
feat: add tab navigation MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-tab-navigation.md
+++ b/changelog/unreleased/feat-mcp-tab-navigation.md
@@ -1,0 +1,2 @@
+### Added
+- **Tab navigation MCP tools** - Add `next_tab`, `previous_tab`, and `go_to_tab` MCP tools for programmatic tab switching within workspaces

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -631,6 +631,9 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ExportTerminalInfo { .. } => {
                 Ok(Self::app_only_error("export_terminal_info"))
             }
+            McpRequest::NextTab { .. } => Ok(Self::app_only_error("next_tab")),
+            McpRequest::PreviousTab { .. } => Ok(Self::app_only_error("previous_tab")),
+            McpRequest::GoToTab { .. } => Ok(Self::app_only_error("go_to_tab")),
         }
     }
 

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 21;
+const BUILD: u32 = 22;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -727,6 +727,52 @@ pub fn list_tools() -> Value {
                     },
                     "required": []
                 }
+            },
+            {
+                "name": "next_tab",
+                "description": "Switch to the next tab in tab order (wraps around to first tab after last)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "previous_tab",
+                "description": "Switch to the previous tab in tab order (wraps around to last tab before first)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "go_to_tab",
+                "description": "Switch to a specific tab by its 0-based index in the tab order",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        },
+                        "index": {
+                            "type": "number",
+                            "description": "0-based index of the tab to switch to"
+                        }
+                    },
+                    "required": ["index"]
+                }
             }
         ]
     })
@@ -1256,6 +1302,25 @@ pub fn call_tool(
         "export_terminal_info" => {
             let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
             McpRequest::ExportTerminalInfo { terminal_id }
+        }
+
+        "next_tab" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::NextTab { workspace_id }
+        }
+
+        "previous_tab" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::PreviousTab { workspace_id }
+        }
+
+        "go_to_tab" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            let index = args
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .ok_or("Missing index")? as u32;
+            McpRequest::GoToTab { workspace_id, index }
         }
 
         _ => return Err(format!("Unknown tool: {}", name)),

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -199,6 +199,21 @@ pub enum McpRequest {
         terminal_id: Option<String>,
     },
 
+    // Tab navigation
+    NextTab {
+        #[serde(default)]
+        workspace_id: Option<String>,
+    },
+    PreviousTab {
+        #[serde(default)]
+        workspace_id: Option<String>,
+    },
+    GoToTab {
+        #[serde(default)]
+        workspace_id: Option<String>,
+        index: u32,
+    },
+
     // Notifications
     Notify {
         terminal_id: String,

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1983,6 +1983,120 @@ pub fn handle_mcp_request(
             }
         }
 
+        McpRequest::NextTab { workspace_id } => {
+            let ws_id = workspace_id
+                .clone()
+                .or_else(|| app_state.active_workspace_id.read().clone());
+            let ws_id = match ws_id {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No workspace_id provided and no active workspace".to_string(),
+                    };
+                }
+            };
+
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    r#"
+                    const state = window.__STORE__.getState();
+                    const ws = state.workspaces.find(w => w.id === '{}');
+                    if (!ws || ws.tabOrder.length === 0) return 'no tabs';
+                    const currentIdx = ws.tabOrder.indexOf(state.activeTerminalId);
+                    const nextIdx = (currentIdx + 1) % ws.tabOrder.length;
+                    const nextId = ws.tabOrder[nextIdx];
+                    window.__STORE__.setActiveTerminal(nextId);
+                    return nextId;
+                    "#,
+                    ws_id
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state)
+            {
+                McpResponse::JsResult {
+                    error: Some(e), ..
+                } => McpResponse::Error { message: e },
+                _ => McpResponse::Ok,
+            }
+        }
+
+        McpRequest::PreviousTab { workspace_id } => {
+            let ws_id = workspace_id
+                .clone()
+                .or_else(|| app_state.active_workspace_id.read().clone());
+            let ws_id = match ws_id {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No workspace_id provided and no active workspace".to_string(),
+                    };
+                }
+            };
+
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    r#"
+                    const state = window.__STORE__.getState();
+                    const ws = state.workspaces.find(w => w.id === '{}');
+                    if (!ws || ws.tabOrder.length === 0) return 'no tabs';
+                    const currentIdx = ws.tabOrder.indexOf(state.activeTerminalId);
+                    const prevIdx = (currentIdx - 1 + ws.tabOrder.length) % ws.tabOrder.length;
+                    const prevId = ws.tabOrder[prevIdx];
+                    window.__STORE__.setActiveTerminal(prevId);
+                    return prevId;
+                    "#,
+                    ws_id
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state)
+            {
+                McpResponse::JsResult {
+                    error: Some(e), ..
+                } => McpResponse::Error { message: e },
+                _ => McpResponse::Ok,
+            }
+        }
+
+        McpRequest::GoToTab {
+            workspace_id,
+            index,
+        } => {
+            let ws_id = workspace_id
+                .clone()
+                .or_else(|| app_state.active_workspace_id.read().clone());
+            let ws_id = match ws_id {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No workspace_id provided and no active workspace".to_string(),
+                    };
+                }
+            };
+
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    r#"
+                    const state = window.__STORE__.getState();
+                    const ws = state.workspaces.find(w => w.id === '{}');
+                    if (!ws || ws.tabOrder.length === 0) return 'no tabs';
+                    const idx = {};
+                    if (idx < 0 || idx >= ws.tabOrder.length) throw new Error('Tab index ' + idx + ' out of range (0-' + (ws.tabOrder.length - 1) + ')');
+                    const targetId = ws.tabOrder[idx];
+                    window.__STORE__.setActiveTerminal(targetId);
+                    return targetId;
+                    "#,
+                    ws_id, index
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state)
+            {
+                McpResponse::JsResult {
+                    error: Some(e), ..
+                } => McpResponse::Error { message: e },
+                _ => McpResponse::Ok,
+            }
+        }
+
         McpRequest::ExportTerminalInfo { terminal_id } => {
             // Resolve terminal: use provided ID or fall back to active terminal
             let tid = terminal_id


### PR DESCRIPTION
## Summary
- Add `next_tab`, `previous_tab`, and `go_to_tab` MCP tools for programmatic tab switching within workspaces
- Part of MCP batch coverage expansion

## Test plan
- [x] `cargo check -p godly-protocol -p godly-mcp` passes
- [x] `cargo nextest run -p godly-protocol` passes (151 tests)
- [ ] CI validates cross-crate type checking