### PR TITLE
feat: add notification settings MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-notifications.md
+++ b/changelog/unreleased/feat-mcp-notifications.md
@@ -1,0 +1,2 @@
+### Added
+- **Notification settings MCP tools** — add `get_notification_config`, `set_notification_sound`, `add_mute_pattern`, `remove_mute_pattern`, and `list_mute_patterns` MCP tools for managing notification preferences programmatically

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -631,6 +631,21 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ExportTerminalInfo { .. } => {
                 Ok(Self::app_only_error("export_terminal_info"))
             }
+            McpRequest::GetNotificationConfig => {
+                Ok(Self::app_only_error("get_notification_config"))
+            }
+            McpRequest::SetNotificationSound { .. } => {
+                Ok(Self::app_only_error("set_notification_sound"))
+            }
+            McpRequest::AddMutePattern { .. } => {
+                Ok(Self::app_only_error("add_mute_pattern"))
+            }
+            McpRequest::RemoveMutePattern { .. } => {
+                Ok(Self::app_only_error("remove_mute_pattern"))
+            }
+            McpRequest::ListMutePatterns => {
+                Ok(Self::app_only_error("list_mute_patterns"))
+            }
         }
     }
 

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 21;
+const BUILD: u32 = 22;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -727,6 +727,66 @@ pub fn list_tools() -> Value {
                     },
                     "required": []
                 }
+            },
+            {
+                "name": "get_notification_config",
+                "description": "Get the current notification settings: enabled state, sound preset, and volume level.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "set_notification_sound",
+                "description": "Set the notification sound preset (e.g., 'chime', 'bell', 'ping', 'none').",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "preset": {
+                            "type": "string",
+                            "description": "Sound preset name to use for notifications"
+                        }
+                    },
+                    "required": ["preset"]
+                }
+            },
+            {
+                "name": "add_mute_pattern",
+                "description": "Add a glob pattern to mute notifications for matching workspace names (e.g., 'test-*', '*-staging').",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "Glob pattern to match workspace names for muting"
+                        }
+                    },
+                    "required": ["pattern"]
+                }
+            },
+            {
+                "name": "remove_mute_pattern",
+                "description": "Remove a glob pattern from the notification mute list.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "The exact glob pattern to remove"
+                        }
+                    },
+                    "required": ["pattern"]
+                }
+            },
+            {
+                "name": "list_mute_patterns",
+                "description": "List all glob patterns currently used to mute notifications for matching workspaces.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
             }
         ]
     })
@@ -1258,6 +1318,37 @@ pub fn call_tool(
             McpRequest::ExportTerminalInfo { terminal_id }
         }
 
+        "get_notification_config" => McpRequest::GetNotificationConfig,
+
+        "set_notification_sound" => {
+            let preset = args
+                .get("preset")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing preset")?
+                .to_string();
+            McpRequest::SetNotificationSound { preset }
+        }
+
+        "add_mute_pattern" => {
+            let pattern = args
+                .get("pattern")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing pattern")?
+                .to_string();
+            McpRequest::AddMutePattern { pattern }
+        }
+
+        "remove_mute_pattern" => {
+            let pattern = args
+                .get("pattern")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing pattern")?
+                .to_string();
+            McpRequest::RemoveMutePattern { pattern }
+        }
+
+        "list_mute_patterns" => McpRequest::ListMutePatterns,
+
         _ => return Err(format!("Unknown tool: {}", name)),
     };
 
@@ -1415,6 +1506,18 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         }
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
+        })),
+        McpResponse::NotificationConfig {
+            enabled,
+            sound_preset,
+            volume,
+        } => Ok(json!({
+            "enabled": enabled,
+            "sound_preset": sound_preset,
+            "volume": volume,
+        })),
+        McpResponse::MutePatterns { patterns } => Ok(json!({
+            "patterns": patterns,
         })),
     }
 }

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -218,6 +218,19 @@ pub enum McpRequest {
         #[serde(default)]
         workspace_id: Option<String>,
     },
+
+    // Notification settings (via execute_js bridge)
+    GetNotificationConfig,
+    SetNotificationSound {
+        preset: String,
+    },
+    AddMutePattern {
+        pattern: String,
+    },
+    RemoveMutePattern {
+        pattern: String,
+    },
+    ListMutePatterns,
 }
 
 /// Terminal info returned by MCP queries
