### PR TITLE
feat: add tab reorder and clipboard MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-tab-reorder-clipboard.md
+++ b/changelog/unreleased/feat-mcp-tab-reorder-clipboard.md
@@ -1,0 +1,2 @@
+### Added
+- **MCP tab reorder and clipboard tools** — added `reorder_tabs`, `get_tab_order`, `copy_to_clipboard`, and `get_selected_text` MCP tools for tab management and clipboard operations

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -631,6 +631,10 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ExportTerminalInfo { .. } => {
                 Ok(Self::app_only_error("export_terminal_info"))
             }
+            McpRequest::ReorderTabs { .. } => Ok(Self::app_only_error("reorder_tabs")),
+            McpRequest::GetTabOrder { .. } => Ok(Self::app_only_error("get_tab_order")),
+            McpRequest::CopyToClipboard { .. } => Ok(Self::app_only_error("copy_to_clipboard")),
+            McpRequest::GetSelectedText { .. } => Ok(Self::app_only_error("get_selected_text")),
         }
     }
 

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 21;
+const BUILD: u32 = 22;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -727,6 +727,67 @@ pub fn list_tools() -> Value {
                     },
                     "required": []
                 }
+            },
+            {
+                "name": "reorder_tabs",
+                "description": "Reorder the terminal tabs in a workspace. Provide the full list of terminal IDs in the desired order.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace whose tabs to reorder"
+                        },
+                        "terminal_ids": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Ordered list of terminal IDs representing the new tab order"
+                        }
+                    },
+                    "required": ["workspace_id", "terminal_ids"]
+                }
+            },
+            {
+                "name": "get_tab_order",
+                "description": "Get the current tab order (list of terminal IDs) for a workspace.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {
+                            "type": "string",
+                            "description": "ID of the workspace to query"
+                        }
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "copy_to_clipboard",
+                "description": "Copy text to the system clipboard.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": "Text to copy to the clipboard"
+                        }
+                    },
+                    "required": ["text"]
+                }
+            },
+            {
+                "name": "get_selected_text",
+                "description": "Get the currently selected text in the webview. Returns the browser's text selection (if any), or an empty string if nothing is selected.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terminal_id": {
+                            "type": "string",
+                            "description": "ID of the terminal to get selection from (optional — reads browser selection if omitted)"
+                        }
+                    },
+                    "required": []
+                }
             }
         ]
     })
@@ -1258,6 +1319,39 @@ pub fn call_tool(
             McpRequest::ExportTerminalInfo { terminal_id }
         }
 
+        "reorder_tabs" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            let terminal_ids: Vec<String> = args
+                .get("terminal_ids")
+                .and_then(|v| v.as_array())
+                .ok_or("Missing terminal_ids array")?
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            if terminal_ids.is_empty() {
+                return Err("terminal_ids array must not be empty".to_string());
+            }
+            McpRequest::ReorderTabs {
+                workspace_id,
+                terminal_ids,
+            }
+        }
+
+        "get_tab_order" => {
+            let workspace_id = args.get("workspace_id").and_then(|v| v.as_str()).ok_or("Missing workspace_id")?.to_string();
+            McpRequest::GetTabOrder { workspace_id }
+        }
+
+        "copy_to_clipboard" => {
+            let text = args.get("text").and_then(|v| v.as_str()).ok_or("Missing text")?.to_string();
+            McpRequest::CopyToClipboard { text }
+        }
+
+        "get_selected_text" => {
+            let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).map(String::from);
+            McpRequest::GetSelectedText { terminal_id }
+        }
+
         _ => return Err(format!("Unknown tool: {}", name)),
     };
 
@@ -1415,6 +1509,12 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         }
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
+        })),
+        McpResponse::TabOrder { terminal_ids } => Ok(json!({
+            "terminal_ids": terminal_ids,
+        })),
+        McpResponse::SelectedText { text } => Ok(json!({
+            "text": text,
         })),
     }
 }

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -199,6 +199,26 @@ pub enum McpRequest {
         terminal_id: Option<String>,
     },
 
