### PR TITLE
feat: AI Tool Mode (Claude / Codex / Both)

### DIFF
--- a/changelog/unreleased/467-ai-tool-mode.md
+++ b/changelog/unreleased/467-ai-tool-mode.md
@@ -1,0 +1,2 @@
+### Added
+- **AI Tool Mode** — Workspaces now support multiple AI tool modes: None, Claude, Codex, and Both. Replaces the binary Claude Code toggle with a cycle button (left-click: `--` → `CC` → `CX` → `2x`) and right-click submenu. "Both" mode creates a vertical split with Claude and Codex terminals side by side, with worktree suffix naming (`-claude`/`-codex`). Backward-compatible with existing `claude_code_mode` persisted data. (refs #467)

--- a/e2e/specs/claude-code.e2e.ts
+++ b/e2e/specs/claude-code.e2e.ts
@@ -32,22 +32,22 @@ async function invokeCommand<T>(cmd: string, args: Record<string, unknown> = {})
 }
 
 /**
- * Toggle Claude Code mode for a workspace via IPC and update the frontend store.
+ * Set AI tool mode for a workspace via IPC and update the frontend store.
  */
-async function toggleClaudeCodeMode(workspaceId: string, enabled: boolean): Promise<void> {
-  await invokeCommand('toggle_claude_code_mode', {
+async function setAiToolMode(workspaceId: string, mode: string): Promise<void> {
+  await invokeCommand('set_ai_tool_mode', {
     workspaceId,
-    enabled,
+    mode,
   });
   await browser.execute(
-    (wsId: string, mode: boolean) => {
+    (wsId: string, aiMode: string) => {
       const appStore = (window as any).__store;
       if (appStore) {
-        appStore.updateWorkspace(wsId, { claudeCodeMode: mode });
+        appStore.updateWorkspace(wsId, { aiToolMode: aiMode });
       }
     },
     workspaceId,
-    enabled
+    mode
   );
   await browser.pause(500);
 }
@@ -63,18 +63,18 @@ async function getActiveWorkspaceId(): Promise<string | null> {
 }
 
 /**
- * Get the claudeCodeMode flag for a workspace from the store.
+ * Get the aiToolMode flag for a workspace from the store.
  */
-async function getClaudeCodeMode(workspaceId: string): Promise<boolean> {
+async function getAiToolMode(workspaceId: string): Promise<string> {
   return browser.execute((wsId: string) => {
     const appStore = (window as any).__store;
-    if (!appStore) return false;
+    if (!appStore) return 'none';
     const ws = appStore.getState().workspaces.find((w: any) => w.id === wsId);
-    return ws ? ws.claudeCodeMode : false;
+    return ws ? ws.aiToolMode : 'none';
   }, workspaceId);
 }
 
-describe('Claude Code Mode', () => {
+describe('AI Tool Mode (Claude Code)', () => {
   let workspaceId: string;
 
   before(async () => {
@@ -86,24 +86,24 @@ describe('Claude Code Mode', () => {
   });
 
   after(async () => {
-    // Ensure CC mode is off after tests
-    await toggleClaudeCodeMode(workspaceId, false);
+    // Ensure AI tool mode is off after tests
+    await setAiToolMode(workspaceId, 'none');
   });
 
-  it('should toggle Claude Code mode on via IPC and show CC toggle active', async () => {
-    await toggleClaudeCodeMode(workspaceId, true);
+  it('should set AI tool mode to claude via IPC and show AI tool toggle active', async () => {
+    await setAiToolMode(workspaceId, 'claude');
 
-    const hasToggle = await elementExists('.claude-code-toggle.active');
+    const hasToggle = await elementExists('.ai-tool-toggle.active');
     expect(hasToggle).toBe(true);
   });
 
   it('should reflect enabled state in the store', async () => {
-    const mode = await getClaudeCodeMode(workspaceId);
-    expect(mode).toBe(true);
+    const mode = await getAiToolMode(workspaceId);
+    expect(mode).toBe('claude');
   });
 
-  it('should auto-execute claude command when creating a terminal with CC mode on', async () => {
-    // CC mode is still on from prior test
+  it('should auto-execute claude command when creating a terminal with AI tool mode claude', async () => {
+    // AI tool mode is still claude from prior test
     const countBefore = await getElementCount('.tab');
     await createNewTerminalTab();
 
@@ -116,18 +116,18 @@ describe('Claude Code Mode', () => {
     await waitForTerminalText('claude', 30000);
   });
 
-  it('should toggle Claude Code mode off and deactivate CC toggle', async () => {
-    await toggleClaudeCodeMode(workspaceId, false);
+  it('should set AI tool mode to none and deactivate AI tool toggle', async () => {
+    await setAiToolMode(workspaceId, 'none');
 
-    const hasActiveToggle = await elementExists('.claude-code-toggle.active');
+    const hasActiveToggle = await elementExists('.ai-tool-toggle.active');
     expect(hasActiveToggle).toBe(false);
 
     // Toggle button should still exist, just not active
-    const hasToggle = await elementExists('.claude-code-toggle');
+    const hasToggle = await elementExists('.ai-tool-toggle');
     expect(hasToggle).toBe(true);
   });
 
-  it('should NOT auto-execute claude command when CC mode is off', async () => {
+  it('should NOT auto-execute claude command when AI tool mode is none', async () => {
     const countBefore = await getElementCount('.tab');
     await createNewTerminalTab();
 
@@ -156,18 +156,18 @@ describe('Claude Code Mode', () => {
     expect(text).not.toContain('claude --dangerously-skip-permissions');
   });
 
-  it('should persist Claude Code mode via toggle_claude_code_mode IPC', async () => {
-    // Enable CC mode
-    await toggleClaudeCodeMode(workspaceId, true);
+  it('should persist AI tool mode via set_ai_tool_mode IPC', async () => {
+    // Enable claude mode
+    await setAiToolMode(workspaceId, 'claude');
 
     // Verify it's enabled in store
-    const enabled = await getClaudeCodeMode(workspaceId);
-    expect(enabled).toBe(true);
+    const enabled = await getAiToolMode(workspaceId);
+    expect(enabled).toBe('claude');
 
     // Disable it
-    await toggleClaudeCodeMode(workspaceId, false);
+    await setAiToolMode(workspaceId, 'none');
 
-    const disabled = await getClaudeCodeMode(workspaceId);
-    expect(disabled).toBe(false);
+    const disabled = await getAiToolMode(workspaceId);
+    expect(disabled).toBe('none');
   });
 });

--- a/src-tauri/remote/src/layout_reader.rs
+++ b/src-tauri/remote/src/layout_reader.rs
@@ -22,6 +22,22 @@ pub enum ShellType {
     Custom { program: String, args: Option<Vec<String>> },
 }
 
+/// AI tool mode (mirrors state/models.rs).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AiToolMode {
+    None,
+    Claude,
+    Codex,
+    Both,
+}
+
+impl Default for AiToolMode {
+    fn default() -> Self {
+        AiToolMode::None
+    }
+}
+
 impl ShellType {
     pub fn display_name(&self) -> String {
         match self {
@@ -59,7 +75,7 @@ pub struct Workspace {
     #[serde(default)]
     pub worktree_mode: bool,
     #[serde(default)]
-    pub claude_code_mode: bool,
+    pub ai_tool_mode: AiToolMode,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/remote/src/routes/workspaces.rs
+++ b/src-tauri/remote/src/routes/workspaces.rs
@@ -15,7 +15,7 @@ pub struct WorkspaceItem {
     /// Redacted to folder name only (not full path) to prevent information disclosure.
     pub folder_path: String,
     pub shell_type: String,
-    pub claude_code_mode: bool,
+    pub ai_tool_mode: String,
     pub terminals: Vec<WorkspaceTerminal>,
 }
 
@@ -104,7 +104,7 @@ pub async fn list_workspaces(
                 name: ws.name.clone(),
                 folder_path: redact_path(&ws.folder_path),
                 shell_type: ws.shell_type.display_name(),
-                claude_code_mode: ws.claude_code_mode,
+                ai_tool_mode: serde_json::to_string(&ws.ai_tool_mode).unwrap_or_else(|_| "\"none\"".to_string()).trim_matches('"').to_string(),
                 terminals,
             }
         })

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use crate::daemon_client::DaemonClient;
 use crate::persistence::AutoSaveManager;
 #[allow(deprecated)]
-use crate::state::{AppState, ShellType, SplitView, Workspace};
+use crate::state::{AiToolMode, AppState, ShellType, SplitView, Workspace};
 
 #[tauri::command]
 pub fn create_workspace(
@@ -26,7 +26,7 @@ pub fn create_workspace(
         tab_order: Vec::new(),
         shell_type: shell_type.unwrap_or_default(),
         worktree_mode: false,
-        claude_code_mode: false,
+        ai_tool_mode: AiToolMode::None,
     };
 
     state.add_workspace(workspace);

--- a/src-tauri/src/commands/worktree.rs
+++ b/src-tauri/src/commands/worktree.rs
@@ -18,13 +18,13 @@ pub fn toggle_worktree_mode(
 }
 
 #[tauri::command]
-pub fn toggle_claude_code_mode(
+pub fn set_ai_tool_mode(
     workspace_id: String,
-    enabled: bool,
+    mode: crate::state::AiToolMode,
     state: State<Arc<AppState>>,
     auto_save: State<Arc<AutoSaveManager>>,
 ) -> Result<(), String> {
-    state.update_workspace_claude_code_mode(&workspace_id, enabled);
+    state.update_workspace_ai_tool_mode(&workspace_id, mode);
     auto_save.mark_dirty();
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -609,7 +609,7 @@ pub fn run() {
             commands::get_cmd_aliases_path,
             commands::ensure_cmd_autorun,
             commands::toggle_worktree_mode,
-            commands::toggle_claude_code_mode,
+            commands::set_ai_tool_mode,
             commands::is_git_repo,
             commands::list_worktrees,
             commands::remove_worktree,

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -44,7 +44,7 @@ fn ensure_mcp_workspace(
         tab_order: Vec::new(),
         shell_type: crate::state::ShellType::default(),
         worktree_mode: false,
-        claude_code_mode: false,
+        ai_tool_mode: crate::state::AiToolMode::None,
     };
 
     app_state.add_workspace(workspace);

--- a/src-tauri/src/persistence/layout.rs
+++ b/src-tauri/src/persistence/layout.rs
@@ -133,7 +133,7 @@ pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
                     tab_order: ws.tab_order.clone(),
                     shell_type: ws.shell_type.clone(),
                     worktree_mode: ws.worktree_mode,
-                    claude_code_mode: ws.claude_code_mode,
+                    ai_tool_mode: ws.ai_tool_mode,
                 });
             }
 

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -110,10 +110,10 @@ impl AppState {
         }
     }
 
-    pub fn update_workspace_claude_code_mode(&self, id: &str, claude_code_mode: bool) {
+    pub fn update_workspace_ai_tool_mode(&self, id: &str, ai_tool_mode: super::models::AiToolMode) {
         let mut workspaces = self.workspaces.write();
         if let Some(workspace) = workspaces.get_mut(id) {
-            workspace.claude_code_mode = claude_code_mode;
+            workspace.ai_tool_mode = ai_tool_mode;
         }
     }
 
@@ -520,7 +520,7 @@ impl Default for AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::models::ShellType;
+    use crate::state::models::{AiToolMode, ShellType};
 
     #[test]
     fn test_workspace_add_and_get() {
@@ -533,7 +533,7 @@ mod tests {
             tab_order: vec![],
             shell_type: ShellType::Windows,
             worktree_mode: false,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         };
 
         state.add_workspace(workspace.clone());
@@ -555,7 +555,7 @@ mod tests {
             tab_order: vec!["term-1".to_string()],
             shell_type: ShellType::Windows,
             worktree_mode: false,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         };
 
         state.add_workspace(workspace);
@@ -576,7 +576,7 @@ mod tests {
             tab_order: vec![],
             shell_type: ShellType::Windows,
             worktree_mode: false,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         });
 
         state.add_terminal(Terminal {
@@ -603,7 +603,7 @@ mod tests {
                 tab_order: vec![],
                 shell_type: ShellType::Windows,
                 worktree_mode: false,
-                claude_code_mode: false,
+                ai_tool_mode: AiToolMode::None,
             },
             Workspace {
                 id: "ws-2".to_string(),
@@ -614,7 +614,7 @@ mod tests {
                     distribution: Some("Ubuntu".to_string()),
                 },
                 worktree_mode: false,
-                claude_code_mode: false,
+                ai_tool_mode: AiToolMode::None,
             },
         ];
 
@@ -775,7 +775,7 @@ mod tests {
             tab_order: vec!["t1".to_string(), "t_dead".to_string(), "t2".to_string()],
             shell_type: ShellType::Windows,
             worktree_mode: false,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         });
         state.add_terminal(Terminal {
             id: "t1".to_string(),

--- a/src-tauri/src/state/models.rs
+++ b/src-tauri/src/state/models.rs
@@ -4,6 +4,22 @@ use serde::{Deserialize, Serialize};
 // Re-export layout tree types from protocol
 pub use godly_protocol::LayoutNode;
 
+/// AI tool mode for a workspace — which AI tool(s) to auto-launch in new terminals.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AiToolMode {
+    None,
+    Claude,
+    Codex,
+    Both,
+}
+
+impl Default for AiToolMode {
+    fn default() -> Self {
+        AiToolMode::None
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ShellType {
@@ -49,18 +65,93 @@ pub struct Terminal {
     pub process_name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Raw deserialization helper that handles both old (`claude_code_mode: bool`)
+/// and new (`ai_tool_mode: AiToolMode`) JSON formats.
+#[derive(Deserialize)]
+struct WorkspaceRaw {
+    id: String,
+    name: String,
+    folder_path: String,
+    tab_order: Vec<String>,
+    #[serde(default)]
+    shell_type: ShellType,
+    #[serde(default)]
+    worktree_mode: bool,
+    /// New field — present in new-format JSON.
+    #[serde(default)]
+    ai_tool_mode: Option<AiToolMode>,
+    /// Legacy field — present in old-format JSON.
+    #[serde(default)]
+    claude_code_mode: Option<bool>,
+}
+
+impl From<WorkspaceRaw> for Workspace {
+    fn from(raw: WorkspaceRaw) -> Self {
+        let ai_tool_mode = match raw.ai_tool_mode {
+            Some(mode) => mode,
+            None => match raw.claude_code_mode {
+                Some(true) => AiToolMode::Claude,
+                _ => AiToolMode::None,
+            },
+        };
+        Workspace {
+            id: raw.id,
+            name: raw.name,
+            folder_path: raw.folder_path,
+            tab_order: raw.tab_order,
+            shell_type: raw.shell_type,
+            worktree_mode: raw.worktree_mode,
+            ai_tool_mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "WorkspaceSer")]
 pub struct Workspace {
     pub id: String,
     pub name: String,
     pub folder_path: String,
     pub tab_order: Vec<String>,
-    #[serde(default)]
     pub shell_type: ShellType,
-    #[serde(default)]
     pub worktree_mode: bool,
-    #[serde(default)]
-    pub claude_code_mode: bool,
+    pub ai_tool_mode: AiToolMode,
+}
+
+/// Serialization helper — writes the new `ai_tool_mode` field only.
+#[derive(Serialize)]
+struct WorkspaceSer {
+    id: String,
+    name: String,
+    folder_path: String,
+    tab_order: Vec<String>,
+    shell_type: ShellType,
+    worktree_mode: bool,
+    ai_tool_mode: AiToolMode,
+}
+
+impl From<Workspace> for WorkspaceSer {
+    fn from(ws: Workspace) -> Self {
+        WorkspaceSer {
+            id: ws.id,
+            name: ws.name,
+            folder_path: ws.folder_path,
+            tab_order: ws.tab_order,
+            shell_type: ws.shell_type,
+            worktree_mode: ws.worktree_mode,
+            ai_tool_mode: ws.ai_tool_mode,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Workspace {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = WorkspaceRaw::deserialize(deserializer)?;
+        Ok(Workspace::from(raw))
+    }
 }
 
 #[deprecated(note = "Use LayoutNode tree instead for recursive split pane support")]
@@ -209,7 +300,7 @@ mod tests {
                 distribution: Some("Debian".to_string()),
             },
             worktree_mode: false,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         };
 
         let json = serde_json::to_string(&workspace).unwrap();
@@ -235,7 +326,7 @@ mod tests {
         let workspace: Workspace = serde_json::from_str(json).unwrap();
         assert_eq!(workspace.shell_type, ShellType::Windows);
         assert!(!workspace.worktree_mode);
-        assert!(!workspace.claude_code_mode);
+        assert_eq!(workspace.ai_tool_mode, AiToolMode::None);
     }
 
     #[test]
@@ -271,7 +362,7 @@ mod tests {
                     tab_order: vec![],
                     shell_type: ShellType::Windows,
                     worktree_mode: false,
-                    claude_code_mode: false,
+                    ai_tool_mode: AiToolMode::None,
                 },
                 Workspace {
                     id: "ws-2".to_string(),
@@ -282,7 +373,7 @@ mod tests {
                         distribution: Some("Alpine".to_string()),
                     },
                     worktree_mode: false,
-                    claude_code_mode: false,
+                    ai_tool_mode: AiToolMode::None,
                 },
             ],
             terminals: vec![],
@@ -315,7 +406,7 @@ mod tests {
                 tab_order: vec!["term-1".to_string(), "term-2".to_string()],
                 shell_type: ShellType::Windows,
                 worktree_mode: false,
-                claude_code_mode: false,
+                ai_tool_mode: AiToolMode::None,
             }],
             terminals: vec![
                 TerminalInfo {
@@ -382,7 +473,7 @@ mod tests {
                 tab_order: vec![],
                 shell_type: ShellType::Windows,
                 worktree_mode: false,
-                claude_code_mode: false,
+                ai_tool_mode: AiToolMode::None,
             }],
             terminals: vec![TerminalInfo {
                 id: original_id.to_string(),
@@ -428,7 +519,7 @@ mod tests {
             tab_order: vec![],
             shell_type: ShellType::Windows,
             worktree_mode: true,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         };
 
         let json = serde_json::to_string(&workspace).unwrap();
@@ -450,7 +541,7 @@ mod tests {
     }
 
     #[test]
-    fn test_workspace_default_claude_code_mode_on_missing_field() {
+    fn test_workspace_default_ai_tool_mode_on_missing_field() {
         let json = r#"{
             "id": "ws-1",
             "name": "Test",
@@ -460,11 +551,11 @@ mod tests {
         }"#;
 
         let workspace: Workspace = serde_json::from_str(json).unwrap();
-        assert!(!workspace.claude_code_mode);
+        assert_eq!(workspace.ai_tool_mode, AiToolMode::None);
     }
 
     #[test]
-    fn test_workspace_roundtrip_with_claude_code_mode() {
+    fn test_workspace_roundtrip_with_ai_tool_mode() {
         let workspace = Workspace {
             id: "ws-1".to_string(),
             name: "Claude WS".to_string(),
@@ -472,12 +563,51 @@ mod tests {
             tab_order: vec![],
             shell_type: ShellType::Windows,
             worktree_mode: false,
-            claude_code_mode: true,
+            ai_tool_mode: AiToolMode::Claude,
         };
 
         let json = serde_json::to_string(&workspace).unwrap();
         let deserialized: Workspace = serde_json::from_str(&json).unwrap();
-        assert!(deserialized.claude_code_mode);
+        assert_eq!(deserialized.ai_tool_mode, AiToolMode::Claude);
+    }
+
+    #[test]
+    fn test_workspace_backward_compat_claude_code_mode_true() {
+        // Old JSON with "claude_code_mode": true should migrate to AiToolMode::Claude
+        let json = r#"{
+            "id": "ws-1",
+            "name": "Old WS",
+            "folder_path": "C:\\repo",
+            "tab_order": [],
+            "shell_type": "windows",
+            "claude_code_mode": true
+        }"#;
+
+        let workspace: Workspace = serde_json::from_str(json).unwrap();
+        assert_eq!(workspace.ai_tool_mode, AiToolMode::Claude);
+    }
+
+    #[test]
+    fn test_workspace_backward_compat_claude_code_mode_false() {
+        let json = r#"{
+            "id": "ws-1",
+            "name": "Old WS",
+            "folder_path": "C:\\repo",
+            "tab_order": [],
+            "claude_code_mode": false
+        }"#;
+
+        let workspace: Workspace = serde_json::from_str(json).unwrap();
+        assert_eq!(workspace.ai_tool_mode, AiToolMode::None);
+    }
+
+    #[test]
+    fn test_ai_tool_mode_serialization_roundtrip() {
+        for mode in &[AiToolMode::None, AiToolMode::Claude, AiToolMode::Codex, AiToolMode::Both] {
+            let json = serde_json::to_string(mode).unwrap();
+            let deserialized: AiToolMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, *mode);
+        }
     }
 
     #[test]
@@ -519,7 +649,7 @@ mod tests {
                 tab_order: vec![],
                 shell_type: ShellType::Windows,
                 worktree_mode: false,
-                claude_code_mode: false,
+                ai_tool_mode: AiToolMode::None,
             }],
             terminals: vec![],
             active_workspace_id: Some("ws-1".to_string()),
@@ -593,7 +723,7 @@ mod tests {
                 args: Some(vec!["-l".to_string()]),
             },
             worktree_mode: false,
-            claude_code_mode: false,
+            ai_tool_mode: AiToolMode::None,
         };
 
         let json = serde_json::to_string(&workspace).unwrap();

--- a/src/components/App.notification-focus-steal.test.ts
+++ b/src/components/App.notification-focus-steal.test.ts
@@ -44,7 +44,7 @@ function setupTwoTerminalState() {
     tabOrder: [],
     shellType: { type: 'windows' },
     worktreeMode: false,
-    claudeCodeMode: false,
+    aiToolMode: 'none',
   });
   store.addTerminal({
     id: 'term-reading',
@@ -61,7 +61,7 @@ function setupTwoTerminalState() {
     tabOrder: [],
     shellType: { type: 'windows' },
     worktreeMode: false,
-    claudeCodeMode: false,
+    aiToolMode: 'none',
   });
   store.addTerminal({
     id: 'term-notify',

--- a/src/components/App.notification.test.ts
+++ b/src/components/App.notification.test.ts
@@ -41,7 +41,7 @@ describe('Notification improvements', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
       store.addTerminal({
         id: 'term-1',
@@ -63,7 +63,7 @@ describe('Notification improvements', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
       store.addTerminal({
         id: 'term-orphan',
@@ -88,7 +88,7 @@ describe('Notification improvements', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
       store.addTerminal({
         id: 'term-osc',
@@ -111,7 +111,7 @@ describe('Notification improvements', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
       store.addTerminal({
         id: 'term-renamed',

--- a/src/components/App.test.ts
+++ b/src/components/App.test.ts
@@ -267,8 +267,8 @@ describe('App Persistence', () => {
     });
   });
 
-  describe('claude code mode persistence', () => {
-    it('should restore claudeCodeMode from layout', async () => {
+  describe('ai tool mode persistence', () => {
+    it('should restore aiToolMode from layout', async () => {
       const savedLayout = {
         workspaces: [
           {
@@ -277,7 +277,7 @@ describe('App Persistence', () => {
             folder_path: 'C:\\Projects',
             tab_order: [],
             shell_type: 'windows',
-            claude_code_mode: true,
+            ai_tool_mode: 'claude',
           },
         ],
         terminals: [],
@@ -297,16 +297,16 @@ describe('App Persistence', () => {
           tabOrder: w.tab_order,
           shellType: convertShellType(w.shell_type),
           worktreeMode: false,
-          claudeCodeMode: w.claude_code_mode ?? false,
+          aiToolMode: w.ai_tool_mode ?? 'none',
         });
       });
 
       const state = store.getState();
-      expect(state.workspaces[0].claudeCodeMode).toBe(true);
+      expect(state.workspaces[0].aiToolMode).toBe('claude');
     });
 
-    it('should default claudeCodeMode to false when missing from old layout', async () => {
-      // Simulate an old layout that doesn't have claude_code_mode field
+    it('should default aiToolMode to none when missing from old layout', async () => {
+      // Simulate an old layout that doesn't have ai_tool_mode field
       const oldLayout = {
         workspaces: [
           {
@@ -315,7 +315,7 @@ describe('App Persistence', () => {
             folder_path: 'C:\\Old',
             tab_order: [],
             shell_type: 'windows',
-            // no claude_code_mode field
+            // no ai_tool_mode field
           },
         ],
         terminals: [],
@@ -334,12 +334,12 @@ describe('App Persistence', () => {
           tabOrder: w.tab_order,
           shellType: convertShellType(w.shell_type),
           worktreeMode: false,
-          claudeCodeMode: (w as any).claude_code_mode ?? false,
+          aiToolMode: (w as any).ai_tool_mode ?? 'none',
         });
       });
 
       const state = store.getState();
-      expect(state.workspaces[0].claudeCodeMode).toBe(false);
+      expect(state.workspaces[0].aiToolMode).toBe('none');
     });
   });
 

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -638,12 +638,13 @@ export class App {
           break;
         }
 
-        case 'workspace.toggleClaudeCodeMode': {
+        case 'workspace.cycleAiToolMode': {
           e.preventDefault();
           if (state.activeWorkspaceId) {
             const workspace = state.workspaces.find(w => w.id === state.activeWorkspaceId);
             if (workspace) {
-              await workspaceService.toggleClaudeCodeMode(workspace.id, !workspace.claudeCodeMode);
+              const nextMode = workspaceService.cycleAiToolMode(workspace.aiToolMode);
+              await workspaceService.setAiToolMode(workspace.id, nextMode);
             }
           }
           break;
@@ -744,6 +745,7 @@ export class App {
           tab_order: string[];
           shell_type?: BackendShellType;
           worktree_mode?: boolean;
+          ai_tool_mode?: string;
           claude_code_mode?: boolean;
         }>;
         terminals: Array<{
@@ -780,7 +782,7 @@ export class App {
             tabOrder: w.tab_order,
             shellType: convertShellType(w.shell_type),
             worktreeMode: w.worktree_mode ?? false,
-            claudeCodeMode: w.claude_code_mode ?? false,
+            aiToolMode: (w.ai_tool_mode as import('../state/store').AiToolMode) ?? (w.claude_code_mode ? 'claude' : 'none'),
           });
         });
 
@@ -1273,9 +1275,14 @@ export class App {
     });
     perfTracer.measure('create_terminal', 'create_terminal_start');
 
-    if (workspace?.claudeCodeMode) {
+    const aiMode = workspace?.aiToolMode ?? 'none';
+    if (aiMode === 'claude') {
       setTimeout(() => {
         terminalService.writeToTerminal(result.id, 'claude --dangerously-skip-permissions\r');
+      }, 500);
+    } else if (aiMode === 'codex') {
+      setTimeout(() => {
+        terminalService.writeToTerminal(result.id, 'codex --yolo\r');
       }, 500);
     }
 
@@ -1418,7 +1425,7 @@ export class App {
             tabOrder: [],
             shellType: { type: 'windows' },
             worktreeMode: false,
-            claudeCodeMode: false,
+            aiToolMode: 'none',
           });
         }
         store.addTerminal({

--- a/src/components/TabBar.drag.test.ts
+++ b/src/components/TabBar.drag.test.ts
@@ -108,7 +108,7 @@ describe('TabBar drag-and-drop reorder', () => {
       tabOrder: [],
       shellType: { type: 'windows' },
       worktreeMode: false,
-      claudeCodeMode: false,
+      aiToolMode: 'none',
     });
 
     store.setActiveWorkspace('ws-1');

--- a/src/components/TabBar.overflow.test.ts
+++ b/src/components/TabBar.overflow.test.ts
@@ -47,7 +47,7 @@ describe('TabBar add-button overlap with many tabs', () => {
       tabOrder: [],
       shellType: { type: 'windows' },
       worktreeMode: false,
-      claudeCodeMode: false,
+      aiToolMode: 'none',
     });
 
     store.setActiveWorkspace('ws-1');

--- a/src/components/TabBar.process-title.test.ts
+++ b/src/components/TabBar.process-title.test.ts
@@ -19,7 +19,7 @@ const TERMINAL_ID = 'tab-title-bug';
 function setupTerminal(processName = 'powershell') {
   store.addWorkspace({
     id: 'ws-1', name: 'Test', folderPath: 'C:\\', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   });
   store.addTerminal({
     id: TERMINAL_ID, workspaceId: 'ws-1',
@@ -119,7 +119,7 @@ describe('Bug: tabs all named "pa-mcp" in Claude Code workspace', () => {
     store.addWorkspace({
       id: 'ws-claude', name: 'Claude WS', folderPath: 'C:\\Projects',
       tabOrder: [], shellType: { type: 'windows' },
-      worktreeMode: false, claudeCodeMode: true,
+      worktreeMode: false, aiToolMode: 'claude',
     });
   });
 

--- a/src/components/TabBar.rename-focus-steal.test.ts
+++ b/src/components/TabBar.rename-focus-steal.test.ts
@@ -48,7 +48,7 @@ describe('TabBar rename focus stealing', () => {
       tabOrder: [],
       shellType: { type: 'windows' },
       worktreeMode: false,
-      claudeCodeMode: false,
+      aiToolMode: 'none',
     });
 
     store.setActiveWorkspace('ws-1');

--- a/src/components/TabBar.rename.test.ts
+++ b/src/components/TabBar.rename.test.ts
@@ -44,7 +44,7 @@ describe('TabBar rename', () => {
       tabOrder: [],
       shellType: { type: 'windows' },
       worktreeMode: false,
-      claudeCodeMode: false,
+      aiToolMode: 'none',
     });
 
     store.setActiveWorkspace('ws-1');

--- a/src/components/TabBar.test.ts
+++ b/src/components/TabBar.test.ts
@@ -197,14 +197,14 @@ describe('getDisplayName - process name autopick', () => {
   });
 });
 
-// Full flow: claudeCodeMode workspace -> terminal created -> process changes
-describe('claudeCodeMode tab naming flow', () => {
+// Full flow: aiToolMode workspace -> terminal created -> process changes
+describe('aiToolMode tab naming flow', () => {
   beforeEach(() => {
     store.reset();
     store.addWorkspace({
       id: 'ws-claude', name: 'Claude WS', folderPath: 'C:\\Projects',
       tabOrder: [], shellType: { type: 'windows' },
-      worktreeMode: false, claudeCodeMode: true,
+      worktreeMode: false, aiToolMode: 'claude',
     });
   });
 

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -137,6 +137,13 @@ export class TabBar {
     if (!state.activeWorkspaceId) return;
 
     const workspace = state.workspaces.find(w => w.id === state.activeWorkspaceId);
+    const aiMode = workspace?.aiToolMode ?? 'none';
+
+    if (aiMode === 'both') {
+      await this.handleNewTabBothMode(workspace!);
+      return;
+    }
+
     let worktreeName: string | undefined;
 
     if (workspace?.worktreeMode) {
@@ -158,11 +165,62 @@ export class TabBar {
       order: 0,
     });
 
-    if (workspace?.claudeCodeMode) {
+    if (aiMode === 'claude') {
       setTimeout(() => {
         terminalService.writeToTerminal(result.id, 'claude --dangerously-skip-permissions\r');
       }, 500);
+    } else if (aiMode === 'codex') {
+      setTimeout(() => {
+        terminalService.writeToTerminal(result.id, 'codex --yolo\r');
+      }, 500);
     }
+  }
+
+  private async handleNewTabBothMode(workspace: import('../state/store').Workspace) {
+    const wsId = workspace.id;
+    let worktreeNameClaude: string | undefined;
+    let worktreeNameCodex: string | undefined;
+
+    if (workspace.worktreeMode) {
+      const { showWorktreeNamePrompt } = await import('./dialogs');
+      const baseName = await showWorktreeNamePrompt('Enter worktree base name (suffixes -claude/-codex added)');
+      if (baseName === null) return; // user cancelled
+      if (baseName) {
+        worktreeNameClaude = `${baseName}-claude`;
+        worktreeNameCodex = `${baseName}-codex`;
+      }
+    }
+
+    // Create first terminal (Claude)
+    const result1 = await terminalService.createTerminal(wsId, { worktreeName: worktreeNameClaude });
+    store.addTerminal({
+      id: result1.id,
+      workspaceId: wsId,
+      name: result1.worktree_branch ?? 'Claude',
+      processName: 'powershell',
+      order: 0,
+    });
+
+    // Create second terminal (Codex)
+    const result2 = await terminalService.createTerminal(wsId, { worktreeName: worktreeNameCodex });
+    store.addTerminal({
+      id: result2.id,
+      workspaceId: wsId,
+      name: result2.worktree_branch ?? 'Codex',
+      processName: 'powershell',
+      order: 0,
+    }, { background: true });
+
+    // Split vertically (top=Claude, bottom=Codex)
+    store.splitTerminalAt(wsId, result1.id, result2.id, 'vertical', 0.5);
+
+    // Write commands after delay
+    setTimeout(() => {
+      terminalService.writeToTerminal(result1.id, 'claude --dangerously-skip-permissions\r');
+    }, 500);
+    setTimeout(() => {
+      terminalService.writeToTerminal(result2.id, 'codex --yolo\r');
+    }, 500);
   }
 
   private showNewTabMenu(e: MouseEvent) {

--- a/src/components/TabBar.wheel-scroll.test.ts
+++ b/src/components/TabBar.wheel-scroll.test.ts
@@ -39,7 +39,7 @@ describe('Bug #189: Tab bar does not scroll with mouse wheel when tabs overflow'
       tabOrder: [],
       shellType: { type: 'windows' },
       worktreeMode: false,
-      claudeCodeMode: false,
+      aiToolMode: 'none',
     });
 
     store.setActiveWorkspace('ws-1');

--- a/src/components/WorkspaceSidebar.ts
+++ b/src/components/WorkspaceSidebar.ts
@@ -390,15 +390,20 @@ export class WorkspaceSidebar {
     };
     nameContainer.appendChild(wtToggle);
 
-    const ccToggle = document.createElement('button');
-    ccToggle.className = `claude-code-toggle${workspace.claudeCodeMode ? ' active' : ''}`;
-    ccToggle.textContent = 'CC';
-    ccToggle.title = workspace.claudeCodeMode ? 'Claude Code mode: ON' : 'Claude Code mode: OFF';
-    ccToggle.onclick = async (e) => {
+    const aiToggle = document.createElement('button');
+    const aiLabel = workspace.aiToolMode === 'claude' ? 'CC'
+      : workspace.aiToolMode === 'codex' ? 'CX'
+      : workspace.aiToolMode === 'both' ? '2x'
+      : '--';
+    aiToggle.className = `ai-tool-toggle${workspace.aiToolMode !== 'none' ? ' active' : ''} mode-${workspace.aiToolMode}`;
+    aiToggle.textContent = aiLabel;
+    aiToggle.title = `AI tool mode: ${workspace.aiToolMode}`;
+    aiToggle.onclick = async (e) => {
       e.stopPropagation();
-      await workspaceService.toggleClaudeCodeMode(workspace.id, !workspace.claudeCodeMode);
+      const nextMode = workspaceService.cycleAiToolMode(workspace.aiToolMode);
+      await workspaceService.setAiToolMode(workspace.id, nextMode);
     };
-    nameContainer.appendChild(ccToggle);
+    nameContainer.appendChild(aiToggle);
 
     item.appendChild(nameContainer);
 
@@ -542,16 +547,25 @@ export class WorkspaceSidebar {
     };
     menu.appendChild(worktreeItem);
 
-    const claudeCodeItem = document.createElement('div');
-    claudeCodeItem.className = 'context-menu-item';
-    claudeCodeItem.textContent = workspace.claudeCodeMode
-      ? 'Disable Claude Code Mode'
-      : 'Enable Claude Code Mode';
-    claudeCodeItem.onclick = async () => {
-      menu.remove();
-      await workspaceService.toggleClaudeCodeMode(workspace.id, !workspace.claudeCodeMode);
-    };
-    menu.appendChild(claudeCodeItem);
+    // AI Tool Mode submenu
+    const aiModeItem = document.createElement('div');
+    aiModeItem.className = 'context-menu-item context-menu-submenu';
+    aiModeItem.textContent = `AI Tool: ${workspace.aiToolMode}`;
+
+    const aiSubmenu = document.createElement('div');
+    aiSubmenu.className = 'context-submenu';
+    for (const mode of ['none', 'claude', 'codex', 'both'] as const) {
+      const opt = document.createElement('div');
+      opt.className = `context-menu-item${workspace.aiToolMode === mode ? ' selected' : ''}`;
+      opt.textContent = mode === 'none' ? 'None' : mode === 'claude' ? 'Claude' : mode === 'codex' ? 'Codex' : 'Both';
+      opt.onclick = async () => {
+        menu.remove();
+        await workspaceService.setAiToolMode(workspace.id, mode);
+      };
+      aiSubmenu.appendChild(opt);
+    }
+    aiModeItem.appendChild(aiSubmenu);
+    menu.appendChild(aiModeItem);
 
     const isMuted = !notificationStore.isWorkspaceNotificationEnabled(workspace.id, workspace.name);
     const notifItem = document.createElement('div');

--- a/src/components/WorktreePanel.ts
+++ b/src/components/WorktreePanel.ts
@@ -229,9 +229,13 @@ export class WorktreePanel {
       order: 0,
     });
 
-    if (workspace.claudeCodeMode) {
+    if (workspace.aiToolMode === 'claude' || workspace.aiToolMode === 'both') {
       setTimeout(() => {
         terminalService.writeToTerminal(result.id, 'claude --dangerously-skip-permissions\r');
+      }, 500);
+    } else if (workspace.aiToolMode === 'codex') {
+      setTimeout(() => {
+        terminalService.writeToTerminal(result.id, 'codex --yolo\r');
       }, 500);
     }
   }

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -4,7 +4,7 @@ import { llmHasApiKey, llmGenerateBranchName } from '../plugins/smollm2/llm-serv
  * Show a prompt dialog for entering a custom worktree branch name.
  * Returns the user's input (empty string = auto-generate), or null if cancelled.
  */
-export function showWorktreeNamePrompt(): Promise<string | null> {
+export function showWorktreeNamePrompt(customTitle?: string): Promise<string | null> {
   return new Promise((resolve) => {
     const overlay = document.createElement('div');
     overlay.className = 'dialog-overlay';
@@ -14,7 +14,7 @@ export function showWorktreeNamePrompt(): Promise<string | null> {
 
     const title = document.createElement('div');
     title.className = 'dialog-title';
-    title.textContent = 'New Worktree Branch';
+    title.textContent = customTitle || 'New Worktree Branch';
     dialog.appendChild(title);
 
     // Description input for AI suggestion

--- a/src/components/osc-title.integration.test.ts
+++ b/src/components/osc-title.integration.test.ts
@@ -19,7 +19,7 @@ describe('OSC title integration (godly-vt pipeline)', () => {
     store.reset();
     store.addWorkspace({
       id: 'ws-1', name: 'Test', folderPath: 'C:\\', tabOrder: [],
-      shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+      shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
     });
     store.addTerminal({
       id: TERMINAL_ID, workspaceId: 'ws-1',

--- a/src/services/terminal-service.test.ts
+++ b/src/services/terminal-service.test.ts
@@ -37,7 +37,7 @@ describe('TerminalService', () => {
           tabOrder: ['t1', 't2'],
           shellType: { type: 'windows' },
           worktreeMode: false,
-          claudeCodeMode: false,
+          aiToolMode: 'none',
         },
       ],
       terminals: [

--- a/src/services/workspace-service.test.ts
+++ b/src/services/workspace-service.test.ts
@@ -323,8 +323,8 @@ describe('WorkspaceService', () => {
     });
   });
 
-  describe('toggleClaudeCodeMode', () => {
-    it('should invoke toggle_claude_code_mode and update store', async () => {
+  describe('setAiToolMode', () => {
+    it('should invoke set_ai_tool_mode and update store', async () => {
       mockedInvoke.mockResolvedValue(undefined);
 
       store.addWorkspace({
@@ -334,19 +334,19 @@ describe('WorkspaceService', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
 
-      await workspaceService.toggleClaudeCodeMode('ws-cc', true);
+      await workspaceService.setAiToolMode('ws-cc', 'claude');
 
-      expect(mockedInvoke).toHaveBeenCalledWith('toggle_claude_code_mode', {
+      expect(mockedInvoke).toHaveBeenCalledWith('set_ai_tool_mode', {
         workspaceId: 'ws-cc',
-        enabled: true,
+        mode: 'claude',
       });
-      expect(store.getState().workspaces[0].claudeCodeMode).toBe(true);
+      expect(store.getState().workspaces[0].aiToolMode).toBe('claude');
     });
 
-    it('should disable claude code mode', async () => {
+    it('should disable ai tool mode', async () => {
       mockedInvoke.mockResolvedValue(undefined);
 
       store.addWorkspace({
@@ -356,21 +356,21 @@ describe('WorkspaceService', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: true,
+        aiToolMode: 'claude',
       });
 
-      await workspaceService.toggleClaudeCodeMode('ws-cc-off', false);
+      await workspaceService.setAiToolMode('ws-cc-off', 'none');
 
-      expect(mockedInvoke).toHaveBeenCalledWith('toggle_claude_code_mode', {
+      expect(mockedInvoke).toHaveBeenCalledWith('set_ai_tool_mode', {
         workspaceId: 'ws-cc-off',
-        enabled: false,
+        mode: 'none',
       });
-      expect(store.getState().workspaces[0].claudeCodeMode).toBe(false);
+      expect(store.getState().workspaces[0].aiToolMode).toBe('none');
     });
   });
 
-  describe('loadWorkspaces claude_code_mode', () => {
-    it('should default claudeCodeMode to false when missing from backend', async () => {
+  describe('loadWorkspaces ai_tool_mode', () => {
+    it('should default aiToolMode to none when missing from backend', async () => {
       const workspaceData: WorkspaceData[] = [
         {
           id: 'ws-old',
@@ -378,7 +378,7 @@ describe('WorkspaceService', () => {
           folder_path: 'C:\\old',
           tab_order: [],
           shell_type: 'windows',
-          // claude_code_mode not present (old layout)
+          // ai_tool_mode not present (old layout)
         },
       ];
 
@@ -386,10 +386,10 @@ describe('WorkspaceService', () => {
 
       const workspaces = await workspaceService.loadWorkspaces();
 
-      expect(workspaces[0].claudeCodeMode).toBe(false);
+      expect(workspaces[0].aiToolMode).toBe('none');
     });
 
-    it('should preserve claudeCodeMode=true from backend', async () => {
+    it('should preserve aiToolMode=claude from backend', async () => {
       const workspaceData: WorkspaceData[] = [
         {
           id: 'ws-cc',
@@ -397,7 +397,7 @@ describe('WorkspaceService', () => {
           folder_path: 'C:\\cc',
           tab_order: [],
           shell_type: 'windows',
-          claude_code_mode: true,
+          ai_tool_mode: 'claude',
         },
       ];
 
@@ -405,7 +405,7 @@ describe('WorkspaceService', () => {
 
       const workspaces = await workspaceService.loadWorkspaces();
 
-      expect(workspaces[0].claudeCodeMode).toBe(true);
+      expect(workspaces[0].aiToolMode).toBe('claude');
     });
   });
 

--- a/src/services/workspace-service.ts
+++ b/src/services/workspace-service.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { store, Workspace, ShellType } from '../state/store';
+import { store, Workspace, ShellType, AiToolMode } from '../state/store';
 import { terminalSettingsStore } from '../state/terminal-settings-store';
 import { notificationStore } from '../state/notification-store';
 
@@ -10,6 +10,8 @@ export interface WorkspaceData {
   tab_order: string[];
   shell_type?: 'windows' | 'pwsh' | 'cmd' | { wsl: { distribution: string | null } } | { custom: { program: string; args: string[] | null } };
   worktree_mode?: boolean;
+  ai_tool_mode?: AiToolMode;
+  /** Legacy field — old persisted data may have this instead of ai_tool_mode */
   claude_code_mode?: boolean;
 }
 
@@ -50,7 +52,7 @@ class WorkspaceService {
       tabOrder: [],
       shellType,
       worktreeMode: false,
-      claudeCodeMode: false,
+      aiToolMode: 'none',
     };
     store.addWorkspace(workspace);
 
@@ -104,7 +106,7 @@ class WorkspaceService {
       tabOrder: w.tab_order,
       shellType: this.convertShellType(w.shell_type),
       worktreeMode: w.worktree_mode ?? false,
-      claudeCodeMode: w.claude_code_mode ?? false,
+      aiToolMode: w.ai_tool_mode ?? (w.claude_code_mode ? 'claude' : 'none'),
     }));
   }
 
@@ -113,9 +115,16 @@ class WorkspaceService {
     store.updateWorkspace(workspaceId, { worktreeMode: enabled });
   }
 
-  async toggleClaudeCodeMode(workspaceId: string, enabled: boolean): Promise<void> {
-    await invoke('toggle_claude_code_mode', { workspaceId, enabled });
-    store.updateWorkspace(workspaceId, { claudeCodeMode: enabled });
+  async setAiToolMode(workspaceId: string, mode: AiToolMode): Promise<void> {
+    await invoke('set_ai_tool_mode', { workspaceId, mode });
+    store.updateWorkspace(workspaceId, { aiToolMode: mode });
+  }
+
+  /** Cycle AI tool mode: none -> claude -> codex -> both -> none */
+  cycleAiToolMode(current: AiToolMode): AiToolMode {
+    const cycle: AiToolMode[] = ['none', 'claude', 'codex', 'both'];
+    const idx = cycle.indexOf(current);
+    return cycle[(idx + 1) % cycle.length];
   }
 
   async isGitRepo(folderPath: string): Promise<boolean> {

--- a/src/state/keybinding-store.test.ts
+++ b/src/state/keybinding-store.test.ts
@@ -87,10 +87,10 @@ describe('KeybindingStore', () => {
       );
     });
 
-    it('matches Ctrl+Shift+E to workspace.toggleClaudeCodeMode', () => {
+    it('matches Ctrl+Shift+E to workspace.cycleAiToolMode', () => {
       const store = new KeybindingStore();
       expect(store.matchAction(keydown('E', { ctrlKey: true, shiftKey: true }))).toBe(
-        'workspace.toggleClaudeCodeMode'
+        'workspace.cycleAiToolMode'
       );
     });
 

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -34,7 +34,7 @@ export type ActionId =
   | 'split.swapPanes'
   | 'split.rotateSplit'
   | 'workspace.toggleWorktreeMode'
-  | 'workspace.toggleClaudeCodeMode'
+  | 'workspace.cycleAiToolMode'
   | 'scroll.pageUp'
   | 'scroll.pageDown'
   | 'scroll.toTop'
@@ -246,8 +246,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'w' },
   },
   {
-    id: 'workspace.toggleClaudeCodeMode',
-    label: 'Toggle Claude Code Mode',
+    id: 'workspace.cycleAiToolMode',
+    label: 'Cycle AI Tool Mode',
     category: 'Workspace',
     type: 'app',
     defaultChord: { ctrlKey: true, shiftKey: true, altKey: false, key: 'e' },

--- a/src/state/store.layout-tree.test.ts
+++ b/src/state/store.layout-tree.test.ts
@@ -8,7 +8,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 const ws: Workspace = {
   id: 'ws-1', name: 'WS', folderPath: 'C:\\ws', tabOrder: [],
-  shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+  shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
 };
 
 function addTerminals(ids: string[]) {
@@ -765,7 +765,7 @@ describe('layout tree state management', () => {
     it('should clear tree when moving a terminal from a 2-pane split', () => {
       store.addWorkspace({
         id: 'ws-2', name: 'WS 2', folderPath: 'C:\\ws2', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       addTerminals(['t1', 't2']);
       store.splitTerminalAt('ws-1', 't1', 't2', 'horizontal');

--- a/src/state/store.mcp-window.test.ts
+++ b/src/state/store.mcp-window.test.ts
@@ -18,7 +18,7 @@ describe('Bug #204: MCP Agent workspace visibility', () => {
     tabOrder: [],
     shellType: { type: 'windows' },
     worktreeMode: false,
-    claudeCodeMode: false,
+    aiToolMode: 'none',
   };
 
   const agentWorkspace: Workspace = {
@@ -28,7 +28,7 @@ describe('Bug #204: MCP Agent workspace visibility', () => {
     tabOrder: [],
     shellType: { type: 'windows' },
     worktreeMode: false,
-    claudeCodeMode: false,
+    aiToolMode: 'none',
   };
 
   beforeEach(() => {

--- a/src/state/store.split-edge-cases.test.ts
+++ b/src/state/store.split-edge-cases.test.ts
@@ -8,11 +8,11 @@ import { store, Workspace } from './store';
 describe('split view edge cases', () => {
   const ws1: Workspace = {
     id: 'ws-1', name: 'WS 1', folderPath: 'C:\\ws1', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   };
   const ws2: Workspace = {
     id: 'ws-2', name: 'WS 2', folderPath: 'C:\\ws2', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   };
 
   beforeEach(() => {

--- a/src/state/store.split-exit-on-tab-click.test.ts
+++ b/src/state/store.split-exit-on-tab-click.test.ts
@@ -8,7 +8,7 @@ import { store, Workspace } from './store';
 describe('split view should exit when clicking a tab outside the split pair', () => {
   const ws1: Workspace = {
     id: 'ws-1', name: 'WS 1', folderPath: 'C:\\ws1', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   };
 
   beforeEach(() => {

--- a/src/state/store.split-navigation.test.ts
+++ b/src/state/store.split-navigation.test.ts
@@ -7,7 +7,7 @@ import { store, Workspace } from './store';
 describe('split view suspend and restore on navigation', () => {
   const ws1: Workspace = {
     id: 'ws-1', name: 'WS 1', folderPath: 'C:\\ws1', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   };
 
   beforeEach(() => {

--- a/src/state/store.split-new-terminal.test.ts
+++ b/src/state/store.split-new-terminal.test.ts
@@ -13,7 +13,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 const ws: Workspace = {
   id: 'ws-1', name: 'WS', folderPath: 'C:\\ws', tabOrder: [],
-  shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+  shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
 };
 
 describe('Bug #391: new terminal during active split creates inconsistent state', () => {

--- a/src/state/store.split-suspend-on-tab-switch.test.ts
+++ b/src/state/store.split-suspend-on-tab-switch.test.ts
@@ -8,7 +8,7 @@ import { store, Workspace } from './store';
 describe('split view should be preserved when switching tabs and coming back', () => {
   const ws1: Workspace = {
     id: 'ws-1', name: 'WS 1', folderPath: 'C:\\ws1', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   };
 
   beforeEach(() => {

--- a/src/state/store.split-tab-grouping.test.ts
+++ b/src/state/store.split-tab-grouping.test.ts
@@ -10,7 +10,7 @@ import { store, Workspace } from './store';
 describe('split tab grouping (#309)', () => {
   const ws: Workspace = {
     id: 'ws-1', name: 'WS', folderPath: 'C:\\ws', tabOrder: [],
-    shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+    shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
   };
 
   beforeEach(() => {

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -286,7 +286,7 @@ describe('Store', () => {
     it('should store oscTitle via updateTerminal', () => {
       store.addWorkspace({
         id: 'ws-1', name: 'WS', folderPath: 'C:\\', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.addTerminal({
         id: 't-1', workspaceId: 'ws-1', name: 'Terminal', processName: 'powershell', order: 0,
@@ -301,7 +301,7 @@ describe('Store', () => {
     it('should clear oscTitle by setting undefined', () => {
       store.addWorkspace({
         id: 'ws-1', name: 'WS', folderPath: 'C:\\', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.addTerminal({
         id: 't-1', workspaceId: 'ws-1', name: 'Terminal', processName: 'powershell', order: 0,
@@ -317,7 +317,7 @@ describe('Store', () => {
     it('should store userRenamed via updateTerminal', () => {
       store.addWorkspace({
         id: 'ws-1', name: 'WS', folderPath: 'C:\\', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.addTerminal({
         id: 't-1', workspaceId: 'ws-1', name: 'Terminal', processName: 'powershell', order: 0,
@@ -332,7 +332,7 @@ describe('Store', () => {
     it('should default oscTitle and userRenamed to undefined on new terminals', () => {
       store.addWorkspace({
         id: 'ws-1', name: 'WS', folderPath: 'C:\\', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.addTerminal({
         id: 't-1', workspaceId: 'ws-1', name: 'Terminal', processName: 'powershell', order: 0,
@@ -344,8 +344,8 @@ describe('Store', () => {
     });
   });
 
-  describe('claude code mode', () => {
-    it('should store claudeCodeMode on workspace', () => {
+  describe('ai tool mode', () => {
+    it('should store aiToolMode on workspace', () => {
       const workspace: Workspace = {
         id: 'ws-cc',
         name: 'Claude Code Workspace',
@@ -353,16 +353,16 @@ describe('Store', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: true,
+        aiToolMode: 'claude',
       };
 
       store.addWorkspace(workspace);
 
       const state = store.getState();
-      expect(state.workspaces[0].claudeCodeMode).toBe(true);
+      expect(state.workspaces[0].aiToolMode).toBe('claude');
     });
 
-    it('should toggle claudeCodeMode via updateWorkspace', () => {
+    it('should update aiToolMode via updateWorkspace', () => {
       store.addWorkspace({
         id: 'ws-cc-toggle',
         name: 'Toggle Test',
@@ -370,21 +370,21 @@ describe('Store', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
 
-      expect(store.getState().workspaces[0].claudeCodeMode).toBe(false);
+      expect(store.getState().workspaces[0].aiToolMode).toBe('none');
 
-      store.updateWorkspace('ws-cc-toggle', { claudeCodeMode: true });
+      store.updateWorkspace('ws-cc-toggle', { aiToolMode: 'claude' });
 
-      expect(store.getState().workspaces[0].claudeCodeMode).toBe(true);
+      expect(store.getState().workspaces[0].aiToolMode).toBe('claude');
 
-      store.updateWorkspace('ws-cc-toggle', { claudeCodeMode: false });
+      store.updateWorkspace('ws-cc-toggle', { aiToolMode: 'none' });
 
-      expect(store.getState().workspaces[0].claudeCodeMode).toBe(false);
+      expect(store.getState().workspaces[0].aiToolMode).toBe('none');
     });
 
-    it('should not affect other workspaces when toggling claudeCodeMode', () => {
+    it('should not affect other workspaces when updating aiToolMode', () => {
       store.addWorkspace({
         id: 'ws-a',
         name: 'A',
@@ -392,7 +392,7 @@ describe('Store', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
       store.addWorkspace({
         id: 'ws-b',
@@ -401,14 +401,14 @@ describe('Store', () => {
         tabOrder: [],
         shellType: { type: 'windows' },
         worktreeMode: false,
-        claudeCodeMode: false,
+        aiToolMode: 'none',
       });
 
-      store.updateWorkspace('ws-a', { claudeCodeMode: true });
+      store.updateWorkspace('ws-a', { aiToolMode: 'claude' });
 
       const state = store.getState();
-      expect(state.workspaces.find(w => w.id === 'ws-a')?.claudeCodeMode).toBe(true);
-      expect(state.workspaces.find(w => w.id === 'ws-b')?.claudeCodeMode).toBe(false);
+      expect(state.workspaces.find(w => w.id === 'ws-a')?.aiToolMode).toBe('claude');
+      expect(state.workspaces.find(w => w.id === 'ws-b')?.aiToolMode).toBe('none');
     });
   });
 
@@ -417,11 +417,11 @@ describe('Store', () => {
     // instead of restoring the previously active tab
     const ws1: Workspace = {
       id: 'ws-1', name: 'WS 1', folderPath: 'C:\\ws1', tabOrder: [],
-      shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+      shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
     };
     const ws2: Workspace = {
       id: 'ws-2', name: 'WS 2', folderPath: 'C:\\ws2', tabOrder: [],
-      shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+      shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
     };
 
     beforeEach(() => {
@@ -495,7 +495,7 @@ describe('Store', () => {
     beforeEach(() => {
       store.addWorkspace({
         id: 'ws-1', name: 'Test', folderPath: 'C:\\', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.addTerminal({
         id: 'term-1', workspaceId: 'ws-1', name: '', processName: 'powershell', order: 0,
@@ -598,7 +598,7 @@ describe('Store', () => {
   describe('split view operations', () => {
     const ws1: Workspace = {
       id: 'ws-1', name: 'WS 1', folderPath: 'C:\\ws1', tabOrder: [],
-      shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+      shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
     };
 
     beforeEach(() => {
@@ -677,7 +677,7 @@ describe('Store', () => {
     it('should auto-clear split when moving a split terminal to another workspace', () => {
       store.addWorkspace({
         id: 'ws-2', name: 'WS 2', folderPath: 'C:\\ws2', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.setSplitView('ws-1', 't1', 't2', 'horizontal');
       store.moveTerminalToWorkspace('t1', 'ws-2');
@@ -696,7 +696,7 @@ describe('Store', () => {
     it('should support independent splits per workspace', () => {
       store.addWorkspace({
         id: 'ws-2', name: 'WS 2', folderPath: 'C:\\ws2', tabOrder: [],
-        shellType: { type: 'windows' }, worktreeMode: false, claudeCodeMode: false,
+        shellType: { type: 'windows' }, worktreeMode: false, aiToolMode: 'none',
       });
       store.addTerminal({ id: 't4', workspaceId: 'ws-2', name: 'Tab 4', processName: 'cmd', order: 0 });
       store.addTerminal({ id: 't5', workspaceId: 'ws-2', name: 'Tab 5', processName: 'cmd', order: 0 });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -35,6 +35,8 @@ export type ShellType =
   | { type: 'wsl'; distribution?: string }
   | { type: 'custom'; program: string; args?: string[] };
 
+export type AiToolMode = 'none' | 'claude' | 'codex' | 'both';
+
 export interface Workspace {
   id: string;
   name: string;
@@ -42,7 +44,7 @@ export interface Workspace {
   tabOrder: string[];
   shellType: ShellType;
   worktreeMode: boolean;
-  claudeCodeMode: boolean;
+  aiToolMode: AiToolMode;
 }
 
 /** Legacy flat split view — kept for backward compatibility. */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -755,8 +755,8 @@ body.dragging-active * {
   border-color: #b9db7a;
 }
 
-/* Claude Code toggle button */
-.claude-code-toggle {
+/* AI tool mode toggle button */
+.ai-tool-toggle {
   font-size: 9px;
   background: none;
   color: var(--text-secondary);
@@ -768,21 +768,68 @@ body.dragging-active * {
   transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 
-.claude-code-toggle:hover {
+.ai-tool-toggle:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
   border-color: var(--text-secondary);
 }
 
-.claude-code-toggle.active {
+.ai-tool-toggle.active {
   background: var(--accent);
   color: white;
   border-color: var(--accent);
 }
 
-.claude-code-toggle.active:hover {
+.ai-tool-toggle.active:hover {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
+}
+
+.ai-tool-toggle.mode-codex.active {
+  background: #10a37f;
+  border-color: #10a37f;
+}
+
+.ai-tool-toggle.mode-codex.active:hover {
+  background: #0d8a6a;
+  border-color: #0d8a6a;
+}
+
+.ai-tool-toggle.mode-both.active {
+  background: #8b5cf6;
+  border-color: #8b5cf6;
+}
+
+.ai-tool-toggle.mode-both.active:hover {
+  background: #7c3aed;
+  border-color: #7c3aed;
+}
+
+/* Context submenu for AI tool mode */
+.context-menu-submenu {
+  position: relative;
+}
+
+.context-submenu {
+  display: none;
+  position: absolute;
+  left: 100%;
+  top: 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px;
+  min-width: 100px;
+  z-index: 1001;
+}
+
+.context-menu-submenu:hover > .context-submenu {
+  display: block;
+}
+
+.context-menu-item.selected {
+  color: var(--accent);
+  font-weight: bold;
 }
 
 /* Worktree panel */


### PR DESCRIPTION
## Summary

- Replace binary `claude_code_mode` toggle with `AiToolMode` enum: **None**, **Claude**, **Codex**, **Both**
- Backward-compatible deserialization: old `claude_code_mode: true` JSON → `AiToolMode::Claude`
- New cycle button UI: left-click cycles `--` → `CC` → `CX` → `2x`, right-click opens submenu
- "Both" mode creates vertical split with Claude + Codex terminals, with `-claude`/`-codex` worktree suffix naming

## Changes

**Rust backend** (10 files): `AiToolMode` enum in models.rs, backward-compat via `WorkspaceRaw` serde, `set_ai_tool_mode` command replacing `toggle_claude_code_mode`, updated persistence/MCP/remote crates

**Frontend** (12 files): Store type `AiToolMode`, `cycleAiToolMode()` service method, WorkspaceSidebar cycle button + submenu, TabBar "both" mode split creation, WorktreePanel multi-mode check, keybinding rename

**Tests** (~24 files): Mechanical rename `claudeCodeMode` → `aiToolMode`, service test updates, new backward-compat + round-trip tests in Rust

## Test plan

- [x] `cargo check -p godly-remote` — passed
- [x] `cargo nextest run -p godly-protocol -p godly-remote` — 227 tests passed
- [x] `npm test` — 78 files, 1080 tests passed
- [ ] CI: full workspace check + nextest + tsc + npm build

Fixes #467