### PR TITLE
feat: add theme management MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-theme.md
+++ b/changelog/unreleased/feat-mcp-theme.md
@@ -1,0 +1,2 @@
+### Added
+- **Theme management MCP tools** — `list_themes`, `get_active_theme`, and `set_theme` allow MCP clients to query and change the terminal theme programmatically.

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -631,6 +631,9 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ExportTerminalInfo { .. } => {
                 Ok(Self::app_only_error("export_terminal_info"))
             }
+            McpRequest::ListThemes => Ok(Self::app_only_error("list_themes")),
+            McpRequest::GetActiveTheme => Ok(Self::app_only_error("get_active_theme")),
+            McpRequest::SetTheme { .. } => Ok(Self::app_only_error("set_theme")),
         }
     }
 

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -727,6 +727,38 @@ pub fn list_tools() -> Value {
                     },
                     "required": []
                 }
+            },
+            {
+                "name": "list_themes",
+                "description": "List all available terminal themes and the currently active theme.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "get_active_theme",
+                "description": "Get the name and ID of the currently active terminal theme.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "set_theme",
+                "description": "Set the active terminal theme by name or ID.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "theme_name": {
+                            "type": "string",
+                            "description": "Name or ID of the theme to activate"
+                        }
+                    },
+                    "required": ["theme_name"]
+                }
             }
         ]
     })
@@ -1258,6 +1290,19 @@ pub fn call_tool(
             McpRequest::ExportTerminalInfo { terminal_id }
         }
 
+        "list_themes" => McpRequest::ListThemes,
+
+        "get_active_theme" => McpRequest::GetActiveTheme,
+
+        "set_theme" => {
+            let theme_name = args
+                .get("theme_name")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing theme_name")?
+                .to_string();
+            McpRequest::SetTheme { theme_name }
+        }
+
         _ => return Err(format!("Unknown tool: {}", name)),
     };
 
@@ -1415,6 +1460,10 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         }
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
+        })),
+        McpResponse::ThemeList { themes, active } => Ok(json!({
+            "themes": themes,
+            "active": active,
         })),
     }
 }

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -199,6 +199,11 @@ pub enum McpRequest {
         terminal_id: Option<String>,
     },
 
+    // Theme management
+    ListThemes,
+    GetActiveTheme,
+    SetTheme { theme_name: String },
+
     // Notifications
     Notify {
         terminal_id: String,
@@ -304,5 +309,9 @@ pub enum McpResponse {
     },
     Screenshot {
         path: String,
+    },
+    ThemeList {
+        themes: Vec<String>,
+        active: String,
     },
 }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1798,6 +1798,108 @@ pub fn handle_mcp_request(
             McpResponse::Ok
         }
 
+        // === Theme management ===
+
+        McpRequest::ListThemes => {
+            let js_req = McpRequest::ExecuteJs {
+                script: r#"
+                    const store = window.__THEME_STORE__;
+                    if (!store) return JSON.stringify({ error: '__THEME_STORE__ not found' });
+                    const all = store.getAllThemes();
+                    const active = store.getActiveTheme();
+                    return JSON.stringify({
+                        themes: all.map(t => t.name),
+                        active: active.name,
+                    });
+                "#.to_string(),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result: Some(json_str), .. } => {
+                    match serde_json::from_str::<serde_json::Value>(&json_str) {
+                        Ok(val) => {
+                            if let Some(err) = val.get("error").and_then(|e| e.as_str()) {
+                                return McpResponse::Error { message: err.to_string() };
+                            }
+                            let themes = val.get("themes")
+                                .and_then(|t| t.as_array())
+                                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                                .unwrap_or_default();
+                            let active = val.get("active")
+                                .and_then(|a| a.as_str())
+                                .unwrap_or("unknown")
+                                .to_string();
+                            McpResponse::ThemeList { themes, active }
+                        }
+                        Err(e) => McpResponse::Error {
+                            message: format!("Failed to parse theme list: {}", e),
+                        },
+                    }
+                }
+                McpResponse::JsResult { result: None, .. } => McpResponse::Error {
+                    message: "Theme list returned no result".to_string(),
+                },
+                other => other,
+            }
+        }
+
+        McpRequest::GetActiveTheme => {
+            let js_req = McpRequest::ExecuteJs {
+                script: r#"
+                    const store = window.__THEME_STORE__;
+                    if (!store) return JSON.stringify({ error: '__THEME_STORE__ not found' });
+                    const active = store.getActiveTheme();
+                    return JSON.stringify({ id: active.id, name: active.name });
+                "#.to_string(),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result, .. } => {
+                    McpResponse::JsResult { result, error: None }
+                }
+                other => other,
+            }
+        }
+
+        McpRequest::SetTheme { theme_name } => {
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    r#"
+                    const store = window.__THEME_STORE__;
+                    if (!store) return JSON.stringify({{ error: '__THEME_STORE__ not found' }});
+                    const all = store.getAllThemes();
+                    const match = all.find(t => t.name === '{}' || t.id === '{}');
+                    if (!match) return JSON.stringify({{ error: 'Theme not found: {}' }});
+                    store.setActiveTheme(match.id);
+                    return JSON.stringify({{ success: true, active: match.name }});
+                    "#,
+                    theme_name.replace('\'', "\\'"),
+                    theme_name.replace('\'', "\\'"),
+                    theme_name.replace('\'', "\\'"),
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result: Some(json_str), .. } => {
+                    match serde_json::from_str::<serde_json::Value>(&json_str) {
+                        Ok(val) => {
+                            if let Some(err) = val.get("error").and_then(|e| e.as_str()) {
+                                return McpResponse::Error { message: err.to_string() };
+                            }
+                            McpResponse::Ok
+                        }
+                        Err(e) => McpResponse::Error {
+                            message: format!("Failed to parse set_theme result: {}", e),
+                        },
+                    }
+                }
+                McpResponse::JsResult { result: None, .. } => McpResponse::Error {
+                    message: "set_theme returned no result".to_string(),
+                },
+                other => other,
+            }
+        }
+
         // === JS bridge ===
 
         McpRequest::ExecuteJs { script } => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { App } from './components/App';
 import { store } from './state/store';
+import { themeStore } from './state/theme-store';
 import { initLogger } from './utils/Logger';
 import { initPlugins } from './plugins/index';
 
@@ -7,6 +8,7 @@ initLogger();
 
 // Expose store globally for MCP execute_js tool
 (window as any).__STORE__ = store;
+(window as any).__THEME_STORE__ = themeStore;
 
 // Prevent WebView2 native zoom on Ctrl+scroll/keyboard everywhere in the app.
 // The terminal canvas has its own Ctrl+scroll handler for font-size zoom, but


### PR DESCRIPTION
## Summary
- Add `list_themes`, `get_active_theme`, and `set_theme` MCP tools for programmatic theme management
- Expose `themeStore` as `window.__THEME_STORE__` for MCP execute_js bridge
- Part of MCP batch coverage expansion

## Test plan
- [x] `cargo check -p godly-protocol -p godly-mcp` passes
- [x] `cargo nextest run -p godly-protocol` — 151 tests pass
- [ ] CI validates full workspace build