### PR TITLE
feat: add workspace management MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-workspace-management.md
+++ b/changelog/unreleased/feat-mcp-workspace-management.md
@@ -1,0 +1,2 @@
+### Added
+- **MCP workspace management tools** — rename_workspace, reorder_workspaces, get_workspace_details, and open_in_explorer MCP tools for richer workspace control from Claude Code

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -601,6 +601,14 @@ impl Backend for DaemonDirectBackend {
             McpRequest::CreateWorkspace { .. } => Ok(Self::app_only_error("create_workspace")),
             McpRequest::DeleteWorkspace { .. } => Ok(Self::app_only_error("delete_workspace")),
             McpRequest::SwitchWorkspace { .. } => Ok(Self::app_only_error("switch_workspace")),
+            McpRequest::RenameWorkspace { .. } => Ok(Self::app_only_error("rename_workspace")),
+            McpRequest::ReorderWorkspaces { .. } => {
+                Ok(Self::app_only_error("reorder_workspaces"))
+            }
+            McpRequest::GetWorkspaceDetails { .. } => {
+                Ok(Self::app_only_error("get_workspace_details"))
+            }
+            McpRequest::OpenInExplorer { .. } => Ok(Self::app_only_error("open_in_explorer")),
             McpRequest::GetActiveWorkspace => Ok(Self::app_only_error("get_active_workspace")),
             McpRequest::GetActiveTerminal => Ok(Self::app_only_error("get_active_terminal")),
             McpRequest::FocusTerminal { .. } => Ok(Self::app_only_error("focus_terminal")),

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 21;
+const BUILD: u32 = 22;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -144,6 +144,67 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "rename_workspace",
+                "description": "Rename a workspace",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace to rename"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "New name for the workspace"
+                        }
+                    },
+                    "required": ["workspace_id", "name"]
+                }
+            },
+            {
+                "name": "reorder_workspaces",
+                "description": "Reorder workspaces in the sidebar. Pass the full list of workspace IDs in the desired order. Unknown IDs are ignored; any existing workspaces not in the list are appended at the end.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_ids": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Ordered list of workspace IDs"
+                        }
+                    },
+                    "required": ["workspace_ids"]
+                }
+            },
+            {
+                "name": "get_workspace_details",
+                "description": "Get detailed information about a workspace including name, folder path, worktree mode, claude code mode, and terminal count.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace to query"
+                        }
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "open_in_explorer",
+                "description": "Open a file or folder path in Windows Explorer.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "File or folder path to open in Explorer"
+                        }
+                    },
+                    "required": ["path"]
+                }
+            },
+            {
                 "name": "move_terminal_to_workspace",
                 "description": "Move a terminal to a different workspace",
                 "inputSchema": {
@@ -831,6 +892,52 @@ pub fn call_tool(
             McpRequest::SwitchWorkspace { workspace_id }
         }
 
+        "rename_workspace" => {
+            let workspace_id = args
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing workspace_id")?
+                .to_string();
+            let name = args
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing name")?
+                .to_string();
+            McpRequest::RenameWorkspace { workspace_id, name }
+        }
+
+        "reorder_workspaces" => {
+            let workspace_ids: Vec<String> = args
+                .get("workspace_ids")
+                .and_then(|v| v.as_array())
+                .ok_or("Missing workspace_ids array")?
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            if workspace_ids.is_empty() {
+                return Err("workspace_ids array must not be empty".to_string());
+            }
+            McpRequest::ReorderWorkspaces { workspace_ids }
+        }
+
+        "get_workspace_details" => {
+            let workspace_id = args
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing workspace_id")?
+                .to_string();
+            McpRequest::GetWorkspaceDetails { workspace_id }
+        }
+
+        "open_in_explorer" => {
+            let path = args
+                .get("path")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing path")?
+                .to_string();
+            McpRequest::OpenInExplorer { path }
+        }
+
         "move_terminal_to_workspace" => {
             let terminal_id = args
                 .get("terminal_id")
@@ -1313,6 +1420,19 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         })),
         McpResponse::TerminalOutput { content } => Ok(json!({
             "content": content,
+        })),
+        McpResponse::WorkspaceDetails {
+            name,
+            folder_path,
+            worktree_mode,
+            claude_code_mode,
+            terminal_count,
+        } => Ok(json!({
+            "name": name,
+            "folder_path": folder_path,
+            "worktree_mode": worktree_mode,
+            "claude_code_mode": claude_code_mode,
+            "terminal_count": terminal_count,
         })),
         McpResponse::ActiveWorkspace { workspace } => match workspace {
             Some(w) => Ok(json!({

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -56,6 +56,9 @@ pub enum McpRequest {
     CreateWorkspace { name: String, folder_path: String },
     DeleteWorkspace { workspace_id: String },
     SwitchWorkspace { workspace_id: String },
+    RenameWorkspace { workspace_id: String, name: String },
+    ReorderWorkspaces { workspace_ids: Vec<String> },
+    GetWorkspaceDetails { workspace_id: String },
     GetActiveWorkspace,
     GetActiveTerminal,
     MoveTerminalToWorkspace {
@@ -182,6 +185,9 @@ pub enum McpRequest {
         terminal_id: Option<String>,
     },
 
+    // OS integration
+    OpenInExplorer { path: String },
+
     // JS bridge (execute JavaScript in WebView, return result)
     ExecuteJs {
         script: String,
@@ -256,6 +262,13 @@ pub enum McpResponse {
     },
     NotificationStatus { enabled: bool, source: String },
     TerminalOutput { content: String },
+    WorkspaceDetails {
+        name: String,
+        folder_path: String,
+        worktree_mode: bool,
+        claude_code_mode: bool,
+        terminal_count: usize,
+    },
     ActiveWorkspace {
         workspace: Option<McpWorkspaceInfo>,
     },

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -708,6 +708,93 @@ pub fn handle_mcp_request(
             McpResponse::Ok
         }
 
+        McpRequest::RenameWorkspace { workspace_id, name } => {
+            // Validate workspace exists
+            if !app_state.workspaces.read().contains_key(workspace_id) {
+                return McpResponse::Error {
+                    message: format!("Workspace {} not found", workspace_id),
+                };
+            }
+
+            app_state.update_workspace_name(workspace_id, name.clone());
+            auto_save.mark_dirty();
+
+            // Sync frontend via execute_js
+            let escaped_name = name.replace('\\', "\\\\").replace('\'', "\\'");
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "window.__STORE__.updateWorkspace('{}', {{name: '{}'}})",
+                    workspace_id, escaped_name
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                _ => McpResponse::Ok,
+            }
+        }
+
+        McpRequest::ReorderWorkspaces { workspace_ids } => {
+            // Validate that at least some workspace IDs are valid
+            {
+                let workspaces = app_state.workspaces.read();
+                let any_valid = workspace_ids.iter().any(|id| workspaces.contains_key(id));
+                if !any_valid {
+                    return McpResponse::Error {
+                        message: "None of the provided workspace IDs are valid".to_string(),
+                    };
+                }
+            }
+
+            // Sync frontend via execute_js — the store handles unknown IDs gracefully
+            let ids_json = serde_json::to_string(workspace_ids).unwrap_or_else(|_| "[]".to_string());
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "window.__STORE__.reorderWorkspaces({})",
+                    ids_json
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                _ => {
+                    auto_save.mark_dirty();
+                    McpResponse::Ok
+                }
+            }
+        }
+
+        McpRequest::GetWorkspaceDetails { workspace_id } => {
+            let workspace = match app_state.get_workspace(workspace_id) {
+                Some(ws) => ws,
+                None => {
+                    return McpResponse::Error {
+                        message: format!("Workspace {} not found", workspace_id),
+                    };
+                }
+            };
+
+            let terminal_count = app_state.get_workspace_terminals(workspace_id).len();
+
+            McpResponse::WorkspaceDetails {
+                name: workspace.name,
+                folder_path: workspace.folder_path,
+                worktree_mode: workspace.worktree_mode,
+                claude_code_mode: workspace.claude_code_mode,
+                terminal_count,
+            }
+        }
+
+        McpRequest::OpenInExplorer { path } => {
+            match std::process::Command::new("explorer")
+                .arg(path)
+                .spawn()
+            {
+                Ok(_) => McpResponse::Ok,
+                Err(e) => McpResponse::Error {
+                    message: format!("Failed to open explorer: {}", e),
+                },
+            }
+        }
+
         McpRequest::MoveTerminalToWorkspace {
             terminal_id,
             workspace_id,

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -103,6 +103,13 @@ impl AppState {
         }
     }
 
+    pub fn update_workspace_name(&self, id: &str, name: String) {
+        let mut workspaces = self.workspaces.write();
+        if let Some(workspace) = workspaces.get_mut(id) {
+            workspace.name = name;
+        }
+    }
+
     pub fn update_workspace_worktree_mode(&self, id: &str, worktree_mode: bool) {
         let mut workspaces = self.workspaces.write();
         if let Some(workspace) = workspaces.get_mut(id) {


### PR DESCRIPTION
## Summary
- Add `rename_workspace` MCP tool — renames a workspace and syncs frontend via execute_js
- Add `reorder_workspaces` MCP tool — reorders workspace sidebar via execute_js
- Add `get_workspace_details` MCP tool — returns workspace metadata (name, folder_path, worktree_mode, claude_code_mode, terminal_count)
- Add `open_in_explorer` MCP tool — opens a file/folder path in Windows Explorer
- Part of MCP batch coverage expansion

## Changes
- `protocol/src/mcp_messages.rs`: 4 new McpRequest variants + WorkspaceDetails McpResponse variant
- `mcp/src/tools.rs`: Tool JSON schemas in list_tools() + dispatch in call_tool() + response_to_json() handler
- `mcp/src/daemon_direct.rs`: App-only fallback arms for new variants
- `mcp/src/main.rs`: BUILD bump (21 → 22)
- `src/mcp_server/handler.rs`: Handler logic for all 4 tools
- `src/state/app_state.rs`: New update_workspace_name() method

## Test plan
- [x] `cargo check -p godly-protocol` passes
- [x] `cargo check -p godly-mcp` passes
- [x] `cargo test -p godly-protocol` — 151 tests pass
- [x] `cargo test -p godly-mcp` — 9 tests pass
- [ ] CI runs full workspace check