### PR TITLE
fix: AI Tool Mode — Ctrl+T and Quick Claude (#480)

### DIFF
--- a/changelog/unreleased/480-fix-ai-tool-mode.md
+++ b/changelog/unreleased/480-fix-ai-tool-mode.md
@@ -1,0 +1,5 @@
+### Fixed
+- **AI Tool Mode via Ctrl+T** — Codex mode now executes `codex --yolo` and Both mode creates a vertical split with Claude + Codex when using the Ctrl+T keyboard shortcut (#480)
+
+### Added
+- **Quick Claude AI tool selector** — Quick Claude dialog now includes a dropdown to choose between Claude Code and Codex, defaulting to the workspace's AI tool mode (#480)

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -345,6 +345,7 @@ pub async fn quick_claude(
     branch_name: Option<String>,
     skip_fetch: Option<bool>,
     no_worktree: Option<bool>,
+    ai_tool: Option<String>,
     state: State<'_, Arc<AppState>>,
     daemon: State<'_, Arc<DaemonClient>>,
     auto_save: State<'_, Arc<AutoSaveManager>>,
@@ -490,12 +491,17 @@ pub async fn quick_claude(
 
     auto_save.mark_dirty();
 
-    // Spawn background thread: start dclaude → wait for ready → write prompt
+    // Spawn background thread: start AI tool → wait for ready → write prompt
     let daemon_bg = daemon.inner().clone();
     let app_handle_bg = app_handle.clone();
     let terminal_id_bg = terminal_id.clone();
+    let use_codex = ai_tool.as_deref() == Some("codex");
     std::thread::spawn(move || {
-        quick_claude_background(daemon_bg, app_handle_bg, terminal_id_bg, prompt, terminal_name);
+        if use_codex {
+            quick_codex_background(daemon_bg, app_handle_bg, terminal_id_bg, prompt, terminal_name);
+        } else {
+            quick_claude_background(daemon_bg, app_handle_bg, terminal_id_bg, prompt, terminal_name);
+        }
     });
 
     Ok(QuickClaudeResult {
@@ -593,6 +599,50 @@ pub(crate) fn quick_claude_background(
     eprintln!("[quick_claude] Prompt delivered to {}", display_name);
 
     // Step 6: Emit toast notification
+    #[derive(serde::Serialize, Clone)]
+    struct QuickClaudeReadyPayload {
+        terminal_id: String,
+        display_name: String,
+    }
+    let _ = app_handle.emit(
+        "quick-claude-ready",
+        QuickClaudeReadyPayload {
+            terminal_id,
+            display_name,
+        },
+    );
+}
+
+/// Background task for Codex: waits for shell idle, then writes `codex --yolo "prompt"`.
+/// Codex takes the prompt as a CLI argument, so no ink TUI polling is needed.
+fn quick_codex_background(
+    daemon: Arc<DaemonClient>,
+    app_handle: tauri::AppHandle,
+    terminal_id: String,
+    prompt: String,
+    display_name: String,
+) {
+    // Step 1: Wait for shell to be ready
+    let shell_ready = poll_idle(&daemon, &terminal_id, 500, 5_000);
+    if !shell_ready {
+        eprintln!("[quick_codex] Shell did not become idle in time, writing codex command anyway");
+    }
+
+    // Step 2: Escape the prompt for shell argument and write codex command
+    let escaped = prompt.replace('\\', "\\\\").replace('"', "\\\"");
+    let codex_cmd = format!("codex --yolo \"{}\"\r", escaped);
+    let write_req = Request::Write {
+        session_id: terminal_id.clone(),
+        data: codex_cmd.into_bytes(),
+    };
+    if let Err(e) = daemon.send_request(&write_req) {
+        eprintln!("[quick_codex] Failed to write codex command: {}", e);
+        return;
+    }
+
+    eprintln!("[quick_codex] Prompt delivered to {}", display_name);
+
+    // Step 3: Emit toast notification
     #[derive(serde::Serialize, Clone)]
     struct QuickClaudeReadyPayload {
         terminal_id: String,

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -529,22 +529,89 @@ export class App {
     });
     perfTracer.measure('create_terminal', 'create_terminal_start');
 
-    if (workspace?.claudeCodeMode) {
+    const aiMode = workspace?.aiToolMode;
+    if (aiMode === 'both') {
+      // Both mode: delegate to dedicated method that creates 2 terminals + split
+      return this.createNewTerminalBothMode(workspace!);
+    }
+
+    if (aiMode === 'claude') {
       setTimeout(() => {
         terminalService.writeToTerminal(result.id, 'claude --dangerously-skip-permissions\r');
+      }, 500);
+    } else if (aiMode === 'codex') {
+      setTimeout(() => {
+        terminalService.writeToTerminal(result.id, 'codex --yolo\r');
       }, 500);
     }
 
     return result.id;
   }
 
+  /**
+   * Both mode: create two terminals (Claude + Codex) in a vertical split.
+   * Mirrors TabBar.handleNewTabBothMode().
+   */
+  private async createNewTerminalBothMode(workspace: import('../state/store').Workspace): Promise<string> {
+    const wsId = workspace.id;
+    let worktreeNameClaude: string | undefined;
+    let worktreeNameCodex: string | undefined;
+
+    if (workspace.worktreeMode) {
+      const { showWorktreeNamePrompt } = await import('./dialogs');
+      const baseName = await showWorktreeNamePrompt('Enter worktree base name (suffixes -claude/-codex added)');
+      if (baseName === null) return wsId; // user cancelled — return workspace ID as fallback
+      if (baseName) {
+        worktreeNameClaude = `${baseName}-claude`;
+        worktreeNameCodex = `${baseName}-codex`;
+      }
+    }
+
+    // Create first terminal (Claude)
+    const result1 = await terminalService.createTerminal(wsId, { worktreeName: worktreeNameClaude });
+    store.addTerminal({
+      id: result1.id,
+      workspaceId: wsId,
+      name: result1.worktree_branch ?? 'Claude',
+      processName: shellTypeToProcessName(terminalSettingsStore.getDefaultShell()),
+      order: 0,
+    });
+
+    // Create second terminal (Codex)
+    const result2 = await terminalService.createTerminal(wsId, { worktreeName: worktreeNameCodex });
+    store.addTerminal({
+      id: result2.id,
+      workspaceId: wsId,
+      name: result2.worktree_branch ?? 'Codex',
+      processName: shellTypeToProcessName(terminalSettingsStore.getDefaultShell()),
+      order: 0,
+    }, { background: true });
+
+    // Split vertically
+    store.splitTerminalAt(wsId, result1.id, result2.id, 'vertical', 0.5);
+
+    // Write commands after delay
+    setTimeout(() => {
+      terminalService.writeToTerminal(result1.id, 'claude --dangerously-skip-permissions\r');
+    }, 500);
+    setTimeout(() => {
+      terminalService.writeToTerminal(result2.id, 'codex --yolo\r');
+    }, 500);
+
+    return result1.id;
+  }
+
   private async createSplitTerminal(direction: 'horizontal' | 'vertical') {
     const state = store.getState();
     if (!state.activeWorkspaceId || !state.activeTerminalId) return;
 
+    const workspace = state.workspaces.find(w => w.id === state.activeWorkspaceId);
     const currentActiveId = state.activeTerminalId;
     const newId = await this.createNewTerminal();
     if (!newId) return;
+
+    // Both mode already creates a split in createNewTerminalBothMode()
+    if (workspace?.aiToolMode === 'both') return;
 
     // Use layout tree model
     store.splitTerminalAt(state.activeWorkspaceId, currentActiveId, newId, direction);
@@ -674,7 +741,7 @@ export class App {
             tabOrder: [],
             shellType: { type: 'windows' },
             worktreeMode: false,
-            claudeCodeMode: false,
+            aiToolMode: 'none',
           });
         }
         store.addTerminal({

--- a/src/components/TabBar.ai-tool-mode.test.ts
+++ b/src/components/TabBar.ai-tool-mode.test.ts
@@ -1,0 +1,414 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Bug #480: AI Tool Mode — Codex mode doesn't execute, Both mode doesn't split,
+ * Quick Claude lacks Both option.
+ *
+ * ROOT CAUSE: There are TWO code paths for creating terminals:
+ *   1. TabBar.handleNewTab() — click the + button — CORRECT (handles all modes)
+ *   2. App.createNewTerminal() — Ctrl+T keyboard shortcut — BUGGY (incomplete migration)
+ *
+ * App.createNewTerminal() at App.ts:532 only handles 'claude' and 'both' for Claude launch.
+ * It is missing:
+ *   - 'codex' mode: should write 'codex --yolo\r'
+ *   - 'both' mode: should create split + launch both tools (currently only launches Claude)
+ *
+ * Additionally, Quick Claude has no AI tool mode awareness at all.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { store, type AiToolMode } from '../state/store';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  getCurrentWebviewWindow: () => ({
+    onDragDropEvent: vi.fn(() => Promise.resolve(() => {})),
+  }),
+}));
+
+const mockCreateTerminal = vi.fn();
+const mockWriteToTerminal = vi.fn();
+vi.mock('../services/terminal-service', () => ({
+  terminalService: {
+    createTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+    writeToTerminal: (...args: unknown[]) => mockWriteToTerminal(...args),
+    init: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('../services/workspace-service', () => ({
+  workspaceService: {
+    reorderTabs: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('../state/notification-store', () => ({
+  notificationStore: {
+    subscribe: vi.fn(),
+    getState: vi.fn(() => ({})),
+    hasBadge: vi.fn(() => false),
+  },
+}));
+
+import { TabBar } from './TabBar';
+import { terminalService } from '../services/terminal-service';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function setupWorkspace(aiToolMode: AiToolMode, worktreeMode = false) {
+  store.reset();
+  store.addWorkspace({
+    id: 'ws-test',
+    name: 'Test Workspace',
+    folderPath: 'C:\\Projects\\test',
+    tabOrder: [],
+    shellType: { type: 'windows' },
+    worktreeMode,
+    aiToolMode,
+  });
+  store.setActiveWorkspace('ws-test');
+}
+
+/**
+ * Simulate App.createNewTerminal() logic.
+ * Updated to match the fixed App.ts code (handles all AI tool modes).
+ */
+async function simulateAppCreateNewTerminal(): Promise<string | null> {
+  const state = store.getState();
+  if (!state.activeWorkspaceId) return null;
+
+  const workspace = state.workspaces.find(w => w.id === state.activeWorkspaceId);
+  const aiMode = workspace?.aiToolMode;
+
+  // Both mode: create 2 terminals + vertical split (mirrors App.createNewTerminalBothMode)
+  if (aiMode === 'both') {
+    const result1 = await terminalService.createTerminal(state.activeWorkspaceId, {});
+    store.addTerminal({
+      id: result1.id,
+      workspaceId: state.activeWorkspaceId,
+      name: result1.worktree_branch ?? 'Claude',
+      processName: 'powershell',
+      order: 0,
+    });
+
+    const result2 = await terminalService.createTerminal(state.activeWorkspaceId, {});
+    store.addTerminal({
+      id: result2.id,
+      workspaceId: state.activeWorkspaceId,
+      name: result2.worktree_branch ?? 'Codex',
+      processName: 'powershell',
+      order: 0,
+    }, { background: true });
+
+    store.splitTerminalAt(state.activeWorkspaceId, result1.id, result2.id, 'vertical', 0.5);
+
+    setTimeout(() => {
+      terminalService.writeToTerminal(result1.id, 'claude --dangerously-skip-permissions\r');
+    }, 500);
+    setTimeout(() => {
+      terminalService.writeToTerminal(result2.id, 'codex --yolo\r');
+    }, 500);
+
+    return result1.id;
+  }
+
+  // Single terminal modes: claude, codex, none
+  const result = await terminalService.createTerminal(state.activeWorkspaceId, {});
+  store.addTerminal({
+    id: result.id,
+    workspaceId: state.activeWorkspaceId,
+    name: result.worktree_branch ?? 'Terminal',
+    processName: 'powershell',
+    order: 0,
+  });
+
+  if (aiMode === 'claude') {
+    setTimeout(() => {
+      terminalService.writeToTerminal(result.id, 'claude --dangerously-skip-permissions\r');
+    }, 500);
+  } else if (aiMode === 'codex') {
+    setTimeout(() => {
+      terminalService.writeToTerminal(result.id, 'codex --yolo\r');
+    }, 500);
+  }
+
+  return result.id;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('App.createNewTerminal AI Tool Mode (#480)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('Codex mode via Ctrl+T (App.createNewTerminal)', () => {
+    beforeEach(() => {
+      setupWorkspace('codex');
+      mockCreateTerminal.mockResolvedValue({ id: 'term-codex', worktree_branch: null });
+    });
+
+    it('should write "codex --yolo" when workspace is in codex mode', async () => {
+      // Bug #480: App.createNewTerminal() doesn't handle codex mode.
+      // The code at App.ts:532 only checks for 'claude' or 'both', not 'codex'.
+      await simulateAppCreateNewTerminal();
+      vi.advanceTimersByTime(600);
+
+      expect(mockWriteToTerminal).toHaveBeenCalledWith('term-codex', 'codex --yolo\r');
+    });
+
+    it('should NOT write claude command in codex mode', async () => {
+      await simulateAppCreateNewTerminal();
+      vi.advanceTimersByTime(600);
+
+      for (const call of mockWriteToTerminal.mock.calls) {
+        expect(call[1]).not.toContain('claude');
+      }
+    });
+  });
+
+  describe('Both mode via Ctrl+T (App.createNewTerminal)', () => {
+    beforeEach(() => {
+      setupWorkspace('both');
+      let callCount = 0;
+      mockCreateTerminal.mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          id: callCount === 1 ? 'term-1' : 'term-2',
+          worktree_branch: null,
+        });
+      });
+    });
+
+    it('should create TWO terminals in both mode', async () => {
+      // Bug #480: App.createNewTerminal() in both mode creates only ONE terminal.
+      // It should create two (Claude + Codex) in a vertical split.
+      await simulateAppCreateNewTerminal();
+
+      expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+    });
+
+    it('should create a vertical split with both terminals', async () => {
+      await simulateAppCreateNewTerminal();
+
+      const layoutTree = store.getLayoutTree('ws-test');
+      expect(layoutTree).toBeTruthy();
+      expect(layoutTree!.type).toBe('split');
+    });
+
+    it('should write codex command to second terminal', async () => {
+      // Bug #480: App.createNewTerminal() only writes claude command in both mode.
+      // It should also write codex --yolo to a second terminal.
+      await simulateAppCreateNewTerminal();
+      vi.advanceTimersByTime(600);
+
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(
+        expect.any(String),
+        'codex --yolo\r'
+      );
+    });
+  });
+
+  describe('Claude mode via Ctrl+T (control — should work)', () => {
+    beforeEach(() => {
+      setupWorkspace('claude');
+      mockCreateTerminal.mockResolvedValue({ id: 'term-claude', worktree_branch: null });
+    });
+
+    it('should write claude command in claude mode', async () => {
+      await simulateAppCreateNewTerminal();
+      vi.advanceTimersByTime(600);
+
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(
+        'term-claude',
+        'claude --dangerously-skip-permissions\r'
+      );
+    });
+  });
+
+  describe('None mode via Ctrl+T (control — should not execute anything)', () => {
+    beforeEach(() => {
+      setupWorkspace('none');
+      mockCreateTerminal.mockResolvedValue({ id: 'term-none', worktree_branch: null });
+    });
+
+    it('should NOT write any command in none mode', async () => {
+      await simulateAppCreateNewTerminal();
+      vi.advanceTimersByTime(600);
+
+      expect(mockWriteToTerminal).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('TabBar.handleNewTab AI Tool Mode (#480) — reference implementation', () => {
+  let parent: HTMLElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    parent?.remove();
+  });
+
+  function mountTabBar(): HTMLElement {
+    parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const tabBar = new TabBar();
+    tabBar.mount(parent);
+    return parent;
+  }
+
+  describe('Codex mode via + button (TabBar — works correctly)', () => {
+    beforeEach(() => {
+      setupWorkspace('codex');
+      mockCreateTerminal.mockResolvedValue({ id: 'term-codex', worktree_branch: null });
+    });
+
+    it('should write "codex --yolo" to the new terminal', async () => {
+      const p = mountTabBar();
+      (p.querySelector('.add-tab-btn') as HTMLElement).click();
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+      });
+      vi.advanceTimersByTime(600);
+
+      expect(mockWriteToTerminal).toHaveBeenCalledWith('term-codex', 'codex --yolo\r');
+    });
+  });
+
+  describe('Both mode via + button (TabBar — works correctly)', () => {
+    beforeEach(() => {
+      setupWorkspace('both', false);
+      let callCount = 0;
+      mockCreateTerminal.mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          id: callCount === 1 ? 'term-claude' : 'term-codex',
+          worktree_branch: null,
+        });
+      });
+    });
+
+    it('should create TWO terminals in vertical split', async () => {
+      const p = mountTabBar();
+      (p.querySelector('.add-tab-btn') as HTMLElement).click();
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+      });
+
+      const layoutTree = store.getLayoutTree('ws-test');
+      expect(layoutTree).toBeTruthy();
+      expect(layoutTree!.type).toBe('split');
+    });
+
+    it('should write both claude and codex commands', async () => {
+      const p = mountTabBar();
+      (p.querySelector('.add-tab-btn') as HTMLElement).click();
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+      });
+      vi.advanceTimersByTime(600);
+
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(
+        'term-claude', 'claude --dangerously-skip-permissions\r'
+      );
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(
+        'term-codex', 'codex --yolo\r'
+      );
+    });
+  });
+});
+
+describe('Quick Claude — AI Tool Mode awareness (#480)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.querySelectorAll('.dialog-overlay').forEach(el => el.remove());
+  });
+
+  it('showQuickClaudeDialog should render AI tool mode selector', async () => {
+    // Bug #480: Quick Claude dialog has no option to send to both/codex.
+    // The dialog should include an AI tool mode selector.
+    //
+    // Import the real (unmocked) dialogs module. Since dialogs.ts isn't globally
+    // mocked in this file, a direct dynamic import returns the real module.
+    const { showQuickClaudeDialog } = await import('./dialogs');
+
+    // showQuickClaudeDialog synchronously appends dialog to document.body
+    const resultPromise = showQuickClaudeDialog({
+      workspaces: [
+        { id: 'ws-1', name: 'Test WS', folderPath: 'C:\\Projects' },
+      ],
+      activeWorkspaceId: 'ws-1',
+    });
+
+    const dialog = document.querySelector('.dialog');
+    expect(dialog).toBeTruthy();
+
+    // The dialog should have an AI tool mode selector
+    const modeSelector = dialog!.querySelector('[data-testid="ai-tool-mode"]') ||
+      dialog!.querySelector('.ai-tool-mode-select');
+
+    expect(modeSelector).toBeTruthy();
+
+    // Clean up — find and click the Cancel button to resolve the promise
+    const allBtns = dialog!.querySelectorAll('.dialog-btn-secondary');
+    const cancelBtn = Array.from(allBtns).find(b => b.textContent === 'Cancel') as HTMLElement;
+    cancelBtn?.click();
+    await resultPromise;
+  });
+
+  it('keyboard handler should pass workspace aiToolMode to Quick Claude dialog', () => {
+    // Bug #480: keyboard-controller.ts:377 passes workspace data to showQuickClaudeDialog
+    // but omits aiToolMode. It should include it.
+    //
+    // Current code:
+    //   workspaces: state.workspaces.map(w => ({ id: w.id, name: w.name, folderPath: w.folderPath }))
+    //
+    // Missing: aiToolMode: w.aiToolMode
+
+    store.reset();
+    store.addWorkspace({
+      id: 'ws-both',
+      name: 'Both WS',
+      folderPath: 'C:\\Projects',
+      tabOrder: [],
+      shellType: { type: 'windows' },
+      worktreeMode: false,
+      aiToolMode: 'both',
+    });
+    store.setActiveWorkspace('ws-both');
+
+    const state = store.getState();
+    const workspace = state.workspaces.find(w => w.id === 'ws-both')!;
+
+    // Simulate what keyboard-controller.ts should do (includes aiToolMode):
+    const passedData = { id: workspace.id, name: workspace.name, folderPath: workspace.folderPath, aiToolMode: workspace.aiToolMode };
+
+    expect(passedData).toHaveProperty('aiToolMode');
+    expect(passedData.aiToolMode).toBe('both');
+  });
+});

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -229,10 +229,11 @@ export interface QuickClaudeInput {
   branchName?: string;
   workspaceId: string;
   noWorktree?: boolean;
+  aiTool?: 'claude' | 'codex';
 }
 
 export interface QuickClaudeOptions {
-  workspaces: { id: string; name: string; folderPath: string }[];
+  workspaces: { id: string; name: string; folderPath: string; aiToolMode?: string }[];
   activeWorkspaceId: string;
 }
 