+    // Tab management
+    ReorderTabs {
+        workspace_id: String,
+        terminal_ids: Vec<String>,
+    },
+    GetTabOrder {
+        workspace_id: String,
+    },
+
+    // Clipboard
+    CopyToClipboard {
+        text: String,
+    },
+
+    // Selection
+    GetSelectedText {
+        #[serde(default)]
+        terminal_id: Option<String>,
+    },
+
     // Notifications
     Notify {
         terminal_id: String,
@@ -304,5 +324,11 @@ pub enum McpResponse {
     },
     Screenshot {
         path: String,
+    },
+    TabOrder {
+        terminal_ids: Vec<String>,
+    },
+    SelectedText {
+        text: String,
     },
 }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1798,6 +1798,87 @@ pub fn handle_mcp_request(
             McpResponse::Ok
         }
 
+        // === Tab management ===
+
+        McpRequest::ReorderTabs {
+            workspace_id,
+            terminal_ids,
+        } => {
+            // Validate workspace exists
+            let mut workspaces = app_state.workspaces.write();
+            match workspaces.get_mut(workspace_id) {
+                Some(ws) => {
+                    ws.tab_order = terminal_ids.clone();
+                }
+                None => {
+                    return McpResponse::Error {
+                        message: format!("Workspace {} not found", workspace_id),
+                    };
+                }
+            }
+            drop(workspaces);
+
+            auto_save.mark_dirty();
+
+            // Sync frontend
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "window.__STORE__.reorderTerminals('{}', {})",
+                    workspace_id,
+                    serde_json::to_string(terminal_ids).unwrap_or_else(|_| "[]".to_string()),
+                ),
+            };
+            let _ = handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state);
+
+            McpResponse::Ok
+        }
+
+        McpRequest::GetTabOrder { workspace_id } => {
+            match app_state.get_workspace(workspace_id) {
+                Some(ws) => McpResponse::TabOrder {
+                    terminal_ids: ws.tab_order,
+                },
+                None => McpResponse::Error {
+                    message: format!("Workspace {} not found", workspace_id),
+                },
+            }
+        }
+
+        // === Clipboard ===
+
+        McpRequest::CopyToClipboard { text } => {
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    "await navigator.clipboard.writeText({}); return 'ok';",
+                    serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string()),
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { .. } => McpResponse::Ok,
+                other => other,
+            }
+        }
+
+        // === Selection ===
+
+        McpRequest::GetSelectedText { terminal_id: _ } => {
+            let js_req = McpRequest::ExecuteJs {
+                script: "return window.getSelection()?.toString() || '';".to_string(),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result, .. } => {
+                    // Result is JSON-stringified, so parse it
+                    let text = result
+                        .and_then(|r| serde_json::from_str::<String>(&r).ok())
+                        .unwrap_or_default();
+                    McpResponse::SelectedText { text }
+                }
+                other => other,
+            }
+        }
+
         // === JS bridge ===
 
         McpRequest::ExecuteJs { script } => {


### PR DESCRIPTION
## Summary
- Add `reorder_tabs` MCP tool to reorder terminal tabs in a workspace (Pattern B: mutate app_state + sync frontend via execute_js)
- Add `get_tab_order` MCP tool to read current tab order for a workspace (Pattern A: read from app_state)
- Add `copy_to_clipboard` MCP tool to copy text to system clipboard via webview (Pattern C: execute_js with navigator.clipboard.writeText)
- Add `get_selected_text` MCP tool to read current text selection from webview (Pattern C: execute_js with window.getSelection)
- Bump godly-mcp BUILD constant to 22

## Test plan
- [x] `cargo check -p godly-protocol` passes
- [x] `cargo check -p godly-mcp` passes
- [x] `cargo test -p godly-protocol` — all 151 tests pass
- [ ] CI validates cross-crate compilation and full test suite