### PR TITLE
feat: add "Both" mode to Quick Claude

### DIFF
--- a/changelog/unreleased/487-quick-claude-both-mode.md
+++ b/changelog/unreleased/487-quick-claude-both-mode.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Quick Claude "Both" mode** — New "Both (Claude + Codex)" option in the Quick Claude dialog (Ctrl+Shift+Q) that creates a vertical split with both tools side-by-side, sending the same prompt to each. Worktree branches use `-cc` / `-c` suffixes. (#487)

--- a/src/controllers/keyboard-controller.ts
+++ b/src/controllers/keyboard-controller.ts
@@ -381,25 +381,86 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
 
         try {
           const { invoke } = await import('@tauri-apps/api/core');
-          const result = await invoke<{ terminal_id: string; worktree_branch: string | null }>(
-            'quick_claude',
-            {
-              workspaceId: input.workspaceId,
-              prompt: input.prompt,
-              branchName: input.branchName ?? null,
-              skipFetch: true,
-              noWorktree: input.noWorktree ?? false,
-              aiTool: input.aiTool ?? 'claude',
-            }
-          );
 
-          store.addTerminal({
-            id: result.terminal_id,
-            workspaceId: input.workspaceId,
-            name: result.worktree_branch ?? 'Quick Claude',
-            processName: shellTypeToProcessName(terminalSettingsStore.getDefaultShell()),
-            order: 0,
-          }, { background: true });
+          if (input.aiTool === 'both') {
+            // Both mode: resolve branch names, invoke twice in parallel, create split
+            let ccBranch: string | null = null;
+            let cBranch: string | null = null;
+
+            if (!input.noWorktree) {
+              const baseName = input.branchName
+                ?? await (async () => {
+                  const { llmGenerateBranchName } = await import('../plugins/smollm2/llm-service');
+                  return llmGenerateBranchName(input.prompt);
+                })();
+              ccBranch = `${baseName}-cc`;
+              cBranch = `${baseName}-c`;
+            }
+
+            const [claudeResult, codexResult] = await Promise.all([
+              invoke<{ terminal_id: string; worktree_branch: string | null }>(
+                'quick_claude',
+                {
+                  workspaceId: input.workspaceId,
+                  prompt: input.prompt,
+                  branchName: ccBranch,
+                  skipFetch: true,
+                  noWorktree: input.noWorktree ?? false,
+                  aiTool: 'claude',
+                }
+              ),
+              invoke<{ terminal_id: string; worktree_branch: string | null }>(
+                'quick_claude',
+                {
+                  workspaceId: input.workspaceId,
+                  prompt: input.prompt,
+                  branchName: cBranch,
+                  skipFetch: true,
+                  noWorktree: input.noWorktree ?? false,
+                  aiTool: 'codex',
+                }
+              ),
+            ]);
+
+            const processName = shellTypeToProcessName(terminalSettingsStore.getDefaultShell());
+            store.addTerminal({
+              id: claudeResult.terminal_id,
+              workspaceId: input.workspaceId,
+              name: claudeResult.worktree_branch ?? 'Claude',
+              processName,
+              order: 0,
+            });
+            store.addTerminal({
+              id: codexResult.terminal_id,
+              workspaceId: input.workspaceId,
+              name: codexResult.worktree_branch ?? 'Codex',
+              processName,
+              order: 0,
+            }, { background: true });
+
+            store.splitTerminalAt(input.workspaceId, claudeResult.terminal_id, codexResult.terminal_id, 'vertical', 0.5);
+          } else {
+            // Single tool mode (claude or codex)
+            const result = await invoke<{ terminal_id: string; worktree_branch: string | null }>(
+              'quick_claude',
+              {
+                workspaceId: input.workspaceId,
+                prompt: input.prompt,
+                branchName: input.branchName ?? null,
+                skipFetch: true,
+                noWorktree: input.noWorktree ?? false,
+                aiTool: input.aiTool ?? 'claude',
+              }
+            );
+
+            store.addTerminal({
+              id: result.terminal_id,
+              workspaceId: input.workspaceId,
+              name: result.worktree_branch ?? 'Quick Claude',
+              processName: shellTypeToProcessName(terminalSettingsStore.getDefaultShell()),
+              order: 0,
+            }, { background: true });
+          }
         } catch (error) {
           console.error('[App] Quick Claude failed:', error);
         }


### PR DESCRIPTION
## Summary

- Adds "Both (Claude + Codex)" option to the Quick Claude dialog dropdown
- When selected, invokes `quick_claude` twice in parallel (one for each tool) and creates a vertical split
- Worktree branch names use suffixes: `<name>-cc` (Claude Code) and `<name>-c` (Codex)
- If no branch name is provided and worktrees are enabled, auto-generates a base name via LLM then suffixes both
- No backend changes needed — frontend orchestrates both invocations

Fixes #487

## Test plan

- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] `npm test` passes (no new failures)
- [ ] Open Quick Claude → select "Both" → enter prompt + branch name → verify two terminals in vertical split
- [ ] Verify Claude Code starts in left pane, Codex in right pane
- [ ] Verify same prompt delivered to both
- [ ] Test with worktrees enabled: branches named `<name>-cc` and `<name>-c`
- [ ] Test with "No worktree" checked: both terminals open without worktrees
- [ ] Test workspace default: set workspace AI mode to "both" → Quick Claude defaults to "Both"