### PR TITLE
feat: add scrollback control MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-scrollback.md
+++ b/changelog/unreleased/feat-mcp-scrollback.md
@@ -1,0 +1,2 @@
+### Added
+- **MCP scrollback control tools** — added `scroll_page_up`, `scroll_page_down`, `scroll_to_top`, `scroll_to_bottom`, and `get_scroll_position` MCP tools for programmatic scrollback navigation

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -596,6 +596,132 @@ impl Backend for DaemonDirectBackend {
                 })
             }
 
+            McpRequest::ScrollPageUp { terminal_id } => {
+                let tid = terminal_id.as_ref().ok_or(
+                    "terminal_id is required in daemon-direct mode (no active terminal available)",
+                )?;
+                let resp = self.daemon_request(&Request::ReadRichGrid {
+                    session_id: tid.clone(),
+                })?;
+                match resp {
+                    Response::RichGrid { grid } => {
+                        let viewport_rows = grid.dimensions.rows as usize;
+                        let new_offset =
+                            (grid.scrollback_offset + viewport_rows).min(grid.total_scrollback);
+                        let set_resp = self.daemon_request(&Request::SetScrollback {
+                            session_id: tid.clone(),
+                            offset: new_offset,
+                        })?;
+                        match set_resp {
+                            Response::Ok => Ok(McpResponse::Ok),
+                            Response::Error { message } => Ok(McpResponse::Error { message }),
+                            other => Ok(McpResponse::Error {
+                                message: format!("Unexpected response: {:?}", other),
+                            }),
+                        }
+                    }
+                    Response::Error { message } => Ok(McpResponse::Error { message }),
+                    other => Ok(McpResponse::Error {
+                        message: format!("Unexpected response: {:?}", other),
+                    }),
+                }
+            }
+
+            McpRequest::ScrollPageDown { terminal_id } => {
+                let tid = terminal_id.as_ref().ok_or(
+                    "terminal_id is required in daemon-direct mode (no active terminal available)",
+                )?;
+                let resp = self.daemon_request(&Request::ReadRichGrid {
+                    session_id: tid.clone(),
+                })?;
+                match resp {
+                    Response::RichGrid { grid } => {
+                        let viewport_rows = grid.dimensions.rows as usize;
+                        let new_offset = grid.scrollback_offset.saturating_sub(viewport_rows);
+                        let set_resp = self.daemon_request(&Request::SetScrollback {
+                            session_id: tid.clone(),
+                            offset: new_offset,
+                        })?;
+                        match set_resp {
+                            Response::Ok => Ok(McpResponse::Ok),
+                            Response::Error { message } => Ok(McpResponse::Error { message }),
+                            other => Ok(McpResponse::Error {
+                                message: format!("Unexpected response: {:?}", other),
+                            }),
+                        }
+                    }
+                    Response::Error { message } => Ok(McpResponse::Error { message }),
+                    other => Ok(McpResponse::Error {
+                        message: format!("Unexpected response: {:?}", other),
+                    }),
+                }
+            }
+
+            McpRequest::ScrollToTop { terminal_id } => {
+                let tid = terminal_id.as_ref().ok_or(
+                    "terminal_id is required in daemon-direct mode (no active terminal available)",
+                )?;
+                let resp = self.daemon_request(&Request::ReadRichGrid {
+                    session_id: tid.clone(),
+                })?;
+                match resp {
+                    Response::RichGrid { grid } => {
+                        let set_resp = self.daemon_request(&Request::SetScrollback {
+                            session_id: tid.clone(),
+                            offset: grid.total_scrollback,
+                        })?;
+                        match set_resp {
+                            Response::Ok => Ok(McpResponse::Ok),
+                            Response::Error { message } => Ok(McpResponse::Error { message }),
+                            other => Ok(McpResponse::Error {
+                                message: format!("Unexpected response: {:?}", other),
+                            }),
+                        }
+                    }
+                    Response::Error { message } => Ok(McpResponse::Error { message }),
+                    other => Ok(McpResponse::Error {
+                        message: format!("Unexpected response: {:?}", other),
+                    }),
+                }
+            }
+
+            McpRequest::ScrollToBottom { terminal_id } => {
+                let tid = terminal_id.as_ref().ok_or(
+                    "terminal_id is required in daemon-direct mode (no active terminal available)",
+                )?;
+                let set_resp = self.daemon_request(&Request::SetScrollback {
+                    session_id: tid.clone(),
+                    offset: 0,
+                })?;
+                match set_resp {
+                    Response::Ok => Ok(McpResponse::Ok),
+                    Response::Error { message } => Ok(McpResponse::Error { message }),
+                    other => Ok(McpResponse::Error {
+                        message: format!("Unexpected response: {:?}", other),
+                    }),
+                }
+            }
+
+            McpRequest::GetScrollPosition { terminal_id } => {
+                let tid = terminal_id.as_ref().ok_or(
+                    "terminal_id is required in daemon-direct mode (no active terminal available)",
+                )?;
+                let resp = self.daemon_request(&Request::ReadRichGrid {
+                    session_id: tid.clone(),
+                })?;
+                match resp {
+                    Response::RichGrid { grid } => Ok(McpResponse::ScrollPosition {
+                        offset: grid.scrollback_offset as u32,
+                        total_scrollback: grid.total_scrollback as u32,
+                        viewport_rows: grid.dimensions.rows as u32,
+                    }),
+                    Response::Error { message } => Ok(McpResponse::Error { message }),
+                    other => Ok(McpResponse::Error {
+                        message: format!("Unexpected response: {:?}", other),
+                    }),
+                }
+            }
+
             // App-only tools that require Tauri
             McpRequest::ListWorkspaces => Ok(Self::app_only_error("list_workspaces")),
             McpRequest::CreateWorkspace { .. } => Ok(Self::app_only_error("create_workspace")),

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 21;
+const BUILD: u32 = 22;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -701,6 +701,76 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "scroll_page_up",
+                "description": "Scroll a terminal up by one page (viewport height). If no terminal_id is provided, uses the active terminal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to scroll (optional — defaults to active terminal)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "scroll_page_down",
+                "description": "Scroll a terminal down by one page (viewport height). If no terminal_id is provided, uses the active terminal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to scroll (optional — defaults to active terminal)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "scroll_to_top",
+                "description": "Scroll a terminal to the top of its scrollback history. If no terminal_id is provided, uses the active terminal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to scroll (optional — defaults to active terminal)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "scroll_to_bottom",
+                "description": "Scroll a terminal to the bottom (live output). If no terminal_id is provided, uses the active terminal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to scroll (optional — defaults to active terminal)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "get_scroll_position",
+                "description": "Get the current scroll position of a terminal, including offset, total scrollback lines, and viewport rows. If no terminal_id is provided, uses the active terminal.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to query (optional — defaults to active terminal)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
                 "name": "capture_screenshot",
                 "description": "Capture a screenshot of a terminal's canvas as a PNG file. Returns the file path to the saved screenshot image. If no terminal_id is provided, captures the first visible canvas.",
                 "inputSchema": {
@@ -1248,6 +1318,31 @@ pub fn call_tool(
             McpRequest::ExecuteJs { script }
         }
 
+        "scroll_page_up" => {
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::ScrollPageUp { terminal_id }
+        }
+
+        "scroll_page_down" => {
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::ScrollPageDown { terminal_id }
+        }
+
+        "scroll_to_top" => {
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::ScrollToTop { terminal_id }
+        }
+
+        "scroll_to_bottom" => {
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::ScrollToBottom { terminal_id }
+        }
+
+        "get_scroll_position" => {
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::GetScrollPosition { terminal_id }
+        }
+
         "capture_screenshot" => {
             let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
             McpRequest::CaptureScreenshot { terminal_id }
@@ -1413,6 +1508,15 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
                 }))
             }
         }
