### PR TITLE
feat: add font/zoom MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-font-zoom.md
+++ b/changelog/unreleased/feat-mcp-font-zoom.md
@@ -1,0 +1,2 @@
+### Added
+- **Font/zoom MCP tools** — add zoom_in, zoom_out, zoom_reset, and get_font_size MCP tools for programmatic font size control

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -631,6 +631,10 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ExportTerminalInfo { .. } => {
                 Ok(Self::app_only_error("export_terminal_info"))
             }
+            McpRequest::ZoomIn => Ok(Self::app_only_error("zoom_in")),
+            McpRequest::ZoomOut => Ok(Self::app_only_error("zoom_out")),
+            McpRequest::ZoomReset => Ok(Self::app_only_error("zoom_reset")),
+            McpRequest::GetFontSize => Ok(Self::app_only_error("get_font_size")),
         }
     }
 

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -727,6 +727,42 @@ pub fn list_tools() -> Value {
                     },
                     "required": []
                 }
+            },
+            {
+                "name": "zoom_in",
+                "description": "Increase the terminal font size by 1 pixel",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "zoom_out",
+                "description": "Decrease the terminal font size by 1 pixel",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "zoom_reset",
+                "description": "Reset the terminal font size to the default (13px)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "get_font_size",
+                "description": "Get the current terminal font size in pixels",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
             }
         ]
     })
@@ -1258,6 +1294,11 @@ pub fn call_tool(
             McpRequest::ExportTerminalInfo { terminal_id }
         }
 
+        "zoom_in" => McpRequest::ZoomIn,
+        "zoom_out" => McpRequest::ZoomOut,
+        "zoom_reset" => McpRequest::ZoomReset,
+        "get_font_size" => McpRequest::GetFontSize,
+
         _ => return Err(format!("Unknown tool: {}", name)),
     };
 
@@ -1415,6 +1456,9 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         }
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
+        })),
+        McpResponse::FontSize { size } => Ok(json!({
+            "font_size": size,
         })),
     }
 }

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -187,6 +187,12 @@ pub enum McpRequest {
         script: String,
     },
 
