### PR TITLE
feat: add split pane focus and resize MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-split-pane.md
+++ b/changelog/unreleased/feat-mcp-split-pane.md
@@ -1,0 +1,2 @@
+### Added
+- **Split pane focus and resize MCP tools** — Add focus_pane, focus_other_pane, resize_pane, set_split_ratio, and rotate_split MCP tools for controlling split pane layout via the MCP API

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -626,6 +626,11 @@ impl Backend for DaemonDirectBackend {
             McpRequest::GetLayoutTree { .. } => Ok(Self::app_only_error("get_layout_tree")),
             McpRequest::SwapPanes { .. } => Ok(Self::app_only_error("swap_panes")),
             McpRequest::ZoomPane { .. } => Ok(Self::app_only_error("zoom_pane")),
+            McpRequest::FocusPane { .. } => Ok(Self::app_only_error("focus_pane")),
+            McpRequest::FocusOtherPane { .. } => Ok(Self::app_only_error("focus_other_pane")),
+            McpRequest::ResizePane { .. } => Ok(Self::app_only_error("resize_pane")),
+            McpRequest::SetSplitRatio { .. } => Ok(Self::app_only_error("set_split_ratio")),
+            McpRequest::RotateSplit { .. } => Ok(Self::app_only_error("rotate_split")),
             McpRequest::ExecuteJs { .. } => Ok(Self::app_only_error("execute_js")),
             McpRequest::CaptureScreenshot { .. } => Ok(Self::app_only_error("capture_screenshot")),
             McpRequest::ExportTerminalInfo { .. } => {

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -687,6 +687,95 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "focus_pane",
+                "description": "Focus the adjacent pane in a split layout by direction. Moves focus left, right, up, or down from the currently active pane.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": ["left", "right", "up", "down"],
+                            "description": "Direction to move focus: 'left', 'right', 'up', or 'down'"
+                        }
+                    },
+                    "required": ["direction"]
+                }
+            },
+            {
+                "name": "focus_other_pane",
+                "description": "Focus the other pane in a 2-pane split layout. Toggles focus between the two panes. Convenient shortcut when you have exactly two panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "resize_pane",
+                "description": "Resize a split pane by adjusting the split ratio in a given direction. Moves the divider left/right or up/down by a delta amount.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": ["left", "right", "up", "down"],
+                            "description": "Direction to resize: 'left'/'right' adjusts horizontal splits, 'up'/'down' adjusts vertical splits"
+                        },
+                        "delta": {
+                            "type": "number",
+                            "default": 0.05,
+                            "description": "Amount to adjust the ratio (default: 0.05 = 5%). Positive values move the divider in the specified direction."
+                        }
+                    },
+                    "required": ["direction"]
+                }
+            },
+            {
+                "name": "set_split_ratio",
+                "description": "Set the exact split ratio for the root split in a workspace. The ratio controls how space is divided between the two panes (0.0 = all first pane, 1.0 = all second pane).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        },
+                        "ratio": {
+                            "type": "number",
+                            "description": "Split ratio between 0.0 and 1.0 (clamped to 0.15–0.85)"
+                        }
+                    },
+                    "required": ["ratio"]
+                }
+            },
+            {
+                "name": "rotate_split",
+                "description": "Toggle the split direction between horizontal (left/right) and vertical (top/bottom) for the root split in a workspace.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace (optional — defaults to active workspace)"
+                        }
+                    },
+                    "required": []
+                }
+            },
+            {
                 "name": "execute_js",
                 "description": "Execute JavaScript in the Godly Terminal webview and return the result. The script runs in the main webview context with access to the DOM, store, and all frontend APIs. The return value is JSON-stringified. Use for DOM inspection, state queries, and UI manipulation.\n\nExamples:\n- Query store state: `return window.__STORE__.getState().splitViews`\n- Get element rect: `return document.querySelector('.split-divider')?.getBoundingClientRect()`\n- Check CSS classes: `return document.querySelector('.terminal-pane')?.className`",
                 "inputSchema": {
@@ -1241,6 +1330,35 @@ pub fn call_tool(
                 workspace_id,
                 terminal_id,
             }
+        }
+
+        "focus_pane" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            let direction = args.get("direction").and_then(|v| v.as_str()).ok_or("Missing direction")?.to_string();
+            McpRequest::FocusPane { workspace_id, direction }
+        }
+
+        "focus_other_pane" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::FocusOtherPane { workspace_id }
+        }
+
+        "resize_pane" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            let direction = args.get("direction").and_then(|v| v.as_str()).ok_or("Missing direction")?.to_string();
+            let delta = args.get("delta").and_then(|v| v.as_f64()).unwrap_or(0.05);
+            McpRequest::ResizePane { workspace_id, direction, delta }
+        }
+
+        "set_split_ratio" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            let ratio = args.get("ratio").and_then(|v| v.as_f64()).ok_or("Missing ratio")?;
+            McpRequest::SetSplitRatio { workspace_id, ratio }
+        }
+
+        "rotate_split" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::RotateSplit { workspace_id }
         }
 
         "execute_js" => {

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -18,6 +18,10 @@ fn default_split_direction() -> String {
     "horizontal".to_string()
 }
 
+fn default_resize_delta() -> f64 {
+    0.05
+}
+
 fn default_split_ratio() -> f64 {
     0.5
 }
@@ -180,6 +184,33 @@ pub enum McpRequest {
     ZoomPane {
         workspace_id: String,
         terminal_id: Option<String>,
+    },
+
+    // Split pane focus and resize (Pattern C — execute_js bridge)
+    FocusPane {
+        #[serde(default)]
+        workspace_id: Option<String>,
+        direction: String,
+    },
+    FocusOtherPane {
+        #[serde(default)]
+        workspace_id: Option<String>,
+    },
+    ResizePane {
+        #[serde(default)]
+        workspace_id: Option<String>,
+        direction: String,
+        #[serde(default = "default_resize_delta")]
+        delta: f64,
+    },
+    SetSplitRatio {
+        #[serde(default)]
+        workspace_id: Option<String>,
+        ratio: f64,
+    },
+    RotateSplit {
+        #[serde(default)]
+        workspace_id: Option<String>,
     },
 
     // JS bridge (execute JavaScript in WebView, return result)

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -76,6 +76,72 @@ fn auto_focus_terminal(
     let _ = app_handle.emit("focus-terminal", terminal_id.to_string());
 }
 
+/// Execute a JavaScript snippet in the main webview via the JS callback bridge.
+/// Returns McpResponse::Ok on success (the JS result is logged but not returned
+/// as structured data — these tools are fire-and-forget commands).
+fn execute_js_bridge(app_handle: &AppHandle, script: &str) -> McpResponse {
+    use tauri::Manager;
+
+    let window = match app_handle.get_webview_window("main") {
+        Some(w) => w,
+        None => {
+            return McpResponse::Error {
+                message: "Main window not found".to_string(),
+            };
+        }
+    };
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (tx, rx) = std::sync::mpsc::channel::<(Option<String>, Option<String>)>();
+
+    {
+        let js_state: tauri::State<'_, crate::JsCallbackState> =
+            app_handle.state::<crate::JsCallbackState>();
+        js_state.senders.lock().insert(request_id.clone(), tx);
+    }
+
+    let wrapped = format!(
+        r#"(async () => {{
+    try {{
+        const __result = await (async () => {{ {script} }})();
+        await window.__TAURI__.core.invoke('mcp_js_result', {{
+            id: '{request_id}',
+            result: JSON.stringify(__result) ?? 'undefined',
+            error: null,
+        }});
+    }} catch (e) {{
+        await window.__TAURI__.core.invoke('mcp_js_result', {{
+            id: '{request_id}',
+            result: null,
+            error: e.message || String(e),
+        }});
+    }}
+}})();"#,
+    );
+
+    if let Err(e) = window.eval(&wrapped) {
+        let js_state: tauri::State<'_, crate::JsCallbackState> =
+            app_handle.state::<crate::JsCallbackState>();
+        js_state.senders.lock().remove(&request_id);
+        return McpResponse::Error {
+            message: format!("Failed to eval JS: {}", e),
+        };
+    }
+
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok((_, Some(error))) => McpResponse::Error { message: error },
+        Ok(_) => McpResponse::Ok,
+        Err(_) => {
+            let js_state: tauri::State<'_, crate::JsCallbackState> =
+                app_handle.state::<crate::JsCallbackState>();
+            js_state.senders.lock().remove(&request_id);
+            McpResponse::Error {
+                message: "JS execution timed out after 10s".to_string(),
+            }
+        }
+    }
+}
+
 /// Handle an MCP request by delegating to AppState and DaemonClient.
 #[allow(deprecated)]
 pub fn handle_mcp_request(
@@ -1796,6 +1862,204 @@ pub fn handle_mcp_request(
             );
 
             McpResponse::Ok
+        }
+
+        // === Split pane focus and resize (Pattern C — execute_js bridge) ===
+
+        McpRequest::FocusPane {
+            workspace_id,
+            direction,
+        } => {
+            // Map direction to (splitDirection, goSecond) for getAdjacentPane
+            let (split_dir, go_second) = match direction.as_str() {
+                "right" => ("horizontal", true),
+                "left" => ("horizontal", false),
+                "down" => ("vertical", true),
+                "up" => ("vertical", false),
+                _ => {
+                    return McpResponse::Error {
+                        message: format!(
+                            "Invalid direction '{}', must be 'left', 'right', 'up', or 'down'",
+                            direction
+                        ),
+                    };
+                }
+            };
+
+            let ws_resolve = match workspace_id {
+                Some(ref id) => format!("'{}'", id),
+                None => "window.__STORE__.getState().activeWorkspaceId".to_string(),
+            };
+
+            let script = format!(
+                r#"
+                const wsId = {ws_resolve};
+                if (!wsId) return 'No active workspace';
+                const currentId = window.__STORE__.getState().activeTerminalId;
+                if (!currentId) return 'No active terminal';
+                const adjId = window.__STORE__.getAdjacentPane(wsId, currentId, '{split_dir}', {go_second});
+                if (!adjId) return 'No adjacent pane in direction {direction}';
+                window.__STORE__.setActiveTerminal(adjId);
+                return 'Focused ' + adjId;
+                "#,
+            );
+
+            return execute_js_bridge(app_handle, &script);
+        }
+
+        McpRequest::FocusOtherPane { workspace_id } => {
+            let ws_resolve = match workspace_id {
+                Some(ref id) => format!("'{}'", id),
+                None => "window.__STORE__.getState().activeWorkspaceId".to_string(),
+            };
+
+            let script = format!(
+                r#"
+                const wsId = {ws_resolve};
+                if (!wsId) return 'No active workspace';
+                const state = window.__STORE__.getState();
+                const tree = state.layoutTrees[wsId];
+                if (!tree || tree.type !== 'split') return 'No split layout in workspace';
+                const currentId = state.activeTerminalId;
+                if (!currentId) return 'No active terminal';
+
+                // Collect all leaf terminal IDs
+                function collectLeaves(node) {{
+                    if (node.type === 'leaf') return [node.terminal_id];
+                    return [...collectLeaves(node.first), ...collectLeaves(node.second)];
+                }}
+                const leaves = collectLeaves(tree);
+                const other = leaves.find(id => id !== currentId);
+                if (!other) return 'No other pane found';
+                window.__STORE__.setActiveTerminal(other);
+                return 'Focused ' + other;
+                "#,
+            );
+
+            return execute_js_bridge(app_handle, &script);
+        }
+
+        McpRequest::ResizePane {
+            workspace_id,
+            direction,
+            delta,
+        } => {
+            // Map direction to (splitDirection, sign)
+            // "right" or "down" = increase ratio, "left" or "up" = decrease ratio
+            let (split_dir, sign) = match direction.as_str() {
+                "right" => ("horizontal", 1.0),
+                "left" => ("horizontal", -1.0),
+                "down" => ("vertical", 1.0),
+                "up" => ("vertical", -1.0),
+                _ => {
+                    return McpResponse::Error {
+                        message: format!(
+                            "Invalid direction '{}', must be 'left', 'right', 'up', or 'down'",
+                            direction
+                        ),
+                    };
+                }
+            };
+
+            let actual_delta = delta * sign;
+
+            let ws_resolve = match workspace_id {
+                Some(ref id) => format!("'{}'", id),
+                None => "window.__STORE__.getState().activeWorkspaceId".to_string(),
+            };
+
+            let script = format!(
+                r#"
+                const wsId = {ws_resolve};
+                if (!wsId) return 'No active workspace';
+                const currentId = window.__STORE__.getState().activeTerminalId;
+                if (!currentId) return 'No active terminal';
+                const tree = window.__STORE__.getState().layoutTrees[wsId];
+                if (!tree || tree.type !== 'split') return 'No split layout in workspace';
+
+                // Use the updateRatio helper from split-types (exposed on store)
+                // We need to find the nearest ancestor split matching the direction
+                // and adjust its ratio
+                function findTerminal(node, id) {{
+                    if (node.type === 'leaf') return node.terminal_id === id;
+                    return findTerminal(node.first, id) || findTerminal(node.second, id);
+                }}
+                function updateRatio(node, targetId, dir, delta) {{
+                    if (node.type === 'leaf') return node;
+                    const inFirst = findTerminal(node.first, targetId);
+                    const inSecond = findTerminal(node.second, targetId);
+                    if ((inFirst || inSecond) && node.direction === dir) {{
+                        const newRatio = Math.max(0.15, Math.min(0.85, node.ratio + delta));
+                        return {{ ...node, ratio: newRatio }};
+                    }}
+                    if (inFirst) {{
+                        const nf = updateRatio(node.first, targetId, dir, delta);
+                        if (nf !== node.first) return {{ ...node, first: nf }};
+                    }}
+                    if (inSecond) {{
+                        const ns = updateRatio(node.second, targetId, dir, delta);
+                        if (ns !== node.second) return {{ ...node, second: ns }};
+                    }}
+                    return node;
+                }}
+                const updated = updateRatio(tree, currentId, '{split_dir}', {actual_delta});
+                if (updated === tree) return 'No matching split to resize in direction {direction}';
+                window.__STORE__.setState({{
+                    layoutTrees: {{ ...window.__STORE__.getState().layoutTrees, [wsId]: updated }},
+                }});
+                return 'Resized';
+                "#,
+            );
+
+            return execute_js_bridge(app_handle, &script);
+        }
+
+        McpRequest::SetSplitRatio {
+            workspace_id,
+            ratio,
+        } => {
+            let clamped = ratio.clamp(0.15, 0.85);
+
+            let ws_resolve = match workspace_id {
+                Some(ref id) => format!("'{}'", id),
+                None => "window.__STORE__.getState().activeWorkspaceId".to_string(),
+            };
+
+            let script = format!(
+                r#"
+                const wsId = {ws_resolve};
+                if (!wsId) return 'No active workspace';
+                window.__STORE__.updateTreeRatio(wsId, [], {clamped});
+                return 'Set ratio to {clamped}';
+                "#,
+            );
+
+            return execute_js_bridge(app_handle, &script);
+        }
+
+        McpRequest::RotateSplit { workspace_id } => {
+            let ws_resolve = match workspace_id {
+                Some(ref id) => format!("'{}'", id),
+                None => "window.__STORE__.getState().activeWorkspaceId".to_string(),
+            };
+
+            let script = format!(
+                r#"
+                const wsId = {ws_resolve};
+                if (!wsId) return 'No active workspace';
+                const state = window.__STORE__.getState();
+                const tree = state.layoutTrees[wsId];
+                if (!tree || tree.type !== 'split') return 'No split layout in workspace';
+                const newDir = tree.direction === 'horizontal' ? 'vertical' : 'horizontal';
+                const rotated = {{ ...tree, direction: newDir }};
+                window.__STORE__.setState({{
+                    layoutTrees: {{ ...state.layoutTrees, [wsId]: rotated }},
+                }});
+                return 'Rotated to ' + newDir;
+                "#,
+            );
+
+            return execute_js_bridge(app_handle, &script);
         }
 
         // === JS bridge ===


### PR DESCRIPTION
## Summary
- Add 5 new MCP tools for split pane management: `focus_pane`, `focus_other_pane`, `resize_pane`, `set_split_ratio`, `rotate_split`
- All tools use Pattern C (execute_js bridge) to interact with the frontend store
- Part of MCP batch coverage expansion

## Test plan
- [x] `cargo check -p godly-protocol` passes
- [x] `cargo check -p godly-mcp` passes
- [x] `cargo check -p godly-terminal` passes
- [x] `cargo nextest run -p godly-protocol` — 151 tests pass
- [ ] CI validates full workspace build