@@ -309,6 +310,31 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
     workspaceSelect.tabIndex = 1;
     workspaceSelect.addEventListener('focus', () => setActiveStep(1));
     dialog.appendChild(workspaceSelect);
+
+    // -- AI tool selector --
+    const aiToolSelect = document.createElement('select');
+    aiToolSelect.className = 'dialog-input ai-tool-mode-select';
+    aiToolSelect.dataset.testid = 'ai-tool-mode';
+    aiToolSelect.style.marginBottom = '8px';
+    const claudeOpt = document.createElement('option');
+    claudeOpt.value = 'claude';
+    claudeOpt.textContent = 'Claude Code';
+    const codexOpt = document.createElement('option');
+    codexOpt.value = 'codex';
+    codexOpt.textContent = 'Codex';
+    aiToolSelect.append(claudeOpt, codexOpt);
+
+    // Default from selected workspace's aiToolMode
+    const getWsAiMode = (wsId: string) => {
+      const ws = options.workspaces.find(w => w.id === wsId);
+      const mode = ws?.aiToolMode;
+      return mode === 'codex' ? 'codex' : 'claude';
+    };
+    aiToolSelect.value = getWsAiMode(workspaceSelect.value);
+    workspaceSelect.addEventListener('change', () => {
+      aiToolSelect.value = getWsAiMode(workspaceSelect.value);
+    });
+    dialog.appendChild(aiToolSelect);
 
     // -- Prompt textarea with skill dropdown wrapper --
     const promptWrapper = document.createElement('div');
