### PR TITLE
feat: add shell settings MCP tools

### DIFF
--- a/changelog/unreleased/feat-mcp-shell-settings.md
+++ b/changelog/unreleased/feat-mcp-shell-settings.md
@@ -1,0 +1,2 @@
+### Added
+- **Shell settings MCP tools** — `list_available_shells`, `get_default_shell`, and `set_default_shell` allow MCP clients to query and change the default shell configuration for new terminals.

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -631,6 +631,20 @@ impl Backend for DaemonDirectBackend {
             McpRequest::ExportTerminalInfo { .. } => {
                 Ok(Self::app_only_error("export_terminal_info"))
             }
+            McpRequest::ListAvailableShells => {
+                // Pure data — can be handled without the app
+                Ok(McpResponse::AvailableShells {
+                    shells: vec![
+                        "windows".to_string(),
+                        "pwsh".to_string(),
+                        "cmd".to_string(),
+                        "wsl".to_string(),
+                        "custom".to_string(),
+                    ],
+                })
+            }
+            McpRequest::GetDefaultShell => Ok(Self::app_only_error("get_default_shell")),
+            McpRequest::SetDefaultShell { .. } => Ok(Self::app_only_error("set_default_shell")),
         }
     }
 

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -727,6 +727,51 @@ pub fn list_tools() -> Value {
                     },
                     "required": []
                 }
+            },
+            {
+                "name": "list_available_shells",
+                "description": "List all supported shell types that can be used as the default shell.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "get_default_shell",
+                "description": "Get the current default shell configuration used for new terminals.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "set_default_shell",
+                "description": "Set the default shell for new terminals. Use list_available_shells to see valid shell_type values. For 'wsl', optionally specify a distribution. For 'custom', provide the program path and optional args.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "shell_type": {
+                            "type": "string",
+                            "description": "Shell type: 'windows', 'pwsh', 'cmd', 'wsl', or 'custom'"
+                        },
+                        "wsl_distribution": {
+                            "type": "string",
+                            "description": "WSL distribution name (only for shell_type='wsl')"
+                        },
+                        "custom_program": {
+                            "type": "string",
+                            "description": "Path to shell executable (required for shell_type='custom')"
+                        },
+                        "custom_args": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Arguments for the custom shell program (only for shell_type='custom')"
+                        }
+                    },
+                    "required": ["shell_type"]
+                }
             }
         ]
     })
@@ -1258,6 +1303,29 @@ pub fn call_tool(
             McpRequest::ExportTerminalInfo { terminal_id }
         }
 
+        "list_available_shells" => McpRequest::ListAvailableShells,
+
+        "get_default_shell" => McpRequest::GetDefaultShell,
+
+        "set_default_shell" => {
+            let shell_type = args
+                .get("shell_type")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing shell_type")?
+                .to_string();
+            let wsl_distribution = args.get("wsl_distribution").and_then(|v| v.as_str()).map(String::from);
+            let custom_program = args.get("custom_program").and_then(|v| v.as_str()).map(String::from);
+            let custom_args = args.get("custom_args").and_then(|v| v.as_array()).map(|arr| {
+                arr.iter().filter_map(|v| v.as_str().map(String::from)).collect()
+            });
+            McpRequest::SetDefaultShell {
+                shell_type,
+                wsl_distribution,
+                custom_program,
+                custom_args,
+            }
+        }
+
         _ => return Err(format!("Unknown tool: {}", name)),
     };
 
@@ -1416,6 +1484,27 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         McpResponse::Screenshot { path } => Ok(json!({
             "path": path,
         })),