+    // Font/zoom controls
+    ZoomIn,
+    ZoomOut,
+    ZoomReset,
+    GetFontSize,
+
     // Screenshot capture
     CaptureScreenshot {
         #[serde(default)]
@@ -304,5 +310,8 @@ pub enum McpResponse {
     },
     Screenshot {
         path: String,
+    },
+    FontSize {
+        size: u32,
     },
 }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1801,69 +1801,55 @@ pub fn handle_mcp_request(
         // === JS bridge ===
 
         McpRequest::ExecuteJs { script } => {
-            use tauri::Manager;
+            execute_js_bridge(script, app_handle)
+        }
 
-            let window = match app_handle.get_webview_window("main") {
-                Some(w) => w,
-                None => {
-                    return McpResponse::Error {
-                        message: "Main window not found".to_string(),
-                    };
-                }
-            };
+        // === Font/zoom controls ===
 
-            // Generate unique request ID
-            let request_id = uuid::Uuid::new_v4().to_string();
-            let (tx, rx) = std::sync::mpsc::channel::<(Option<String>, Option<String>)>();
-
-            // Store the sender in the shared state
-            {
-                let js_state: tauri::State<'_, crate::JsCallbackState> =
-                    app_handle.state::<crate::JsCallbackState>();
-                js_state.senders.lock().insert(request_id.clone(), tx);
+        McpRequest::ZoomIn => {
+            let script = "const s = window.__TERMINAL_SETTINGS_STORE__; s.setFontSize(s.getFontSize() + 1); return 'ok'";
+            let res = execute_js_bridge(script, app_handle);
+            match res {
+                McpResponse::JsResult { error: None, .. } => McpResponse::Ok,
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                other => other,
             }
+        }
 
-            // Wrap the user's script: execute it, then invoke the callback command
-            let wrapped = format!(
-                r#"(async () => {{
-    try {{
-        const __result = await (async () => {{ {script} }})();
-        await window.__TAURI__.core.invoke('mcp_js_result', {{
-            id: '{request_id}',
-            result: JSON.stringify(__result) ?? 'undefined',
-            error: null,
-        }});
-    }} catch (e) {{
-        await window.__TAURI__.core.invoke('mcp_js_result', {{
-            id: '{request_id}',
-            result: null,
-            error: e.message || String(e),
-        }});
-    }}
-}})();"#,
-            );
-
-            if let Err(e) = window.eval(&wrapped) {
-                // Clean up sender
-                let js_state: tauri::State<'_, crate::JsCallbackState> =
-                    app_handle.state::<crate::JsCallbackState>();
-                js_state.senders.lock().remove(&request_id);
-                return McpResponse::Error {
-                    message: format!("Failed to eval JS: {}", e),
-                };
+        McpRequest::ZoomOut => {
+            let script = "const s = window.__TERMINAL_SETTINGS_STORE__; s.setFontSize(s.getFontSize() - 1); return 'ok'";
+            let res = execute_js_bridge(script, app_handle);
+            match res {
+                McpResponse::JsResult { error: None, .. } => McpResponse::Ok,
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                other => other,
             }
+        }
 
-            // Wait for the callback with 10s timeout
-            match rx.recv_timeout(std::time::Duration::from_secs(10)) {
-                Ok((result, error)) => McpResponse::JsResult { result, error },
-                Err(_) => {
-                    let js_state: tauri::State<'_, crate::JsCallbackState> =
-                        app_handle.state::<crate::JsCallbackState>();
-                    js_state.senders.lock().remove(&request_id);
-                    McpResponse::Error {
-                        message: "JS execution timed out after 10s".to_string(),
+        McpRequest::ZoomReset => {
+            let script = "const s = window.__TERMINAL_SETTINGS_STORE__; s.setFontSize(13); return 'ok'";
+            let res = execute_js_bridge(script, app_handle);
+            match res {
+                McpResponse::JsResult { error: None, .. } => McpResponse::Ok,
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                other => other,
+            }
+        }
+
+        McpRequest::GetFontSize => {
+            let script = "return window.__TERMINAL_SETTINGS_STORE__.getFontSize()";
+            let res = execute_js_bridge(script, app_handle);
+            match res {
+                McpResponse::JsResult { result: Some(val), error: None } => {
+                    match val.trim().parse::<u32>() {
+                        Ok(size) => McpResponse::FontSize { size },
+                        Err(_) => McpResponse::Error {
+                            message: format!("Failed to parse font size from: {}", val),
+                        },
                     }
                 }
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                other => other,
             }
         }
 
@@ -2053,6 +2039,74 @@ pub fn handle_mcp_request(
             );
 
             McpResponse::TerminalOutput { content: snippet }
+        }
+    }
+}
+
+/// Execute a JavaScript snippet in the main webview and return the result.
+///
+/// Shared helper used by `ExecuteJs`, `ZoomIn`, `ZoomOut`, `ZoomReset`, and `GetFontSize`.
+fn execute_js_bridge(
+    script: &str,
+    app_handle: &AppHandle,
+) -> McpResponse {
+    use tauri::Manager;
+
+    let window = match app_handle.get_webview_window("main") {
+        Some(w) => w,
+        None => {
+            return McpResponse::Error {
+                message: "Main window not found".to_string(),
+            };
+        }
+    };
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (tx, rx) = std::sync::mpsc::channel::<(Option<String>, Option<String>)>();
+
+    {
+        let js_state: tauri::State<'_, crate::JsCallbackState> =
+            app_handle.state::<crate::JsCallbackState>();
+        js_state.senders.lock().insert(request_id.clone(), tx);
+    }
+
+    let wrapped = format!(
+        r#"(async () => {{
+    try {{
+        const __result = await (async () => {{ {script} }})();
+        await window.__TAURI__.core.invoke('mcp_js_result', {{
+            id: '{request_id}',
+            result: JSON.stringify(__result) ?? 'undefined',
+            error: null,
+        }});
+    }} catch (e) {{
+        await window.__TAURI__.core.invoke('mcp_js_result', {{
+            id: '{request_id}',
+            result: null,
+            error: e.message || String(e),
+        }});
+    }}
+}})();"#,
+    );
+
+    if let Err(e) = window.eval(&wrapped) {
+        let js_state: tauri::State<'_, crate::JsCallbackState> =
+            app_handle.state::<crate::JsCallbackState>();
+        js_state.senders.lock().remove(&request_id);
+        return McpResponse::Error {
+            message: format!("Failed to eval JS: {}", e),
+        };
+    }
+
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok((result, error)) => McpResponse::JsResult { result, error },
+        Err(_) => {
+            let js_state: tauri::State<'_, crate::JsCallbackState> =
+                app_handle.state::<crate::JsCallbackState>();
+            js_state.senders.lock().remove(&request_id);
+            McpResponse::Error {
+                message: "JS execution timed out after 10s".to_string(),
+            }
         }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { App } from './components/App';
 import { store } from './state/store';
+import { terminalSettingsStore } from './state/terminal-settings-store';
 import { initLogger } from './utils/Logger';
 import { initPlugins } from './plugins/index';
 
@@ -7,6 +8,7 @@ initLogger();
 
 // Expose store globally for MCP execute_js tool
 (window as any).__STORE__ = store;
+(window as any).__TERMINAL_SETTINGS_STORE__ = terminalSettingsStore;
 
 // Prevent WebView2 native zoom on Ctrl+scroll/keyboard everywhere in the app.
 // The terminal canvas has its own Ctrl+scroll handler for font-size zoom, but


### PR DESCRIPTION
## Summary
- Add `zoom_in`, `zoom_out`, `zoom_reset`, `get_font_size` MCP tools for programmatic font size control
- Expose `terminalSettingsStore` as `window.__TERMINAL_SETTINGS_STORE__` for MCP JS bridge access
- Part of MCP batch coverage expansion

## Test plan
- `cargo check -p godly-protocol -p godly-mcp` passes
- `cargo nextest run -p godly-protocol` — 151 tests pass
- CI validates cross-crate builds and full test suite