+        McpResponse::ScrollPosition {
+            offset,
+            total_scrollback,
+            viewport_rows,
+        } => Ok(json!({
+            "offset": offset,
+            "total_scrollback": total_scrollback,
+            "viewport_rows": viewport_rows,
+        })),
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
         })),

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -187,6 +187,28 @@ pub enum McpRequest {
         script: String,
     },
 
+    // Scrollback control
+    ScrollPageUp {
+        #[serde(default)]
+        terminal_id: Option<String>,
+    },
+    ScrollPageDown {
+        #[serde(default)]
+        terminal_id: Option<String>,
+    },
+    ScrollToTop {
+        #[serde(default)]
+        terminal_id: Option<String>,
+    },
+    ScrollToBottom {
+        #[serde(default)]
+        terminal_id: Option<String>,
+    },
+    GetScrollPosition {
+        #[serde(default)]
+        terminal_id: Option<String>,
+    },
+
     // Screenshot capture
     CaptureScreenshot {
         #[serde(default)]
@@ -301,6 +323,11 @@ pub enum McpResponse {
     JsResult {
         result: Option<String>,
         error: Option<String>,
+    },
+    ScrollPosition {
+        offset: u32,
+        total_scrollback: u32,
+        viewport_rows: u32,
     },
     Screenshot {
         path: String,

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1798,6 +1798,220 @@ pub fn handle_mcp_request(
             McpResponse::Ok
         }
 
+        // === Scrollback control ===
+
+        McpRequest::ScrollPageUp { terminal_id } => {
+            let tid = terminal_id
+                .clone()
+                .or_else(|| app_state.get_active_terminal_id());
+            let tid = match tid {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No terminal_id provided and no active terminal".to_string(),
+                    };
+                }
+            };
+            // Get current scroll state from the daemon
+            let request = godly_protocol::Request::ReadRichGrid {
+                session_id: tid.clone(),
+            };
+            match daemon.send_request(&request) {
+                Ok(godly_protocol::Response::RichGrid { grid }) => {
+                    let viewport_rows = grid.dimensions.rows as usize;
+                    let new_offset = grid.scrollback_offset + viewport_rows;
+                    // Clamp to total_scrollback
+                    let new_offset = new_offset.min(grid.total_scrollback);
+                    let set_req = godly_protocol::Request::SetScrollback {
+                        session_id: tid,
+                        offset: new_offset,
+                    };
+                    match daemon.send_request(&set_req) {
+                        Ok(godly_protocol::Response::Ok) => McpResponse::Ok,
+                        Ok(godly_protocol::Response::Error { message }) => {
+                            McpResponse::Error { message }
+                        }
+                        Ok(other) => McpResponse::Error {
+                            message: format!("Unexpected response: {:?}", other),
+                        },
+                        Err(e) => McpResponse::Error {
+                            message: format!("Daemon error: {}", e),
+                        },
+                    }
+                }
+                Ok(godly_protocol::Response::Error { message }) => {
+                    McpResponse::Error { message }
+                }
+                Ok(other) => McpResponse::Error {
+                    message: format!("Unexpected response: {:?}", other),
+                },
+                Err(e) => McpResponse::Error {
+                    message: format!("Daemon error: {}", e),
+                },
+            }
+        }
+
+        McpRequest::ScrollPageDown { terminal_id } => {
+            let tid = terminal_id
+                .clone()
+                .or_else(|| app_state.get_active_terminal_id());
+            let tid = match tid {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No terminal_id provided and no active terminal".to_string(),
+                    };
+                }
+            };
+            let request = godly_protocol::Request::ReadRichGrid {
+                session_id: tid.clone(),
+            };
+            match daemon.send_request(&request) {
+                Ok(godly_protocol::Response::RichGrid { grid }) => {
+                    let viewport_rows = grid.dimensions.rows as usize;
+                    let new_offset = grid.scrollback_offset.saturating_sub(viewport_rows);
+                    let set_req = godly_protocol::Request::SetScrollback {
+                        session_id: tid,
+                        offset: new_offset,
+                    };
+                    match daemon.send_request(&set_req) {
+                        Ok(godly_protocol::Response::Ok) => McpResponse::Ok,
+                        Ok(godly_protocol::Response::Error { message }) => {
+                            McpResponse::Error { message }
+                        }
+                        Ok(other) => McpResponse::Error {
+                            message: format!("Unexpected response: {:?}", other),
+                        },
+                        Err(e) => McpResponse::Error {
+                            message: format!("Daemon error: {}", e),
+                        },
+                    }
+                }
+                Ok(godly_protocol::Response::Error { message }) => {
+                    McpResponse::Error { message }
+                }
+                Ok(other) => McpResponse::Error {
+                    message: format!("Unexpected response: {:?}", other),
+                },
+                Err(e) => McpResponse::Error {
+                    message: format!("Daemon error: {}", e),
+                },
+            }
+        }
+
+        McpRequest::ScrollToTop { terminal_id } => {
+            let tid = terminal_id
+                .clone()
+                .or_else(|| app_state.get_active_terminal_id());
+            let tid = match tid {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No terminal_id provided and no active terminal".to_string(),
+                    };
+                }
+            };
+            // Get total_scrollback from the daemon, then set offset to that value
+            let request = godly_protocol::Request::ReadRichGrid {
+                session_id: tid.clone(),
+            };
+            match daemon.send_request(&request) {
+                Ok(godly_protocol::Response::RichGrid { grid }) => {
+                    let set_req = godly_protocol::Request::SetScrollback {
+                        session_id: tid,
+                        offset: grid.total_scrollback,
+                    };
+                    match daemon.send_request(&set_req) {
+                        Ok(godly_protocol::Response::Ok) => McpResponse::Ok,
+                        Ok(godly_protocol::Response::Error { message }) => {
+                            McpResponse::Error { message }
+                        }
+                        Ok(other) => McpResponse::Error {
+                            message: format!("Unexpected response: {:?}", other),
+                        },
+                        Err(e) => McpResponse::Error {
+                            message: format!("Daemon error: {}", e),
+                        },
+                    }
+                }
+                Ok(godly_protocol::Response::Error { message }) => {
+                    McpResponse::Error { message }
+                }
+                Ok(other) => McpResponse::Error {
+                    message: format!("Unexpected response: {:?}", other),
+                },
+                Err(e) => McpResponse::Error {
+                    message: format!("Daemon error: {}", e),
+                },
+            }
+        }
+
+        McpRequest::ScrollToBottom { terminal_id } => {
+            let tid = terminal_id
+                .clone()
+                .or_else(|| app_state.get_active_terminal_id());
+            let tid = match tid {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No terminal_id provided and no active terminal".to_string(),
+                    };
+                }
+            };
+            // Offset 0 = live view (bottom)
+            let set_req = godly_protocol::Request::SetScrollback {
+                session_id: tid,
+                offset: 0,
+            };
+            match daemon.send_request(&set_req) {
+                Ok(godly_protocol::Response::Ok) => McpResponse::Ok,
+                Ok(godly_protocol::Response::Error { message }) => {
+                    McpResponse::Error { message }
+                }
+                Ok(other) => McpResponse::Error {
+                    message: format!("Unexpected response: {:?}", other),
+                },
+                Err(e) => McpResponse::Error {
+                    message: format!("Daemon error: {}", e),
+                },
+            }
+        }
+
+        McpRequest::GetScrollPosition { terminal_id } => {
+            let tid = terminal_id
+                .clone()
+                .or_else(|| app_state.get_active_terminal_id());
+            let tid = match tid {
+                Some(id) => id,
+                None => {
+                    return McpResponse::Error {
+                        message: "No terminal_id provided and no active terminal".to_string(),
+                    };
+                }
+            };
+            let request = godly_protocol::Request::ReadRichGrid {
+                session_id: tid,
+            };
+            match daemon.send_request(&request) {
+                Ok(godly_protocol::Response::RichGrid { grid }) => {
+                    McpResponse::ScrollPosition {
+                        offset: grid.scrollback_offset as u32,
+                        total_scrollback: grid.total_scrollback as u32,
+                        viewport_rows: grid.dimensions.rows as u32,
+                    }
+                }
+                Ok(godly_protocol::Response::Error { message }) => {
+                    McpResponse::Error { message }
+                }
+                Ok(other) => McpResponse::Error {
+                    message: format!("Unexpected response: {:?}", other),
+                },
+                Err(e) => McpResponse::Error {
+                    message: format!("Daemon error: {}", e),
+                },
+            }
+        }
+
         // === JS bridge ===
 
         McpRequest::ExecuteJs { script } => {


### PR DESCRIPTION
## Summary
- Add 5 new MCP tools: `scroll_page_up`, `scroll_page_down`, `scroll_to_top`, `scroll_to_bottom`, `get_scroll_position`
- All tools accept optional `terminal_id` (defaults to active terminal)
- Implemented via daemon IPC (`ReadRichGrid` + `SetScrollback`) in both app handler and daemon-direct backend
- New `McpResponse::ScrollPosition` variant for `get_scroll_position` results
- Part of MCP batch coverage expansion

## Test plan
- [x] `cargo check -p godly-protocol -p godly-mcp` passes
- [x] `cargo nextest run -p godly-protocol` — 151 tests pass
- [ ] CI validates cross-crate compilation (`cargo check --workspace`)