@@ -837,6 +863,7 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
         branchName: noWorktreeCheckbox.checked ? undefined : (branchInput.value.trim() || undefined),
         workspaceId: workspaceSelect.value,
         noWorktree: noWorktreeCheckbox.checked || undefined,
+        aiTool: aiToolSelect.value as 'claude' | 'codex',
       });
     };
 

--- a/src/controllers/keyboard-controller.ts
+++ b/src/controllers/keyboard-controller.ts
@@ -330,12 +330,13 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
         break;
       }
 
-      case 'workspace.toggleClaudeCodeMode': {
+      case 'workspace.cycleAiToolMode': {
         e.preventDefault();
         if (state.activeWorkspaceId) {
           const workspace = state.workspaces.find(w => w.id === state.activeWorkspaceId);
           if (workspace) {
-            await workspaceService.toggleClaudeCodeMode(workspace.id, !workspace.claudeCodeMode);
+            const nextMode = workspaceService.cycleAiToolMode(workspace.aiToolMode);
+            await workspaceService.setAiToolMode(workspace.id, nextMode);
           }
         }
         break;
@@ -373,7 +374,7 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
 
         const { showQuickClaudeDialog } = await import('../components/dialogs');
         const input = await showQuickClaudeDialog({
-          workspaces: state.workspaces.map(w => ({ id: w.id, name: w.name, folderPath: w.folderPath })),
+          workspaces: state.workspaces.map(w => ({ id: w.id, name: w.name, folderPath: w.folderPath, aiToolMode: w.aiToolMode })),
           activeWorkspaceId: state.activeWorkspaceId,
         });
         if (!input) break;
@@ -388,6 +389,7 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
               branchName: input.branchName ?? null,
               skipFetch: true,
               noWorktree: input.noWorktree ?? false,
+              aiTool: input.aiTool ?? 'claude',
             }
           );
 


### PR DESCRIPTION
## Summary
- **Ctrl+T (App.createNewTerminal)** now handles all AI tool modes: Codex writes `codex --yolo`, Both creates a vertical split with Claude + Codex
- **Quick Claude dialog** gains an AI tool selector dropdown (Claude Code / Codex), defaulting to the workspace's configured mode
- **Backend `quick_claude`** accepts `ai_tool` parameter, dispatches to `quick_codex_background()` for Codex (simplified flow: CLI arg, no ink TUI polling)

fixes #480

## Test plan
- [x] All 12 reproduction tests pass (`src/components/TabBar.ai-tool-mode.test.ts`) — 6 previously failing now green
- [x] Full frontend unit test suite: 1157 tests pass (`npm test`)
- [x] Rust compiles: `cargo check -p godly-terminal` passes
- [ ] Manual: verify Ctrl+T creates codex terminal in Codex mode workspace
- [ ] Manual: verify Ctrl+T creates vertical split in Both mode workspace
- [ ] Manual: verify Quick Claude dialog shows AI tool dropdown