+        McpResponse::AvailableShells { shells } => Ok(json!({
+            "shells": shells,
+        })),
+        McpResponse::ShellInfo {
+            shell_type,
+            wsl_distribution,
+            custom_program,
+            custom_args,
+        } => {
+            let mut obj = json!({ "shell_type": shell_type });
+            if let Some(dist) = wsl_distribution {
+                obj["wsl_distribution"] = json!(dist);
+            }
+            if let Some(prog) = custom_program {
+                obj["custom_program"] = json!(prog);
+            }
+            if let Some(args) = custom_args {
+                obj["custom_args"] = json!(args);
+            }
+            Ok(obj)
+        }
     }
 }
 

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -182,6 +182,19 @@ pub enum McpRequest {
         terminal_id: Option<String>,
     },
 
+    // Shell settings
+    ListAvailableShells,
+    GetDefaultShell,
+    SetDefaultShell {
+        shell_type: String,
+        #[serde(default)]
+        wsl_distribution: Option<String>,
+        #[serde(default)]
+        custom_program: Option<String>,
+        #[serde(default)]
+        custom_args: Option<Vec<String>>,
+    },
+
     // JS bridge (execute JavaScript in WebView, return result)
     ExecuteJs {
         script: String,
@@ -304,5 +317,17 @@ pub enum McpResponse {
     },
     Screenshot {
         path: String,
+    },
+    AvailableShells {
+        shells: Vec<String>,
+    },
+    ShellInfo {
+        shell_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wsl_distribution: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        custom_program: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        custom_args: Option<Vec<String>>,
     },
 }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -1798,6 +1798,155 @@ pub fn handle_mcp_request(
             McpResponse::Ok
         }
 
