### PR TITLE
fix: binary framing for GridDiff on daemon→bridge pipe

### DIFF
--- a/changelog/unreleased/481-binary-grid-diff-framing.md
+++ b/changelog/unreleased/481-binary-grid-diff-framing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Binary framing for GridDiff on daemon→bridge pipe** — GridDiff events now use compact binary encoding (tag 0x04) instead of JSON serialization on the daemon→bridge named pipe, reducing per-diff payload by ~10x. The bridge also performs zero-copy forwarding of raw binary diffs to the stream:// protocol, eliminating redundant deserialize + re-encode cycles. Fixes low FPS (~18) and high input latency (p50=3.5s) caused by JSON serialization saturating the single-threaded bridge I/O loop. (PR #481)

--- a/src-tauri/protocol/src/frame.rs
+++ b/src-tauri/protocol/src/frame.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::binary_diff::{decode_grid_diff, encode_grid_diff_into};
 use crate::messages::{DaemonMessage, Event, Request, Response};
 
 // ── Binary frame type tags ──────────────────────────────────────────────
@@ -11,6 +12,7 @@ use crate::messages::{DaemonMessage, Event, Request, Response};
 const TAG_EVENT_OUTPUT: u8 = 0x01;
 const TAG_REQUEST_WRITE: u8 = 0x02;
 const TAG_RESPONSE_BUFFER: u8 = 0x03;
+const TAG_EVENT_GRID_DIFF: u8 = 0x04;
 
 // ── Shim binary frame tags ──────────────────────────────────────────────
 // Used for daemon <-> pty-shim communication. Different tag range (0x1x)
@@ -116,11 +118,19 @@ pub fn read_message<R: io::Read, T: DeserializeOwned>(reader: &mut R) -> io::Res
 ///
 /// - `Event::Output` → binary (tag 0x01)
 /// - `Response::Buffer` → binary (tag 0x03)
