### PR TITLE
fix: recover terminal updates when diff stream stalls

### DIFF
--- a/src/components/TerminalPane.diff-stream-stall-regression.test.ts
+++ b/src/components/TerminalPane.diff-stream-stall-regression.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Bug #486 regression variant:
+ * typing/output updates only appear after switching terminals away and back.
+ *
+ * Trigger:
+ * 1. A diff frame arrives once -> `diffStreamActive = true`.
+ * 2. Diff stream stalls/disconnects while tab remains active (no pause()).
+ * 3. Output fallback callbacks fire, but TerminalPane ignores them because
+ *    `diffStreamActive` is still true.
+ *
+ * Expected:
+ * Fallback output should schedule a snapshot fetch without requiring a tab switch.
+ *
+ * Run: npx vitest run src/components/TerminalPane.diff-stream-stall-regression.test.ts
+ */
+
+class DiffStreamStallSimulator {
+  paused = false;
+  diffStreamActive = false;
+  forceFullFetch = false;
+  snapshotPending = false;
+  diffStallFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+  static readonly DIFF_STALL_FALLBACK_MS = 250;
+
+  outputEventsHandled = 0;
+
+  /**
+   * Mirror of TerminalPane.scheduleSnapshotFetch() guard logic.
+   */
+  scheduleSnapshotFetch() {
+    if (this.paused) return;
+    if (this.diffStreamActive && !this.forceFullFetch) return;
+    if (this.snapshotPending) return;
+    this.snapshotPending = true;
+  }
+
+  /**
+   * Mirror of connectOutputStream callback in TerminalPane.mount()/resume().
+   */
+  onOutputStreamData() {
+    if (this.paused) return;
+    if (this.diffStreamActive) {
+      this.armDiffStallFallback();
+      return;
+    }
+    this.outputEventsHandled++;
+    this.scheduleSnapshotFetch();
+  }
+
+  /**
+   * Mirror of onTerminalOutput event handler in TerminalPane.mount().
+   */
+  onTerminalOutputEvent() {
+    if (this.paused) return;
+    if (this.diffStreamActive) {
+      this.armDiffStallFallback();
+      return;
+    }
+    this.outputEventsHandled++;
+    this.scheduleSnapshotFetch();
+  }
+
+  /**
+   * Mirror of connectDiffStream callback path: latch diff mode.
+   */
+  onDiffFrame() {
+    if (this.paused) return;
+    this.clearDiffStallFallback();
+    this.diffStreamActive = true;
+  }
+
+  /**
+   * Current production behavior: no callback clears diffStreamActive when the
+   * diff stream silently stalls. This no-op documents that missing transition.
+   */
+  onDiffStreamStalled() {
+    // Intentionally empty.
+  }
+
+  armDiffStallFallback() {
+    if (this.diffStallFallbackTimer !== null) return;
+    this.diffStallFallbackTimer = setTimeout(() => {
+      this.diffStallFallbackTimer = null;
+      if (this.paused) return;
+      if (!this.diffStreamActive) return;
+      this.diffStreamActive = false;
+      this.forceFullFetch = true;
+      this.scheduleSnapshotFetch();
+    }, DiffStreamStallSimulator.DIFF_STALL_FALLBACK_MS);
+  }
+
+  clearDiffStallFallback() {
+    if (this.diffStallFallbackTimer !== null) {
+      clearTimeout(this.diffStallFallbackTimer);
+      this.diffStallFallbackTimer = null;
+    }
+  }
+
+  /**
+   * Mirror of TerminalPane.pause(): tab switch away.
+   */
+  pause() {
+    this.paused = true;
+    this.diffStreamActive = false;
+    this.snapshotPending = false;
+    this.clearDiffStallFallback();
+  }
+
+  /**
+   * Mirror of TerminalPane.resume(): tab switch back.
+   */
+  resume() {
+    this.paused = false;
+    this.forceFullFetch = true;
+  }
+}
+
+describe('Bug #486 regression: diff stream stall suppresses in-tab updates', () => {
+  let sim: DiffStreamStallSimulator;
+
+  beforeEach(() => {
+    sim = new DiffStreamStallSimulator();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should recover via fallback output without requiring tab switch', () => {
+    // Diff stream is healthy at first and latches diff mode.
+    sim.onDiffFrame();
+    expect(sim.diffStreamActive).toBe(true);
+
+    // Stream then stalls while this tab remains active.
+    sim.onDiffStreamStalled();
+
+    // User types; shell emits output notifications.
+    sim.onOutputStreamData();
+    sim.onTerminalOutputEvent();
+
+    // Expected: fallback path should schedule a recovery snapshot in-place.
+    // The fallback is timer-driven: if no diff frame arrives in the grace
+    // window, diff mode is dropped and a recovery snapshot is scheduled.
+    expect(sim.snapshotPending).toBe(false);
+    vi.advanceTimersByTime(DiffStreamStallSimulator.DIFF_STALL_FALLBACK_MS + 1);
+    expect(sim.snapshotPending).toBe(true);
+  });
+
+  it('tab switch away/back resets diff mode and allows recovery scheduling', () => {
+    sim.onDiffFrame();
+    sim.onDiffStreamStalled();
+
+    // User performs the workaround.
+    sim.pause();
+    sim.resume();
+
+    // Next output callback can now drive recovery.
+    sim.onOutputStreamData();
+    expect(sim.snapshotPending).toBe(true);
+    expect(sim.outputEventsHandled).toBe(1);
+  });
+});