+        // === Shell settings ===
+
+        McpRequest::ListAvailableShells => {
+            McpResponse::AvailableShells {
+                shells: vec![
+                    "windows".to_string(),
+                    "pwsh".to_string(),
+                    "cmd".to_string(),
+                    "wsl".to_string(),
+                    "custom".to_string(),
+                ],
+            }
+        }
+
+        McpRequest::GetDefaultShell => {
+            let js_req = McpRequest::ExecuteJs {
+                script: r#"
+                    const store = window.__TERMINAL_SETTINGS_STORE__;
+                    if (!store) return JSON.stringify({ error: '__TERMINAL_SETTINGS_STORE__ not found' });
+                    const shell = store.getDefaultShell();
+                    return JSON.stringify(shell);
+                "#.to_string(),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result: Some(json_str), .. } => {
+                    match serde_json::from_str::<serde_json::Value>(&json_str) {
+                        Ok(val) => {
+                            if let Some(err) = val.get("error").and_then(|e| e.as_str()) {
+                                return McpResponse::Error { message: err.to_string() };
+                            }
+                            let shell_type = val.get("type")
+                                .and_then(|t| t.as_str())
+                                .unwrap_or("unknown")
+                                .to_string();
+                            let wsl_distribution = val.get("distribution")
+                                .and_then(|d| d.as_str())
+                                .map(String::from);
+                            let custom_program = val.get("program")
+                                .and_then(|p| p.as_str())
+                                .map(String::from);
+                            let custom_args = val.get("args")
+                                .and_then(|a| a.as_array())
+                                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect());
+                            McpResponse::ShellInfo {
+                                shell_type,
+                                wsl_distribution,
+                                custom_program,
+                                custom_args,
+                            }
+                        }
+                        Err(e) => McpResponse::Error {
+                            message: format!("Failed to parse shell info: {}", e),
+                        },
+                    }
+                }
+                McpResponse::JsResult { result: None, .. } => McpResponse::Error {
+                    message: "get_default_shell returned no result".to_string(),
+                },
+                other => other,
+            }
+        }
+
+        McpRequest::SetDefaultShell {
+            shell_type,
+            wsl_distribution,
+            custom_program,
+            custom_args,
+        } => {
+            // Validate and build the JS shell object
+            let shell_js = match shell_type.as_str() {
+                "windows" | "pwsh" | "cmd" => {
+                    format!("{{ type: '{}' }}", shell_type)
+                }
+                "wsl" => {
+                    match &wsl_distribution {
+                        Some(dist) => format!(
+                            "{{ type: 'wsl', distribution: '{}' }}",
+                            dist.replace('\'', "\\'")
+                        ),
+                        None => "{ type: 'wsl' }".to_string(),
+                    }
+                }
+                "custom" => {
+                    let program = match &custom_program {
+                        Some(p) => p.replace('\'', "\\'"),
+                        None => {
+                            return McpResponse::Error {
+                                message: "custom_program is required for shell_type='custom'".to_string(),
+                            };
+                        }
+                    };
+                    match &custom_args {
+                        Some(args) => {
+                            let args_js: Vec<String> = args.iter()
+                                .map(|a| format!("'{}'", a.replace('\'', "\\'")))
+                                .collect();
+                            format!(
+                                "{{ type: 'custom', program: '{}', args: [{}] }}",
+                                program,
+                                args_js.join(", ")
+                            )
+                        }
+                        None => format!("{{ type: 'custom', program: '{}' }}", program),
+                    }
+                }
+                other => {
+                    return McpResponse::Error {
+                        message: format!(
+                            "Invalid shell_type: '{}'. Valid values: windows, pwsh, cmd, wsl, custom",
+                            other
+                        ),
+                    };
+                }
+            };
+
+            let js_req = McpRequest::ExecuteJs {
+                script: format!(
+                    r#"
+                    const store = window.__TERMINAL_SETTINGS_STORE__;
+                    if (!store) return JSON.stringify({{ error: '__TERMINAL_SETTINGS_STORE__ not found' }});
+                    store.setDefaultShell({});
+                    return JSON.stringify({{ success: true }});
+                    "#,
+                    shell_js,
+                ),
+            };
+            match handle_mcp_request(&js_req, app_state, daemon, auto_save, app_handle, llm_state) {
+                McpResponse::JsResult { error: Some(e), .. } => McpResponse::Error { message: e },
+                McpResponse::JsResult { result: Some(json_str), .. } => {
+                    match serde_json::from_str::<serde_json::Value>(&json_str) {
+                        Ok(val) => {
+                            if let Some(err) = val.get("error").and_then(|e| e.as_str()) {
+                                return McpResponse::Error { message: err.to_string() };
+                            }
+                            McpResponse::Ok
+                        }
+                        Err(e) => McpResponse::Error {
+                            message: format!("Failed to parse set_default_shell result: {}", e),
+                        },
+                    }
+                }
+                McpResponse::JsResult { result: None, .. } => McpResponse::Error {
+                    message: "set_default_shell returned no result".to_string(),
+                },
+                other => other,
+            }
+        }
+
         // === JS bridge ===
 
         McpRequest::ExecuteJs { script } => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { App } from './components/App';
 import { store } from './state/store';
+import { terminalSettingsStore } from './state/terminal-settings-store';
 import { initLogger } from './utils/Logger';
 import { initPlugins } from './plugins/index';
 
@@ -7,6 +8,7 @@ initLogger();
 
 // Expose store globally for MCP execute_js tool
 (window as any).__STORE__ = store;
+(window as any).__TERMINAL_SETTINGS_STORE__ = terminalSettingsStore;
 
 // Prevent WebView2 native zoom on Ctrl+scroll/keyboard everywhere in the app.
 // The terminal canvas has its own Ctrl+scroll handler for font-size zoom, but


### PR DESCRIPTION
## Summary
- Add `list_available_shells`, `get_default_shell`, and `set_default_shell` MCP tools
- `list_available_shells` returns the fixed list of supported shell types (works in daemon-direct mode too)
- `get_default_shell` reads the current default shell from the frontend terminal settings store
- `set_default_shell` validates shell type and sets it via the frontend store
- Expose `__TERMINAL_SETTINGS_STORE__` globally in `main.ts` for MCP access
- Part of MCP batch coverage expansion

## Test plan
- [x] `cargo check -p godly-protocol -p godly-mcp` passes
- [x] 151 protocol tests pass (`cargo nextest run -p godly-protocol`)
- [ ] CI validates cross-crate compilation