+/// - `Event::GridDiff` → binary (tag 0x04) — compact binary diff, ~10x smaller than JSON
 /// - Everything else → JSON
 pub fn write_daemon_message<W: io::Write>(writer: &mut W, msg: &DaemonMessage) -> io::Result<()> {
     match msg {
         DaemonMessage::Event(Event::Output { session_id, data }) => {
             let frame = encode_binary_frame(TAG_EVENT_OUTPUT, session_id, data);
+            write_length_prefixed(writer, &frame)
+        }
+        DaemonMessage::Event(Event::GridDiff { session_id, diff }) => {
+            // Binary-encode the diff, then wrap in our binary frame format.
+            let mut diff_bytes = Vec::new();
+            encode_grid_diff_into(diff, &mut diff_bytes);
+            let frame = encode_binary_frame(TAG_EVENT_GRID_DIFF, session_id, &diff_bytes);
             write_length_prefixed(writer, &frame)
         }
         DaemonMessage::Response(Response::Buffer { session_id, data }) => {
@@ -131,14 +141,36 @@ pub fn write_daemon_message<W: io::Write>(writer: &mut W, msg: &DaemonMessage) -
     }
 }
 
-/// Read a DaemonMessage, auto-detecting binary vs JSON by first byte.
+/// Result of reading a daemon message with zero-copy support for binary diffs.
 ///
-/// - First byte == 0x7B ('{') → JSON
-/// - First byte is a type tag → binary frame
-pub fn read_daemon_message<R: io::Read>(reader: &mut R) -> io::Result<Option<DaemonMessage>> {
+/// The bridge uses this to forward binary-encoded GridDiff frames directly
+/// to the DiffStreamRegistry without deserializing + re-encoding.
+#[derive(Debug)]
+pub enum ReadResult {
+    /// A fully parsed DaemonMessage.
+    Message(DaemonMessage),
+    /// A binary-encoded GridDiff frame. Contains the session_id and raw binary
+    /// diff bytes (already in the compact `encode_grid_diff` format) that can
+    /// be pushed directly to the diff stream registry.
+    RawGridDiff {
+        session_id: String,
+        binary_diff: Vec<u8>,
+    },
+    /// End of stream.
+    Eof,
+}
+
+/// Read a DaemonMessage with zero-copy support for binary GridDiff frames.
+///
+/// Returns `ReadResult::RawGridDiff` for GridDiff events so the bridge can
+/// push the pre-encoded bytes directly to the DiffStreamRegistry without
+/// deserializing and re-encoding.
+///
+/// For all other message types, returns `ReadResult::Message`.
+pub fn read_daemon_message_ext<R: io::Read>(reader: &mut R) -> io::Result<ReadResult> {
     let buf = match read_length_prefixed(reader)? {
         Some(buf) => buf,
-        None => return Ok(None),
+        None => return Ok(ReadResult::Eof),
     };
 
     if buf.is_empty() {
@@ -152,24 +184,63 @@ pub fn read_daemon_message<R: io::Read>(reader: &mut R) -> io::Result<Option<Dae
         // JSON message
         let msg = serde_json::from_slice(&buf)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok(Some(msg))
+        Ok(ReadResult::Message(msg))
     } else {
         // Binary frame
         let (tag, session_id, data) = decode_binary_frame(&buf)?;
         match tag {
-            TAG_EVENT_OUTPUT => Ok(Some(DaemonMessage::Event(Event::Output {
+            TAG_EVENT_OUTPUT => Ok(ReadResult::Message(DaemonMessage::Event(Event::Output {
                 session_id: session_id.to_string(),
                 data: data.to_vec(),
             }))),
-            TAG_RESPONSE_BUFFER => Ok(Some(DaemonMessage::Response(Response::Buffer {
-                session_id: session_id.to_string(),
-                data: data.to_vec(),
-            }))),
+            TAG_EVENT_GRID_DIFF => {
+                // Return raw binary diff bytes for zero-copy forwarding
+                Ok(ReadResult::RawGridDiff {
+                    session_id: session_id.to_string(),
+                    binary_diff: data.to_vec(),
+                })
+            }
+            TAG_RESPONSE_BUFFER => Ok(ReadResult::Message(DaemonMessage::Response(
+                Response::Buffer {
+                    session_id: session_id.to_string(),
+                    data: data.to_vec(),
+                },
+            ))),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Unknown daemon binary frame tag: 0x{:02X}", tag),
             )),
         }
+    }
+}
+
+/// Read a DaemonMessage, auto-detecting binary vs JSON by first byte.
+///
+/// - First byte == 0x7B ('{') → JSON
+/// - First byte is a type tag → binary frame
+///
+/// For GridDiff events (tag 0x04), this fully decodes the binary diff.
+/// Use `read_daemon_message_ext` instead if you need zero-copy forwarding.
+pub fn read_daemon_message<R: io::Read>(reader: &mut R) -> io::Result<Option<DaemonMessage>> {
+    match read_daemon_message_ext(reader)? {
+        ReadResult::Message(msg) => Ok(Some(msg)),
+        ReadResult::RawGridDiff {
+            session_id,
+            binary_diff,
+        } => {
+            // Decode the binary diff into a full RichGridDiff
+            let (diff, _) = decode_grid_diff(&binary_diff).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to decode binary GridDiff: {}", e),
+                )
+            })?;
+            Ok(Some(DaemonMessage::Event(Event::GridDiff {
+                session_id,
+                diff,
+            })))
+        }
+        ReadResult::Eof => Ok(None),
     }
 }
 
@@ -332,6 +403,158 @@ mod tests {
             }
             other => panic!("Expected Event::Output, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn binary_grid_diff_roundtrip() {
+        use crate::types::{CursorState, GridDimensions, RichGridCell, RichGridDiff, RichGridRow};
+
+        let diff = RichGridDiff {
+            dirty_rows: vec![(
+                3,
+                RichGridRow {
+                    cells: vec![
+                        RichGridCell {
+                            content: "A".into(),
+                            fg: "#cd3131".into(),
+                            bg: "default".into(),
+                            bold: true,
+                            dim: false,
+                            italic: false,
+                            underline: false,
+                            inverse: false,
+                            wide: false,
+                            wide_continuation: false,
+                        },
+                        RichGridCell {
+                            content: " ".into(),
+                            fg: "default".into(),
+                            bg: "#1e1e1e".into(),
+                            bold: false,
+                            dim: false,
+                            italic: true,
+                            underline: false,
+                            inverse: false,
+                            wide: false,
+                            wide_continuation: false,
+                        },
+                    ],
+                    wrapped: false,
+                },
+            )],
+            cursor: CursorState { row: 3, col: 1 },
+            dimensions: GridDimensions { rows: 24, cols: 80 },
+            alternate_screen: false,
+            cursor_hidden: false,
+            title: "test".into(),
+            scrollback_offset: 10,
+            total_scrollback: 500,
+            full_repaint: false,
+        };
+        let msg = DaemonMessage::Event(Event::GridDiff {
+            session_id: "sess-diff".into(),
+            diff: diff.clone(),
+        });
+
+        let mut buf = Vec::new();
+        write_daemon_message(&mut buf, &msg).unwrap();
+
+        // Verify it's using binary framing (first byte after length prefix is NOT '{')
+        assert_ne!(buf[4], 0x7B, "GridDiff should use binary framing, not JSON");
+
+        // Test read_daemon_message (full decode)
+        let mut cursor = Cursor::new(buf.clone());
+        let result = read_daemon_message(&mut cursor).unwrap().unwrap();
+        match result {
+            DaemonMessage::Event(Event::GridDiff { session_id, diff: decoded }) => {
+                assert_eq!(session_id, "sess-diff");
+                assert_eq!(decoded.dirty_rows.len(), 1);
+                assert_eq!(decoded.dirty_rows[0].0, 3);
+                assert_eq!(decoded.dirty_rows[0].1.cells.len(), 2);
+                assert_eq!(decoded.dirty_rows[0].1.cells[0].content, "A");
+                assert!(decoded.dirty_rows[0].1.cells[0].bold);
+                assert_eq!(decoded.cursor.row, 3);
+                assert_eq!(decoded.cursor.col, 1);
+                assert_eq!(decoded.title, "test");
+                assert_eq!(decoded.scrollback_offset, 10);
+                assert_eq!(decoded.total_scrollback, 500);
+            }
+            other => panic!("Expected Event::GridDiff, got {:?}", other),
+        }
+
+        // Test read_daemon_message_ext (raw bytes for zero-copy)
+        let mut cursor = Cursor::new(buf.clone());
+        match read_daemon_message_ext(&mut cursor).unwrap() {
+            ReadResult::RawGridDiff { session_id, binary_diff } => {
+                assert_eq!(session_id, "sess-diff");
+                assert!(!binary_diff.is_empty());
+                // Verify the binary diff can be decoded
+                let (decoded, _) = decode_grid_diff(&binary_diff).unwrap();
+                assert_eq!(decoded.dirty_rows.len(), 1);
+            }
+            other => panic!("Expected RawGridDiff, got {:?}", other),
+        }
+
+        // Verify binary is much smaller than JSON would be
+        let mut json_buf = Vec::new();
+        write_message(&mut json_buf, &DaemonMessage::Event(Event::GridDiff {
+            session_id: "sess-diff".into(),
+            diff,
+        })).unwrap();
+        assert!(
+            buf.len() < json_buf.len(),
+            "Binary ({} bytes) should be smaller than JSON ({} bytes)",
+            buf.len(),
+            json_buf.len()
+        );
+    }
+
+    #[test]
+    fn binary_grid_diff_in_mixed_sequence() {
+        use crate::types::{CursorState, GridDimensions, RichGridDiff};
+
+        let diff = RichGridDiff {
+            dirty_rows: vec![],
+            cursor: CursorState { row: 0, col: 0 },
+            dimensions: GridDimensions { rows: 24, cols: 80 },
+            alternate_screen: false,
+            cursor_hidden: false,
+            title: String::new(),
+            scrollback_offset: 0,
+            total_scrollback: 0,
+            full_repaint: false,
+        };
+
+        let mut buf = Vec::new();
+        // Output (binary tag 0x01)
+        write_daemon_message(&mut buf, &DaemonMessage::Event(Event::Output {
+            session_id: "s1".into(),
+            data: vec![65],
+        })).unwrap();
+        // GridDiff (binary tag 0x04)
+        write_daemon_message(&mut buf, &DaemonMessage::Event(Event::GridDiff {
+            session_id: "s1".into(),
+            diff: diff.clone(),
+        })).unwrap();
+        // JSON (Pong)
+        write_daemon_message(&mut buf, &DaemonMessage::Response(Response::Pong)).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+
+        // Read Output
+        let m1 = read_daemon_message(&mut cursor).unwrap().unwrap();
+        assert!(matches!(m1, DaemonMessage::Event(Event::Output { .. })));
+
+        // Read GridDiff
+        let m2 = read_daemon_message(&mut cursor).unwrap().unwrap();
+        assert!(matches!(m2, DaemonMessage::Event(Event::GridDiff { .. })));
+
+        // Read Pong
+        let m3 = read_daemon_message(&mut cursor).unwrap().unwrap();
+        assert!(matches!(m3, DaemonMessage::Response(Response::Pong)));
+
+        // EOF
+        assert!(read_daemon_message(&mut cursor).unwrap().is_none());
     }
 
     #[test]

--- a/src-tauri/protocol/src/lib.rs
+++ b/src-tauri/protocol/src/lib.rs
@@ -8,7 +8,7 @@ pub mod messages;
 pub mod types;
 pub mod whisper;
 
-pub use frame::{read_daemon_message, read_message, read_request, write_daemon_message, write_message, write_request};
+pub use frame::{read_daemon_message, read_daemon_message_ext, read_message, read_request, write_daemon_message, write_message, write_request, ReadResult};
 pub use frame::{
     read_shim_frame, write_shim_binary, write_shim_json, ShimFrame,
     TAG_SHIM_WRITE, TAG_SHIM_BUFFER_DATA, TAG_SHIM_OUTPUT,

--- a/src-tauri/src/daemon_client/bridge.rs
+++ b/src-tauri/src/daemon_client/bridge.rs
@@ -8,8 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tauri::{AppHandle, Emitter};
 
-use godly_protocol::{DaemonMessage, Event, Request, Response, read_daemon_message, write_request};
-use godly_protocol::binary_diff::encode_grid_diff_into;
+use godly_protocol::{DaemonMessage, Event, Request, Response, ReadResult, read_daemon_message_ext, write_request};
 
 // ── Per-session output stream registry ──────────────────────────────────
 //
@@ -712,8 +711,23 @@ impl DaemonBridge {
                                     PeekResult::Data => {
                                         update_phase(&health, PHASE_READ);
                                         let read_start = Instant::now();
-                                        match read_daemon_message(&mut reader) {
-                                            Ok(Some(DaemonMessage::Event(event))) => {
+                                        match read_daemon_message_ext(&mut reader) {
+                                            // Zero-copy GridDiff during response-wait
+                                            Ok(ReadResult::RawGridDiff { session_id, binary_diff }) => {
+                                                total_events += 1;
+                                                if let Some(ref diff_reg) = diff_registry {
+                                                    diff_reg.push(&session_id, &binary_diff);
+                                                }
+                                                update_phase(&health, PHASE_EMIT);
+                                                if !emitter.try_send(EmitPayload::TerminalOutput {
+                                                    terminal_id: session_id,
+                                                }) {
+                                                    dropped_events += 1;
+                                                    blog!("DROPPED EVENT (channel full, total dropped={})", dropped_events);
+                                                }
+                                                continue;
+                                            }
+                                            Ok(ReadResult::Message(DaemonMessage::Event(event))) => {
                                                 total_events += 1;
 
                                                 // Push to stream registries even during response-wait
@@ -723,10 +737,8 @@ impl DaemonBridge {
                                                     }
                                                 }
                                                 if let Some(ref diff_reg) = diff_registry {
-                                                    if let Event::GridDiff { ref session_id, ref diff } = event {
-                                                        let mut encode_buf = Vec::new();
-                                                        encode_grid_diff_into(diff, &mut encode_buf);
-                                                        diff_reg.push(session_id, &encode_buf);
+                                                    if let Event::SessionClosed { ref session_id, .. } = event {
+                                                        diff_reg.remove(session_id);
                                                     }
                                                 }
 
@@ -739,7 +751,7 @@ impl DaemonBridge {
                                                 // Keep reading — response hasn't arrived yet
                                                 continue;
                                             }
-                                            Ok(Some(DaemonMessage::Response(response))) => {
+                                            Ok(ReadResult::Message(DaemonMessage::Response(response))) => {
                                                 total_responses += 1;
                                                 if orphan_responses > 0 {
                                                     orphan_responses -= 1;
@@ -751,7 +763,7 @@ impl DaemonBridge {
                                                 }
                                                 break;
                                             }
-                                            Ok(None) => {
+                                            Ok(ReadResult::Eof) => {
                                                 eprintln!("[bridge] Daemon connection closed");
                                                 blog!("Daemon connection closed (EOF)");
                                                 running.store(false, Ordering::Relaxed);
@@ -826,8 +838,31 @@ impl DaemonBridge {
                         PeekResult::Data => {
                             update_phase(&health, PHASE_READ);
                             let read_start = Instant::now();
-                            match read_daemon_message(&mut reader) {
-                                Ok(Some(DaemonMessage::Event(event))) => {
+                            match read_daemon_message_ext(&mut reader) {
+                                // Zero-copy path: binary GridDiff arrives pre-encoded.
+                                // Push raw bytes directly to DiffStreamRegistry —
+                                // no deserialization, no re-encoding.
+                                Ok(ReadResult::RawGridDiff { session_id, binary_diff }) => {
+                                    total_events += 1;
+                                    events_this_iteration += 1;
+                                    did_work = true;
+
+                                    if let Some(ref diff_reg) = diff_registry {
+                                        diff_reg.push(&session_id, &binary_diff);
+                                    }
+
+                                    // Emit lightweight signal — no diff data.
+                                    // The binary diff stream is the primary rendering path;
+                                    // the Tauri event just triggers the fallback pull path.
+                                    update_phase(&health, PHASE_EMIT);
+                                    if !emitter.try_send(EmitPayload::TerminalOutput {
+                                        terminal_id: session_id,
+                                    }) {
+                                        dropped_events += 1;
+                                        blog!("DROPPED EVENT (channel full, total dropped={})", dropped_events);
+                                    }
+                                }
+                                Ok(ReadResult::Message(DaemonMessage::Event(event))) => {
                                     total_events += 1;
                                     events_this_iteration += 1;
                                     did_work = true;
@@ -847,19 +882,10 @@ impl DaemonBridge {
                                         }
                                     }
 
-                                    // Binary-encode grid diffs and push to the diff stream
-                                    // registry for the stream://localhost/terminal-diff/ protocol.
+                                    // Clean up diff stream registry on session close.
                                     if let Some(ref diff_reg) = diff_registry {
-                                        match &event {
-                                            Event::GridDiff { session_id, diff } => {
-                                                let mut encode_buf = Vec::new();
-                                                encode_grid_diff_into(diff, &mut encode_buf);
-                                                diff_reg.push(session_id, &encode_buf);
-                                            }
-                                            Event::SessionClosed { session_id, .. } => {
-                                                diff_reg.remove(session_id);
-                                            }
-                                            _ => {}
+                                        if let Event::SessionClosed { session_id, .. } = &event {
+                                            diff_reg.remove(session_id);
                                         }
                                     }
 
@@ -870,7 +896,7 @@ impl DaemonBridge {
                                         blog!("DROPPED EVENT (channel full, total dropped={})", dropped_events);
                                     }
                                 }
-                                Ok(Some(DaemonMessage::Response(response))) => {
+                                Ok(ReadResult::Message(DaemonMessage::Response(response))) => {
                                     total_responses += 1;
                                     did_work = true;
                                     if orphan_responses > 0 {
@@ -885,7 +911,7 @@ impl DaemonBridge {
                                     }
                                     break;
                                 }
-                                Ok(None) => {
+                                Ok(ReadResult::Eof) => {
                                     eprintln!("[bridge] Daemon connection closed");
                                     blog!("Daemon connection closed (EOF)");
                                     running.store(false, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

- **Binary-encode GridDiff events** on the daemon→bridge named pipe using a new tag `0x04`, replacing JSON serialization (~10x payload reduction)
- **Zero-copy bridge forwarding** — raw binary diff bytes pushed directly to `DiffStreamRegistry` without deserialize + re-encode
- **Eliminate redundant Tauri event payload** — emit lightweight `TerminalOutput` signal instead of full `TerminalGridDiff` with diff data

## Root Cause

`Event::GridDiff` used JSON serialization (~32KB per diff for a 200-col terminal with 1 dirty row) while `Event::Output` already used efficient binary framing. The diff data was serialized 3 times: JSON on pipe → binary re-encode for stream:// → JSON for Tauri event. With multiple sessions generating diffs at 60fps, this saturated the single-threaded bridge I/O loop, causing FPS to drop to ~18 and keydown→paint latency of p50=3.5s.

## Test plan

- [x] `cargo nextest run -p godly-protocol` — 177/177 tests pass (includes 2 new roundtrip tests)
- [x] `cargo check -p godly-daemon` — compiles
- [x] `cargo check -p godly-terminal` — compiles
- [ ] CI full build + test suite
- [ ] Manual verification: check PerfOverlay FPS and latency metrics after installing

Fixes #481