--- a/src/components/TerminalPane.ts
+++ b/src/components/TerminalPane.ts
@@ -44,6 +44,9 @@ export class TerminalPane {
   // within the interval collapse into a single IPC call, capping snapshot
   // fetches to ~60fps under sustained output.
   private static readonly SNAPSHOT_MIN_INTERVAL_MS = 16;
+  // If output notifications arrive but no diff follows within this window,
+  // treat the diff stream as stalled and recover via full snapshot pull.
+  private static readonly DIFF_STALL_FALLBACK_MS = 250;
   private snapshotPending = false;
   private snapshotTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -94,6 +97,10 @@ export class TerminalPane {
   // When true, binary diff stream is delivering diffs directly — suppresses
   // the pull path (scheduleSnapshotFetch) and output stream notifications.
   private diffStreamActive = false;
+  // Recovery watchdog: when output arrives while diffStreamActive is true,
+  // wait briefly for a diff frame. If none arrives, drop diff mode and
+  // schedule a pull-based recovery fetch.
+  private diffStallFallbackTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Hidden textarea for keyboard input (handles dead keys, IME composition).
   // Canvas elements don't support text composition, so dead keys (e.g. quote
@@ -314,7 +321,10 @@ export class TerminalPane {
       this.terminalId,
       () => {
         if (this.paused) return;
-        if (this.diffStreamActive) return;
+        if (this.diffStreamActive) {
+          this.armDiffStallFallback();
+          return;
+        }
         perfTracer.mark('terminal_output_event');
         perfTracer.measure('keydown_to_output', 'keydown');
         if (this.renderer.isActivelySelecting()) return;
@@ -331,7 +341,10 @@ export class TerminalPane {
     // When the binary diff stream is active, this becomes a no-op.
     terminalService.connectOutputStream(this.terminalId, () => {
       if (this.paused) return;
-      if (this.diffStreamActive) return;
+      if (this.diffStreamActive) {
+        this.armDiffStallFallback();
+        return;
+      }
       if (this.renderer.isActivelySelecting()) return;
       if (this.isUserScrolled && terminalSettingsStore.getAutoScrollOnOutput()) {
         this.snapToBottom();
@@ -347,6 +360,7 @@ export class TerminalPane {
     terminalService.connectDiffStream(this.terminalId, (diff) => {
       if (this.paused) return;
       if (this.renderer.isActivelySelecting()) return;
+      this.clearDiffStallFallback();
       this.diffStreamActive = true;
       if (this.isUserScrolled && terminalSettingsStore.getAutoScrollOnOutput()) {
         this.snapToBottom();
@@ -761,6 +775,25 @@ export class TerminalPane {
 
   private useDiffSnapshots = true;
 
+  private clearDiffStallFallback() {
+    if (this.diffStallFallbackTimer !== null) {
+      clearTimeout(this.diffStallFallbackTimer);
+      this.diffStallFallbackTimer = null;
+    }
+  }
+
+  private armDiffStallFallback() {
+    if (this.diffStallFallbackTimer !== null) return;
+    this.diffStallFallbackTimer = setTimeout(() => {
+      this.diffStallFallbackTimer = null;
+      if (this.paused) return;
+      if (!this.diffStreamActive) return;
+      this.diffStreamActive = false;
+      this.forceFullFetch = true;
+      this.scheduleSnapshotFetch();
+    }, TerminalPane.DIFF_STALL_FALLBACK_MS);
+  }
+
   private async fetchAndRenderSnapshot() {
     const forceFull = this.forceFullFetch;
     if (forceFull) this.forceFullFetch = false;
@@ -1060,6 +1093,7 @@ export class TerminalPane {
     if (this.paused) return;
     this.paused = true;
     this.diffStreamActive = false;
+    this.clearDiffStallFallback();
     terminalService.disconnectDiffStream(this.terminalId);
     terminalService.disconnectOutputStream(this.terminalId);
     if (this.snapshotTimer !== null) {
@@ -1120,6 +1154,7 @@ export class TerminalPane {
     terminalService.connectDiffStream(this.terminalId, (diff) => {
       if (this.paused) return;
       if (this.renderer.isActivelySelecting()) return;
+      this.clearDiffStallFallback();
       this.diffStreamActive = true;
       if (this.isUserScrolled && terminalSettingsStore.getAutoScrollOnOutput()) {
         this.snapToBottom();
@@ -1228,6 +1263,7 @@ export class TerminalPane {
       clearTimeout(this.snapshotTimer);
       this.snapshotTimer = null;
     }
+    this.clearDiffStallFallback();
     this.snapshotPending = false;
     this.snapshotRetryRequested = false;
     if (this.scrollRafId !== null) {


### PR DESCRIPTION
## Summary
- add a diff-stream stall watchdog in `TerminalPane` so output can recover without tab switch
- when output arrives but no diff follows within 250ms, drop diff-only mode and force a snapshot fetch
- clear the watchdog on real diff frames and on pause/destroy lifecycle paths
- add regression coverage for the stall path in `TerminalPane.diff-stream-stall-regression.test.ts`

## Why
Typing/output could stop updating in-place when `diffStreamActive` stayed latched true after a diff-stream stall. Updates only became visible after switching tabs (pause/resume), which reset state.

## Testing
- `npx vitest run src/components/TerminalPane.diff-stream-stall-regression.test.ts`
- `npx vitest run src/components/TerminalPane.diff-stream-deadlock.test.ts src/components/TerminalPane.diff-stream-inflight-recovery.test.ts src/components/TerminalPane.typing-rollback.test.ts src/components/TerminalPane.scroll-input-update.test.ts`
- `npx vitest run src/components/TerminalPane.pause.test.ts src/components/TerminalPane.cold-switch.test.ts src/components/TerminalPane.tab-switch.test.ts src/components/TerminalPane.activation.test.ts`
- targeted regression rerun 3x passed

fixes #486