@@ -304,5 +317,13 @@ pub enum McpResponse {
     },
     Screenshot {
         path: String,
+    },
+    NotificationConfig {
+        enabled: bool,
+        sound_preset: String,
+        volume: f64,
+    },
+    MutePatterns {
+        patterns: Vec<String>,
     },
 }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -947,6 +947,90 @@ pub fn handle_mcp_request(
             }
         }
 
+        McpRequest::GetNotificationConfig => {
+            let js_req = McpRequest::ExecuteJs {
+                script: "const s = window.__NOTIFICATION_STORE__.getSettings(); return { enabled: s.globalEnabled, sound_preset: s.soundPreset, volume: s.volume };".to_string(),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result, .. } => {
+                    let json_str = result.unwrap_or_else(|| "{}".to_string());
+                    match serde_json::from_str::<serde_json::Value>(&json_str) {
+                        Ok(val) => McpResponse::NotificationConfig {
+                            enabled: val.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true),
+                            sound_preset: val.get("sound_preset").and_then(|v| v.as_str()).unwrap_or("chime").to_string(),
+                            volume: val.get("volume").and_then(|v| v.as_f64()).unwrap_or(0.5),
+                        },
+                        Err(e) => McpResponse::Error {
+                            message: format!("Failed to parse notification config: {}", e),
+                        },
+                    }
+                }
+                other => other,
+            }
+        }
+
+        McpRequest::SetNotificationSound { preset } => {
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "window.__NOTIFICATION_STORE__.setSoundPreset('{}'); return 'ok';",
+                    preset.replace('\\', "\\\\").replace('\'', "\\'")
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { .. } => McpResponse::Ok,
+                other => other,
+            }
+        }
+
+        McpRequest::AddMutePattern { pattern } => {
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "window.__NOTIFICATION_STORE__.addMutedPattern('{}'); return 'ok';",
+                    pattern.replace('\\', "\\\\").replace('\'', "\\'")
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { .. } => McpResponse::Ok,
+                other => other,
+            }
+        }
+
+        McpRequest::RemoveMutePattern { pattern } => {
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "window.__NOTIFICATION_STORE__.removeMutedPattern('{}'); return 'ok';",
+                    pattern.replace('\\', "\\\\").replace('\'', "\\'")
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { .. } => McpResponse::Ok,
+                other => other,
+            }
+        }
+
+        McpRequest::ListMutePatterns => {
+            let js_req = McpRequest::ExecuteJs {
+                script: "return window.__NOTIFICATION_STORE__.getMutedPatterns();".to_string(),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result, .. } => {
+                    let json_str = result.unwrap_or_else(|| "[]".to_string());
+                    match serde_json::from_str::<Vec<String>>(&json_str) {
+                        Ok(patterns) => McpResponse::MutePatterns { patterns },
+                        Err(e) => McpResponse::Error {
+                            message: format!("Failed to parse mute patterns: {}", e),
+                        },
+                    }
+                }
+                other => other,
+            }
+        }
+
         McpRequest::SendKeys { terminal_id, keys } => {
             // Validate terminal exists
             if !app_state.terminals.read().contains_key(terminal_id) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { App } from './components/App';
 import { store } from './state/store';
+import { notificationStore } from './state/notification-store';
 import { initLogger } from './utils/Logger';
 import { initPlugins } from './plugins/index';
 
@@ -7,6 +8,7 @@ initLogger();
 
 // Expose store globally for MCP execute_js tool
 (window as any).__STORE__ = store;
+(window as any).__NOTIFICATION_STORE__ = notificationStore;
 
 // Prevent WebView2 native zoom on Ctrl+scroll/keyboard everywhere in the app.
 // The terminal canvas has its own Ctrl+scroll handler for font-size zoom, but


### PR DESCRIPTION
## Summary
- Add 5 new MCP tools for notification settings management: `get_notification_config`, `set_notification_sound`, `add_mute_pattern`, `remove_mute_pattern`, `list_mute_patterns`
- Expose `notificationStore` as `window.__NOTIFICATION_STORE__` in main.ts for execute_js bridge access
- All tools use Pattern C (execute_js bridge) to read/write the frontend notification store
- Bump godly-mcp BUILD constant to 22

## Test plan
- [x] `cargo check -p godly-protocol` passes
- [x] `cargo check -p godly-mcp` passes
- [x] `cargo nextest run -p godly-protocol` — 151 tests pass
- [ ] CI validates cross-crate build and full test suite