### PR TITLE
feat: add Quick Claude settings tab with preset system

### DIFF
--- a/changelog/unreleased/quick-claude-settings-tab.md
+++ b/changelog/unreleased/quick-claude-settings-tab.md
@@ -1,0 +1,4 @@
+### Added
+
+- **Quick Claude Settings Tab** — New "Quick Claude" tab in Settings with a preset system for reusable launch configurations. Presets define which agents to launch, their split layout (single/vertical/horizontal/grid), and per-agent launch step sequences. Ships with 3 built-in presets: Solo Claude, Solo Codex, and Claude + Codex Split.
+- **Preset selector in Quick Claude dialog** — Choose a preset before launching to use its agent/layout configuration, or select "Custom..." for the existing manual tool picker.

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -1,5 +1,6 @@
 import { llmHasApiKey, llmGenerateBranchName } from '../plugins/smollm2/llm-service';
 import { aiToolsSettingsStore } from '../state/ai-tools-settings-store';
+import { quickClaudeSettingsStore } from '../state/quick-claude-settings-store';
 
 /**
  * Show a prompt dialog for entering a custom worktree branch name.
@@ -231,6 +232,7 @@ export interface QuickClaudeInput {
   workspaceId: string;
   noWorktree?: boolean;
   aiTool?: string;
+  presetId?: string;
 }
 
 export interface QuickClaudeOptions {
@@ -242,6 +244,7 @@ const QUICK_CLAUDE_WORKSPACE_KEY = 'quick-claude-last-workspace';
 const QUICK_CLAUDE_NO_WORKTREE_KEY = 'quick-claude-no-worktree';
 const QUICK_CLAUDE_AUTO_SUGGEST_KEY = 'quick-claude-auto-suggest';
 const QUICK_CLAUDE_AI_TOOL_KEY = 'quick-claude-ai-tool';
+const QUICK_CLAUDE_PRESET_KEY = 'quick-claude-preset';
 
 const IMAGE_EXTENSIONS = new Set([
   '.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.svg', '.tiff', '.tif', '.ico',
@@ -313,6 +316,42 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
     workspaceSelect.addEventListener('focus', () => setActiveStep(1));
     dialog.appendChild(workspaceSelect);
 
+    // -- Preset selector --
+    const presetSelect = document.createElement('select');
+    presetSelect.className = 'dialog-input qc-preset-select';
+    presetSelect.style.marginBottom = '8px';
+
+    const agentSummary = document.createElement('div');
+    agentSummary.className = 'qc-agent-summary';
+    agentSummary.style.display = 'none';
+
+    function populatePresets() {
+      presetSelect.innerHTML = '';
+      const presets = quickClaudeSettingsStore.getPresets();
+      for (const p of presets) {
+        const opt = document.createElement('option');
+        opt.value = p.id;
+        opt.textContent = p.name + (p.isDefault ? ' (Default)' : '');
+        presetSelect.appendChild(opt);
+      }
+      const customOpt = document.createElement('option');
+      customOpt.value = '__custom__';
+      customOpt.textContent = 'Custom...';
+      presetSelect.appendChild(customOpt);
+    }
+    populatePresets();
+
+    const savedPreset = localStorage.getItem(QUICK_CLAUDE_PRESET_KEY);
+    const presetIds = quickClaudeSettingsStore.getPresets().map(p => p.id);
+    if (savedPreset && presetIds.includes(savedPreset)) {
+      presetSelect.value = savedPreset;
+    } else {
+      const defaultPreset = quickClaudeSettingsStore.getDefaultPreset();
+      presetSelect.value = defaultPreset?.id ?? '__custom__';
+    }
+
+    dialog.appendChild(presetSelect);
+
     // -- AI tool selector --
     const aiToolSelect = document.createElement('select');
     aiToolSelect.className = 'dialog-input ai-tool-mode-select';
@@ -344,7 +383,30 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
         aiToolSelect.value = getWsAiMode(workspaceSelect.value);
       }
     });
+
+    function updatePresetUI() {
+      const isCustom = presetSelect.value === '__custom__';
+      aiToolSelect.style.display = isCustom ? '' : 'none';
+      if (!isCustom) {
+        const preset = quickClaudeSettingsStore.getPreset(presetSelect.value);
+        if (preset) {
+          const names = preset.agents.map(a => a.label).join(', ');
+          const layoutLabel = preset.layout === 'single' ? '' : ` \u00b7 ${preset.layout}`;
+          agentSummary.textContent = `${names}${layoutLabel}`;
+          agentSummary.style.display = '';
+        } else {
+          agentSummary.style.display = 'none';
+        }
+      } else {
+        agentSummary.style.display = 'none';
+      }
+    }
+
+    presetSelect.addEventListener('change', updatePresetUI);
+    updatePresetUI();
+
     dialog.appendChild(aiToolSelect);
+    dialog.appendChild(agentSummary);
 
     // -- Prompt textarea with skill dropdown wrapper --
     const promptWrapper = document.createElement('div');
@@ -859,6 +921,7 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
       localStorage.setItem(QUICK_CLAUDE_WORKSPACE_KEY, workspaceSelect.value);
       localStorage.setItem(QUICK_CLAUDE_NO_WORKTREE_KEY, String(noWorktreeCheckbox.checked));
       localStorage.setItem(QUICK_CLAUDE_AI_TOOL_KEY, aiToolSelect.value);
+      localStorage.setItem(QUICK_CLAUDE_PRESET_KEY, presetSelect.value);
 
       // Prepend image paths to the prompt so Claude Code auto-loads them
       let prompt = promptText;
@@ -868,6 +931,8 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
         prompt = prompt ? `${imagePrefix} ${prompt}` : imagePrefix;
       }
 
+      const selectedPresetId = presetSelect.value !== '__custom__' ? presetSelect.value : undefined;
+
       close();
       resolve({
         prompt,
@@ -875,6 +940,7 @@ export function showQuickClaudeDialog(options: QuickClaudeOptions): Promise<Quic
         workspaceId: workspaceSelect.value,
         noWorktree: noWorktreeCheckbox.checked || undefined,
         aiTool: aiToolSelect.value,
+        presetId: selectedPresetId,
       });
     };
 

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -7,11 +7,13 @@ import { FlowsTab } from './flows-tab';
 import { ShortcutsTab } from './shortcuts-tab';
 import { RemoteTab } from './remote-tab';
 import { AiToolsTab } from './ai-tools-tab';
+import { QuickClaudeTab } from './quick-claude-tab';
 
 // Register in display order
 registerSettingsTab(new ThemesTab());
 registerSettingsTab(new TerminalTab());
 registerSettingsTab(new AiToolsTab());
+registerSettingsTab(new QuickClaudeTab());
 registerSettingsTab(new NotificationsTab());
 registerSettingsTab(new PluginsTab());
 registerSettingsTab(new FlowsTab());

--- a/src/components/settings/quick-claude-tab.ts
+++ b/src/components/settings/quick-claude-tab.ts
@@ -1,0 +1,714 @@
+import {
+  quickClaudeSettingsStore,
+  LAYOUT_MAX_AGENTS,
+  type QuickClaudePreset,
+  type PresetAgent,
+  type PresetLayout,
+  type LaunchStep,
+  type LaunchStepType,
+} from '../../state/quick-claude-settings-store';
+import { aiToolsSettingsStore } from '../../state/ai-tools-settings-store';
+import type { SettingsTabProvider, SettingsDialogContext } from './types';
+
+// ── Step type metadata ──────────────────────────────────────────────
+
+const STEP_TYPE_LABELS: Record<LaunchStepType, string> = {
+  'create-terminal': 'Create Terminal',
+  'wait-idle': 'Wait for Idle',
+  'run-command': 'Run Command',
+  'wait-ready': 'Wait for Ready',
+  'send-prompt': 'Send Prompt',
+  'send-enter': 'Send Enter',
+  'delay': 'Delay',
+};
+
+const LAYOUT_LABELS: Record<PresetLayout, string> = {
+  single: 'Single',
+  vertical: 'Left / Right',
+  horizontal: 'Top / Bottom',
+  grid: '2x2 Grid',
+};
+
+const LAYOUT_ICONS: Record<PresetLayout, string> = {
+  single: '\u25A0',
+  vertical: '\u25EB',
+  horizontal: '\u2B12',
+  grid: '\u2B1A',
+};
+
+// ── Quick Claude Settings Tab ───────────────────────────────────────
+
+export class QuickClaudeTab implements SettingsTabProvider {
+  id = 'quick-claude';
+  label = 'Quick Claude';
+
+  buildContent(_dialog: SettingsDialogContext): HTMLDivElement {
+    const content = document.createElement('div');
+    content.className = 'settings-tab-content';
+
+    let editingPresetId: string | null = null;
+
+    const renderList = () => {
+      editingPresetId = null;
+      content.textContent = '';
+      this.renderPresetList(content, (presetId) => {
+        editingPresetId = presetId;
+        renderEditor();
+      });
+    };
+
+    const renderEditor = () => {
+      if (!editingPresetId) return;
+      content.textContent = '';
+      this.renderPresetEditor(content, editingPresetId, () => renderList());
+    };
+
+    renderList();
+
+    const unsub = quickClaudeSettingsStore.subscribe(() => {
+      if (!editingPresetId) renderList();
+    });
+    (content as any).__qcUnsub = unsub;
+
+    return content;
+  }
+
+  // ── List View ─────────────────────────────────────────────────────
+
+  private renderPresetList(
+    container: HTMLElement,
+    onEdit: (presetId: string) => void,
+  ): void {
+    const header = document.createElement('div');
+    header.className = 'flow-list-header';
+
+    const title = document.createElement('div');
+    title.className = 'settings-section-title';
+    title.textContent = 'Quick Claude Presets';
+    title.style.marginBottom = '0';
+    header.appendChild(title);
+
+    const headerActions = document.createElement('div');
+    headerActions.className = 'flow-header-actions';
+
+    const newBtn = document.createElement('button');
+    newBtn.className = 'flow-btn flow-btn-primary';
+    newBtn.textContent = 'New Preset';
+    newBtn.addEventListener('click', () => {
+      const preset: QuickClaudePreset = {
+        id: crypto.randomUUID(),
+        name: 'New Preset',
+        description: '',
+        layout: 'single',
+        agents: [{
+          id: crypto.randomUUID(),
+          toolId: 'claude',
+          label: 'Claude Code',
+          steps: quickClaudeSettingsStore.getDefaultStepsForTool('claude'),
+        }],
+        isDefault: false,
+        createdAt: Date.now(),
+      };
+      quickClaudeSettingsStore.addPreset(preset);
+      onEdit(preset.id);
+    });
+    headerActions.appendChild(newBtn);
+    header.appendChild(headerActions);
+    container.appendChild(header);
+
+    const desc = document.createElement('div');
+    desc.className = 'settings-description';
+    desc.textContent = 'Named launch configurations for Quick Claude. Each preset defines which agents to launch, their layout, and step sequence.';
+    container.appendChild(desc);
+
+    const presets = quickClaudeSettingsStore.getPresets();
+
+    if (presets.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'flow-empty';
+      empty.textContent = 'No presets yet. Create one to get started.';
+      container.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('div');
+    list.className = 'flow-list';
+
+    for (const preset of presets) {
+      list.appendChild(this.createPresetCard(preset, onEdit));
+    }
+
+    container.appendChild(list);
+  }
+
+  private createPresetCard(
+    preset: QuickClaudePreset,
+    onEdit: (presetId: string) => void,
+  ): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'flow-card';
+
+    const cardHeader = document.createElement('div');
+    cardHeader.className = 'flow-card-header';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'flow-card-name';
+    nameEl.textContent = preset.name;
+    cardHeader.appendChild(nameEl);
+
+    // Layout badge
+    const layoutBadge = document.createElement('span');
+    layoutBadge.className = 'qc-layout-badge';
+    layoutBadge.textContent = `${LAYOUT_ICONS[preset.layout]} ${LAYOUT_LABELS[preset.layout]}`;
+    cardHeader.appendChild(layoutBadge);
+
+    // Default star
+    if (preset.isDefault) {
+      const star = document.createElement('span');
+      star.className = 'qc-default-star';
+      star.textContent = '\u2605';
+      star.title = 'Default preset';
+      cardHeader.appendChild(star);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'flow-card-actions';
+
+    // Set as default
+    if (!preset.isDefault) {
+      const defaultBtn = document.createElement('button');
+      defaultBtn.className = 'flow-btn flow-btn-icon';
+      defaultBtn.title = 'Set as default';
+      defaultBtn.textContent = '\u2606'; // empty star
+      defaultBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        quickClaudeSettingsStore.setDefault(preset.id);
+      });
+      actions.appendChild(defaultBtn);
+    }
+
+    // Edit
+    const editBtn = document.createElement('button');
+    editBtn.className = 'flow-btn flow-btn-icon';
+    editBtn.title = 'Edit';
+    editBtn.textContent = '\u270E';
+    editBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      onEdit(preset.id);
+    });
+    actions.appendChild(editBtn);
+
+    // Duplicate
+    const dupBtn = document.createElement('button');
+    dupBtn.className = 'flow-btn flow-btn-icon';
+    dupBtn.title = 'Duplicate';
+    dupBtn.textContent = '\u2398';
+    dupBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      quickClaudeSettingsStore.duplicatePreset(preset.id);
+    });
+    actions.appendChild(dupBtn);
+
+    // Delete (not for built-ins)
+    if (!preset.id.startsWith('builtin-')) {
+      const delBtn = document.createElement('button');
+      delBtn.className = 'flow-btn flow-btn-icon flow-btn-danger-icon';
+      delBtn.title = 'Delete';
+      delBtn.textContent = '\u2715';
+      delBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        quickClaudeSettingsStore.deletePreset(preset.id);
+      });
+      actions.appendChild(delBtn);
+    }
+
+    cardHeader.appendChild(actions);
+    card.appendChild(cardHeader);
+
+    if (preset.description) {
+      const descEl = document.createElement('div');
+      descEl.className = 'flow-card-description';
+      descEl.textContent = preset.description;
+      card.appendChild(descEl);
+    }
+
+    // Agent count
+    const meta = document.createElement('div');
+    meta.className = 'flow-card-meta';
+    const agentNames = preset.agents.map(a => a.label).join(', ');
+    meta.textContent = `${preset.agents.length} agent${preset.agents.length !== 1 ? 's' : ''}: ${agentNames}`;
+    card.appendChild(meta);
+
+    return card;
+  }
+
+  // ── Editor View ───────────────────────────────────────────────────
+
+  private renderPresetEditor(
+    container: HTMLElement,
+    presetId: string,
+    onBack: () => void,
+  ): void {
+    const preset = quickClaudeSettingsStore.getPreset(presetId);
+    if (!preset) { onBack(); return; }
+
+    let editName = preset.name;
+    let editDescription = preset.description;
+    let editLayout = preset.layout;
+    let editAgents = structuredClone(preset.agents);
+
+    const editor = document.createElement('div');
+    editor.className = 'flow-editor';
+
+    // Header
+    const header = document.createElement('div');
+    header.className = 'flow-editor-header';
+    const backBtn = document.createElement('button');
+    backBtn.className = 'flow-btn flow-btn-secondary';
+    backBtn.textContent = '\u2190 Back';
+    backBtn.addEventListener('click', onBack);
+    header.appendChild(backBtn);
+    const headerTitle = document.createElement('span');
+    headerTitle.className = 'flow-editor-title';
+    headerTitle.textContent = 'Edit Preset';
+    header.appendChild(headerTitle);
+    editor.appendChild(header);
+
+    // Name
+    const nameGroup = this.createFieldGroup('Name');
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'flow-input';
+    nameInput.value = editName;
+    nameInput.placeholder = 'Preset name';
+    nameInput.addEventListener('input', () => { editName = nameInput.value; });
+    nameGroup.appendChild(nameInput);
+    editor.appendChild(nameGroup);
+
+    // Description
+    const descGroup = this.createFieldGroup('Description');
+    const descInput = document.createElement('input');
+    descInput.type = 'text';
+    descInput.className = 'flow-input';
+    descInput.value = editDescription;
+    descInput.placeholder = 'Optional description';
+    descInput.addEventListener('input', () => { editDescription = descInput.value; });
+    descGroup.appendChild(descInput);
+    editor.appendChild(descGroup);
+
+    // Layout selector
+    const layoutGroup = this.createFieldGroup('Layout');
+    const layoutSelector = document.createElement('div');
+    layoutSelector.className = 'qc-layout-selector';
+
+    const layouts: PresetLayout[] = ['single', 'vertical', 'horizontal', 'grid'];
+    for (const layout of layouts) {
+      const radio = document.createElement('label');
+      radio.className = 'qc-layout-option' + (layout === editLayout ? ' qc-layout-option-active' : '');
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'qc-layout';
+      input.value = layout;
+      input.checked = layout === editLayout;
+      input.style.display = 'none';
+      input.addEventListener('change', () => {
+        editLayout = layout;
+        // Update active class
+        layoutSelector.querySelectorAll('.qc-layout-option').forEach(el => el.classList.remove('qc-layout-option-active'));
+        radio.classList.add('qc-layout-option-active');
+        // Trim agents if needed
+        const max = LAYOUT_MAX_AGENTS[layout];
+        if (editAgents.length > max) {
+          editAgents = editAgents.slice(0, max);
+        }
+        renderAgents();
+      });
+
+      const icon = document.createElement('span');
+      icon.className = 'qc-layout-icon';
+      icon.textContent = LAYOUT_ICONS[layout];
+
+      const label = document.createElement('span');
+      label.className = 'qc-layout-label';
+      label.textContent = LAYOUT_LABELS[layout];
+
+      const maxLabel = document.createElement('span');
+      maxLabel.className = 'qc-layout-max';
+      maxLabel.textContent = `max ${LAYOUT_MAX_AGENTS[layout]}`;
+
+      radio.append(input, icon, label, maxLabel);
+      layoutSelector.appendChild(radio);
+    }
+
+    layoutGroup.appendChild(layoutSelector);
+    editor.appendChild(layoutGroup);
+
+    // Agents section
+    const agentsGroup = this.createFieldGroup('Agents');
+    const agentsContainer = document.createElement('div');
+    agentsContainer.className = 'qc-agents';
+
+    const renderAgents = () => {
+      agentsContainer.textContent = '';
+
+      editAgents.forEach((agent, idx) => {
+        agentsContainer.appendChild(
+          this.createAgentCard(agent, idx, editAgents, () => renderAgents()),
+        );
+      });
+
+      // Add Agent button
+      const max = LAYOUT_MAX_AGENTS[editLayout];
+      if (editAgents.length < max) {
+        const addBtn = document.createElement('button');
+        addBtn.className = 'flow-add-step';
+        addBtn.textContent = '+ Add Agent';
+        addBtn.addEventListener('click', () => {
+          const toolId = 'claude';
+          editAgents.push({
+            id: crypto.randomUUID(),
+            toolId,
+            label: 'Claude Code',
+            steps: quickClaudeSettingsStore.getDefaultStepsForTool(toolId),
+          });
+          renderAgents();
+        });
+        agentsContainer.appendChild(addBtn);
+      }
+    };
+
+    renderAgents();
+    agentsGroup.appendChild(agentsContainer);
+    editor.appendChild(agentsGroup);
+
+    // Action buttons
+    const actionsRow = document.createElement('div');
+    actionsRow.className = 'flow-actions';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'flow-btn flow-btn-primary';
+    saveBtn.textContent = 'Save';
+    saveBtn.addEventListener('click', () => {
+      quickClaudeSettingsStore.updatePreset(presetId, {
+        name: editName,
+        description: editDescription,
+        layout: editLayout,
+        agents: editAgents,
+      });
+      onBack();
+    });
+    actionsRow.appendChild(saveBtn);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'flow-btn flow-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', onBack);
+    actionsRow.appendChild(cancelBtn);
+
+    editor.appendChild(actionsRow);
+    container.appendChild(editor);
+  }
+
+  // ── Agent Card ────────────────────────────────────────────────────
+
+  private createAgentCard(
+    agent: PresetAgent,
+    index: number,
+    allAgents: PresetAgent[],
+    onChanged: () => void,
+  ): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'qc-agent-card';
+
+    // Header row
+    const headerRow = document.createElement('div');
+    headerRow.className = 'qc-agent-header';
+
+    const posLabel = document.createElement('span');
+    posLabel.className = 'qc-agent-position';
+    posLabel.textContent = `Agent ${index + 1}`;
+    headerRow.appendChild(posLabel);
+
+    // Tool selector
+    const toolSelect = document.createElement('select');
+    toolSelect.className = 'flow-select';
+    const toolOptions = aiToolsSettingsStore.getAllToolOptions().filter(t => t.id !== 'both');
+    for (const tool of toolOptions) {
+      const opt = document.createElement('option');
+      opt.value = tool.id;
+      opt.textContent = tool.name;
+      toolSelect.appendChild(opt);
+    }
+    toolSelect.value = agent.toolId;
+    toolSelect.addEventListener('change', () => {
+      agent.toolId = toolSelect.value;
+      const selected = toolOptions.find(t => t.id === toolSelect.value);
+      if (selected) {
+        agent.label = selected.name;
+        labelInput.value = selected.name;
+      }
+    });
+    headerRow.appendChild(toolSelect);
+
+    // Remove button
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'flow-btn flow-btn-icon flow-btn-danger-icon';
+    removeBtn.title = 'Remove agent';
+    removeBtn.textContent = '\u2715';
+    removeBtn.addEventListener('click', () => {
+      const idx = allAgents.indexOf(agent);
+      if (idx !== -1) allAgents.splice(idx, 1);
+      onChanged();
+    });
+    headerRow.appendChild(removeBtn);
+
+    card.appendChild(headerRow);
+
+    // Label
+    const labelRow = document.createElement('div');
+    labelRow.className = 'qc-agent-field';
+    const labelLabel = document.createElement('span');
+    labelLabel.className = 'qc-agent-field-label';
+    labelLabel.textContent = 'Label';
+    labelRow.appendChild(labelLabel);
+    const labelInput = document.createElement('input');
+    labelInput.type = 'text';
+    labelInput.className = 'flow-input';
+    labelInput.value = agent.label;
+    labelInput.placeholder = 'Display name';
+    labelInput.addEventListener('input', () => { agent.label = labelInput.value; });
+    labelRow.appendChild(labelInput);
+    card.appendChild(labelRow);
+
+    // Command override
+    const cmdRow = document.createElement('div');
+    cmdRow.className = 'qc-agent-field';
+    const cmdLabel = document.createElement('span');
+    cmdLabel.className = 'qc-agent-field-label';
+    cmdLabel.textContent = 'Command Override';
+    cmdRow.appendChild(cmdLabel);
+    const cmdInput = document.createElement('input');
+    cmdInput.type = 'text';
+    cmdInput.className = 'flow-input';
+    cmdInput.value = agent.commandOverride ?? '';
+    cmdInput.placeholder = 'Optional (uses tool default)';
+    cmdInput.addEventListener('input', () => {
+      agent.commandOverride = cmdInput.value || undefined;
+    });
+    cmdRow.appendChild(cmdInput);
+    card.appendChild(cmdRow);
+
+    // Branch suffix override
+    const suffixRow = document.createElement('div');
+    suffixRow.className = 'qc-agent-field';
+    const suffixLabel = document.createElement('span');
+    suffixLabel.className = 'qc-agent-field-label';
+    suffixLabel.textContent = 'Branch Suffix';
+    suffixRow.appendChild(suffixLabel);
+    const suffixInput = document.createElement('input');
+    suffixInput.type = 'text';
+    suffixInput.className = 'flow-input';
+    suffixInput.value = agent.branchSuffixOverride ?? '';
+    suffixInput.placeholder = 'Optional (uses tool default)';
+    suffixInput.style.width = '120px';
+    suffixInput.addEventListener('input', () => {
+      agent.branchSuffixOverride = suffixInput.value || undefined;
+    });
+    suffixRow.appendChild(suffixInput);
+    card.appendChild(suffixRow);
+
+    // Steps section
+    const stepsHeader = document.createElement('div');
+    stepsHeader.className = 'qc-steps-header';
+    const stepsTitle = document.createElement('span');
+    stepsTitle.className = 'qc-agent-field-label';
+    stepsTitle.textContent = 'Launch Steps';
+    stepsHeader.appendChild(stepsTitle);
+
+    const resetBtn = document.createElement('button');
+    resetBtn.className = 'flow-btn flow-btn-secondary';
+    resetBtn.style.cssText = 'font-size: 11px; padding: 2px 8px;';
+    resetBtn.textContent = 'Reset to Default';
+    resetBtn.addEventListener('click', () => {
+      agent.steps = quickClaudeSettingsStore.getDefaultStepsForTool(agent.toolId);
+      onChanged();
+    });
+    stepsHeader.appendChild(resetBtn);
+    card.appendChild(stepsHeader);
+
+    const stepsContainer = document.createElement('div');
+    stepsContainer.className = 'qc-step-list';
+
+    for (const step of agent.steps) {
+      stepsContainer.appendChild(this.createStepRow(step));
+    }
+
+    card.appendChild(stepsContainer);
+
+    return card;
+  }
+
+  // ── Step Row ──────────────────────────────────────────────────────
+
+  private createStepRow(step: LaunchStep): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'qc-step-row';
+
+    // Checkbox
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = step.enabled;
+    checkbox.className = 'qc-step-checkbox';
+    checkbox.addEventListener('change', () => { step.enabled = checkbox.checked; });
+    row.appendChild(checkbox);
+
+    // Type label
+    const typeLabel = document.createElement('span');
+    typeLabel.className = 'qc-step-type';
+    typeLabel.textContent = STEP_TYPE_LABELS[step.type] ?? step.type;
+    row.appendChild(typeLabel);
+
+    // Inline config
+    const configEl = document.createElement('span');
+    configEl.className = 'qc-step-config';
+    configEl.textContent = this.formatStepConfig(step);
+    row.appendChild(configEl);
+
+    // Expandable config fields
+    if (this.hasEditableConfig(step)) {
+      const expandBtn = document.createElement('button');
+      expandBtn.className = 'flow-btn flow-btn-icon';
+      expandBtn.title = 'Configure';
+      expandBtn.textContent = '\u2699';
+      expandBtn.style.cssText = 'font-size: 12px; padding: 1px 4px;';
+
+      const configPanel = document.createElement('div');
+      configPanel.className = 'qc-step-config-panel';
+      configPanel.style.display = 'none';
+      this.renderStepConfig(configPanel, step, () => {
+        configEl.textContent = this.formatStepConfig(step);
+      });
+
+      expandBtn.addEventListener('click', () => {
+        const visible = configPanel.style.display !== 'none';
+        configPanel.style.display = visible ? 'none' : '';
+      });
+
+      row.appendChild(expandBtn);
+      row.appendChild(configPanel);
+    }
+
+    return row;
+  }
+
+  private formatStepConfig(step: LaunchStep): string {
+    switch (step.type) {
+      case 'wait-idle':
+        return `${step.config.idleMs ?? 2000}ms idle, ${step.config.timeoutMs ?? 30000}ms timeout`;
+      case 'run-command':
+        return step.config.command ? String(step.config.command) : '(no command)';
+      case 'wait-ready':
+        return `marker: ${step.config.marker ?? 'ready'}`;
+      case 'delay':
+        return `${step.config.ms ?? 1000}ms`;
+      default:
+        return '';
+    }
+  }
+
+  private hasEditableConfig(step: LaunchStep): boolean {
+    return ['wait-idle', 'run-command', 'wait-ready', 'delay'].includes(step.type);
+  }
+
+  private renderStepConfig(
+    container: HTMLElement,
+    step: LaunchStep,
+    onChanged: () => void,
+  ): void {
+    switch (step.type) {
+      case 'wait-idle': {
+        container.appendChild(this.createNumberField('Idle (ms)', step.config, 'idleMs', 2000, onChanged));
+        container.appendChild(this.createNumberField('Timeout (ms)', step.config, 'timeoutMs', 30000, onChanged));
+        break;
+      }
+      case 'run-command': {
+        container.appendChild(this.createStringField('Command', step.config, 'command', 'echo hello', onChanged));
+        break;
+      }
+      case 'wait-ready': {
+        container.appendChild(this.createStringField('Marker', step.config, 'marker', 'ready', onChanged));
+        container.appendChild(this.createNumberField('Timeout (ms)', step.config, 'timeoutMs', 30000, onChanged));
+        break;
+      }
+      case 'delay': {
+        container.appendChild(this.createNumberField('Delay (ms)', step.config, 'ms', 1000, onChanged));
+        break;
+      }
+    }
+  }
+
+  // ── Helper: field builders ────────────────────────────────────────
+
+  private createFieldGroup(labelText: string): HTMLElement {
+    const group = document.createElement('div');
+    group.className = 'flow-field-group';
+    const label = document.createElement('label');
+    label.className = 'flow-field-label';
+    label.textContent = labelText;
+    group.appendChild(label);
+    return group;
+  }
+
+  private createNumberField(
+    label: string,
+    config: Record<string, unknown>,
+    key: string,
+    defaultVal: number,
+    onChanged: () => void,
+  ): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'qc-config-field';
+    const labelEl = document.createElement('span');
+    labelEl.className = 'qc-config-label';
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'flow-input';
+    input.style.width = '100px';
+    input.value = String(config[key] ?? defaultVal);
+    input.addEventListener('input', () => {
+      config[key] = input.value ? Number(input.value) : defaultVal;
+      onChanged();
+    });
+    row.appendChild(input);
+    return row;
+  }
+
+  private createStringField(
+    label: string,
+    config: Record<string, unknown>,
+    key: string,
+    placeholder: string,
+    onChanged: () => void,
+  ): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'qc-config-field';
+    const labelEl = document.createElement('span');
+    labelEl.className = 'qc-config-label';
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'flow-input';
+    input.value = String(config[key] ?? '');
+    input.placeholder = placeholder;
+    input.addEventListener('input', () => {
+      config[key] = input.value;
+      onChanged();
+    });
+    row.appendChild(input);
+    return row;
+  }
+}

--- a/src/controllers/keyboard-controller.ts
+++ b/src/controllers/keyboard-controller.ts
@@ -1,6 +1,7 @@
 import { store } from '../state/store';
 import { terminalSettingsStore } from '../state/terminal-settings-store';
 import { aiToolsSettingsStore } from '../state/ai-tools-settings-store';
+import { quickClaudeSettingsStore, type PresetLayout } from '../state/quick-claude-settings-store';
 import { terminalService } from '../services/terminal-service';
 import { workspaceService } from '../services/workspace-service';
 import { keybindingStore } from '../state/keybinding-store';
@@ -383,6 +384,68 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
         try {
           const { invoke } = await import('@tauri-apps/api/core');
 
+          // ── Preset-based launch path ──
+          if (input.presetId) {
+            const preset = quickClaudeSettingsStore.getPreset(input.presetId);
+            if (preset && preset.agents.length > 0) {
+              // Resolve base branch name
+              let baseName: string | null = null;
+              if (!input.noWorktree) {
+                baseName = input.branchName
+                  ?? await (async () => {
+                    const { llmGenerateBranchName } = await import('../plugins/smollm2/llm-service');
+                    return llmGenerateBranchName(input.prompt);
+                  })();
+              }
+
+              // Resolve per-agent branch names
+              const branches = preset.agents.map(agent => {
+                if (!baseName) return null;
+                const suffix = agent.branchSuffixOverride
+                  ?? aiToolsSettingsStore.getBranchSuffix(agent.toolId);
+                return suffix ? `${baseName}${suffix}` : baseName;
+              });
+
+              // Launch all agents in parallel
+              const results = await Promise.all(
+                preset.agents.map((agent, i) =>
+                  invoke<{ terminal_id: string; worktree_branch: string | null }>(
+                    'quick_claude',
+                    {
+                      workspaceId: input.workspaceId,
+                      prompt: input.prompt,
+                      branchName: branches[i],
+                      skipFetch: true,
+                      noWorktree: input.noWorktree ?? false,
+                      aiTool: agent.toolId,
+                    },
+                  ),
+                ),
+              );
+
+              const processName = shellTypeToProcessName(terminalSettingsStore.getDefaultShell());
+
+              // Add terminals to store
+              for (let i = 0; i < results.length; i++) {
+                const r = results[i];
+                const agent = preset.agents[i];
+                store.addTerminal({
+                  id: r.terminal_id,
+                  workspaceId: input.workspaceId,
+                  name: r.worktree_branch ?? agent.label,
+                  processName,
+                  order: 0,
+                }, i > 0 ? { background: true } : undefined);
+              }
+
+              // Build layout from preset
+              buildPresetLayout(input.workspaceId, preset.layout, results.map(r => r.terminal_id));
+              break;
+            }
+          }
+
+          // ── Custom (non-preset) launch path ──
+
           // Determine which tools to launch
           const toolsToLaunch: string[] = [];
           if (input.aiTool === 'both') {
@@ -487,4 +550,28 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
 
   // Listen for voice toggle events from the mic button in TabBar
   document.addEventListener('voice-toggle-recording', () => deps.handleVoiceToggle());
+}
+
+/**
+ * Map a preset layout + terminal IDs to store.splitTerminalAt() calls.
+ */
+function buildPresetLayout(workspaceId: string, layout: PresetLayout, terminalIds: string[]): void {
+  if (terminalIds.length <= 1 || layout === 'single') return;
+
+  if (layout === 'vertical' && terminalIds.length >= 2) {
+    // Left / Right split
+    store.splitTerminalAt(workspaceId, terminalIds[0], terminalIds[1], 'vertical', 0.5);
+  } else if (layout === 'horizontal' && terminalIds.length >= 2) {
+    // Top / Bottom split
+    store.splitTerminalAt(workspaceId, terminalIds[0], terminalIds[1], 'horizontal', 0.5);
+  } else if (layout === 'grid' && terminalIds.length >= 2) {
+    // 2x2 grid: first split left/right, then split each half top/bottom
+    store.splitTerminalAt(workspaceId, terminalIds[0], terminalIds[1], 'vertical', 0.5);
+    if (terminalIds[2]) {
+      store.splitTerminalAt(workspaceId, terminalIds[0], terminalIds[2], 'horizontal', 0.5);
+    }
+    if (terminalIds[3]) {
+      store.splitTerminalAt(workspaceId, terminalIds[1], terminalIds[3], 'horizontal', 0.5);
+    }
+  }
 }

--- a/src/state/quick-claude-settings-store.test.ts
+++ b/src/state/quick-claude-settings-store.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Reset localStorage and re-import store for each test
+let store: typeof import('./quick-claude-settings-store');
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+});
+
+async function getStore() {
+  store = await import('./quick-claude-settings-store');
+  return store.quickClaudeSettingsStore;
+}
+
+describe('QuickClaudeSettingsStore', () => {
+  describe('built-in presets', () => {
+    it('seeds 3 built-in presets on first run', async () => {
+      const s = await getStore();
+      const presets = s.getPresets();
+      expect(presets.length).toBe(3);
+      const names = presets.map(p => p.name);
+      expect(names).toContain('Solo Claude');
+      expect(names).toContain('Solo Codex');
+      expect(names).toContain('Claude + Codex Split');
+    });
+
+    it('marks Solo Claude as default', async () => {
+      const s = await getStore();
+      const def = s.getDefaultPreset();
+      expect(def?.name).toBe('Solo Claude');
+      expect(def?.isDefault).toBe(true);
+    });
+
+    it('does not duplicate built-ins when already present', async () => {
+      const s1 = await getStore();
+      expect(s1.getPresets().length).toBe(3);
+      // Re-import to simulate restart
+      vi.resetModules();
+      const s2 = await getStore();
+      expect(s2.getPresets().length).toBe(3);
+    });
+  });
+
+  describe('preset CRUD', () => {
+    it('adds a custom preset', async () => {
+      const s = await getStore();
+      s.addPreset({
+        id: 'custom-1',
+        name: 'Custom',
+        description: 'test',
+        layout: 'horizontal',
+        agents: [],
+        isDefault: false,
+        createdAt: Date.now(),
+      });
+      expect(s.getPresets().length).toBe(4);
+      expect(s.getPreset('custom-1')?.name).toBe('Custom');
+    });
+
+    it('ignores duplicate add', async () => {
+      const s = await getStore();
+      s.addPreset({
+        id: 'custom-1', name: 'A', description: '', layout: 'single',
+        agents: [], isDefault: false, createdAt: 0,
+      });
+      s.addPreset({
+        id: 'custom-1', name: 'B', description: '', layout: 'single',
+        agents: [], isDefault: false, createdAt: 0,
+      });
+      expect(s.getPreset('custom-1')?.name).toBe('A');
+    });
+
+    it('updates a preset', async () => {
+      const s = await getStore();
+      s.updatePreset('builtin-solo-claude', { name: 'Renamed', layout: 'horizontal' });
+      const p = s.getPreset('builtin-solo-claude');
+      expect(p?.name).toBe('Renamed');
+      expect(p?.layout).toBe('horizontal');
+    });
+
+    it('setting isDefault clears other defaults', async () => {
+      const s = await getStore();
+      s.updatePreset('builtin-solo-codex', { isDefault: true });
+      expect(s.getPreset('builtin-solo-claude')?.isDefault).toBe(false);
+      expect(s.getPreset('builtin-solo-codex')?.isDefault).toBe(true);
+    });
+
+    it('deletes a custom preset', async () => {
+      const s = await getStore();
+      s.addPreset({
+        id: 'to-delete', name: 'Delete me', description: '', layout: 'single',
+        agents: [], isDefault: false, createdAt: 0,
+      });
+      s.deletePreset('to-delete');
+      expect(s.getPreset('to-delete')).toBeUndefined();
+    });
+
+    it('cannot delete built-in presets', async () => {
+      const s = await getStore();
+      s.deletePreset('builtin-solo-claude');
+      expect(s.getPreset('builtin-solo-claude')).toBeDefined();
+    });
+
+    it('reassigns default when default preset deleted', async () => {
+      const s = await getStore();
+      s.addPreset({
+        id: 'custom-def', name: 'Def', description: '', layout: 'single',
+        agents: [], isDefault: true, createdAt: 0,
+      });
+      s.deletePreset('custom-def');
+      const presets = s.getPresets();
+      expect(presets.some(p => p.isDefault)).toBe(true);
+    });
+
+    it('duplicates a preset with new IDs', async () => {
+      const s = await getStore();
+      const copy = s.duplicatePreset('builtin-solo-claude');
+      expect(copy).toBeDefined();
+      expect(copy!.id).not.toBe('builtin-solo-claude');
+      expect(copy!.name).toBe('Solo Claude (Copy)');
+      expect(copy!.isDefault).toBe(false);
+      expect(copy!.agents[0].id).not.toBe(s.getPreset('builtin-solo-claude')!.agents[0].id);
+    });
+  });
+
+  describe('agent CRUD', () => {
+    it('respects layout max agents', async () => {
+      const s = await getStore();
+      // Solo Claude is single layout with 1 agent — can't add more
+      const agent = s.addAgent('builtin-solo-claude', 'codex');
+      expect(agent).toBeUndefined();
+    });
+
+    it('adds agent to multi-agent layout', async () => {
+      const s = await getStore();
+      s.addPreset({
+        id: 'grid-test', name: 'Grid', description: '', layout: 'grid',
+        agents: [], isDefault: false, createdAt: 0,
+      });
+      const a1 = s.addAgent('grid-test', 'claude');
+      const a2 = s.addAgent('grid-test', 'codex');
+      const a3 = s.addAgent('grid-test', 'claude');
+      const a4 = s.addAgent('grid-test', 'codex');
+      const a5 = s.addAgent('grid-test', 'claude');
+      expect(a1).toBeDefined();
+      expect(a2).toBeDefined();
+      expect(a3).toBeDefined();
+      expect(a4).toBeDefined();
+      expect(a5).toBeUndefined(); // grid max = 4
+    });
+
+    it('updates agent fields', async () => {
+      const s = await getStore();
+      const preset = s.getPreset('builtin-solo-claude')!;
+      const agentId = preset.agents[0].id;
+      s.updateAgent('builtin-solo-claude', agentId, { label: 'My Claude', commandOverride: 'test' });
+      const updated = s.getPreset('builtin-solo-claude')!.agents[0];
+      expect(updated.label).toBe('My Claude');
+      expect(updated.commandOverride).toBe('test');
+    });
+
+    it('removes an agent', async () => {
+      const s = await getStore();
+      const preset = s.getPreset('builtin-claude-codex-split')!;
+      const agentId = preset.agents[1].id;
+      s.removeAgent('builtin-claude-codex-split', agentId);
+      expect(s.getPreset('builtin-claude-codex-split')!.agents.length).toBe(1);
+    });
+  });
+
+  describe('step operations', () => {
+    it('updates a step', async () => {
+      const s = await getStore();
+      const preset = s.getPreset('builtin-solo-claude')!;
+      const agent = preset.agents[0];
+      const step = agent.steps.find(st => st.type === 'wait-idle')!;
+      s.updateStep('builtin-solo-claude', agent.id, step.id, { enabled: false, config: { idleMs: 5000 } });
+      const updated = s.getPreset('builtin-solo-claude')!.agents[0].steps.find(st => st.id === step.id)!;
+      expect(updated.enabled).toBe(false);
+      expect(updated.config.idleMs).toBe(5000);
+    });
+
+    it('resets steps to default', async () => {
+      const s = await getStore();
+      const preset = s.getPreset('builtin-solo-claude')!;
+      const agent = preset.agents[0];
+      s.updateStep('builtin-solo-claude', agent.id, agent.steps[0].id, { enabled: false });
+      s.resetStepsToDefault('builtin-solo-claude', agent.id);
+      const refreshed = s.getPreset('builtin-solo-claude')!.agents[0];
+      expect(refreshed.steps.every(st => st.enabled)).toBe(true);
+      expect(refreshed.steps[0].type).toBe('create-terminal');
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('notifies on changes', async () => {
+      const s = await getStore();
+      const fn = vi.fn();
+      s.subscribe(fn);
+      s.updatePreset('builtin-solo-claude', { name: 'test' });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribes correctly', async () => {
+      const s = await getStore();
+      const fn = vi.fn();
+      const unsub = s.subscribe(fn);
+      unsub();
+      s.updatePreset('builtin-solo-claude', { name: 'test' });
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('localStorage roundtrip', () => {
+    it('persists and restores presets', async () => {
+      const s1 = await getStore();
+      s1.addPreset({
+        id: 'roundtrip-test', name: 'RT', description: 'roundtrip', layout: 'horizontal',
+        agents: [{
+          id: 'a1', toolId: 'claude', label: 'C',
+          steps: [{ id: 's1', type: 'delay', enabled: true, config: { ms: 100 } }],
+        }],
+        isDefault: false, createdAt: 123,
+      });
+
+      vi.resetModules();
+      const s2 = await getStore();
+      const p = s2.getPreset('roundtrip-test');
+      expect(p).toBeDefined();
+      expect(p!.name).toBe('RT');
+      expect(p!.agents[0].steps[0].config.ms).toBe(100);
+    });
+  });
+
+  describe('setDefault', () => {
+    it('changes the default preset', async () => {
+      const s = await getStore();
+      s.setDefault('builtin-solo-codex');
+      expect(s.getDefaultPreset()?.id).toBe('builtin-solo-codex');
+      expect(s.getPreset('builtin-solo-claude')?.isDefault).toBe(false);
+    });
+  });
+});

--- a/src/state/quick-claude-settings-store.ts
+++ b/src/state/quick-claude-settings-store.ts
@@ -1,0 +1,382 @@
+const STORAGE_KEY = 'godly-quick-claude-presets';
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export type LaunchStepType =
+  | 'create-terminal' | 'wait-idle' | 'run-command'
+  | 'wait-ready' | 'send-prompt' | 'send-enter' | 'delay';
+
+export interface LaunchStep {
+  id: string;
+  type: LaunchStepType;
+  enabled: boolean;
+  config: Record<string, unknown>;
+}
+
+export interface PresetAgent {
+  id: string;
+  toolId: string;
+  label: string;
+  commandOverride?: string;
+  branchSuffixOverride?: string;
+  steps: LaunchStep[];
+}
+
+export type PresetLayout = 'single' | 'vertical' | 'horizontal' | 'grid';
+
+export interface QuickClaudePreset {
+  id: string;
+  name: string;
+  description: string;
+  layout: PresetLayout;
+  agents: PresetAgent[];
+  isDefault: boolean;
+  createdAt: number;
+}
+
+// ── Layout constraints ──────────────────────────────────────────────
+
+export const LAYOUT_MAX_AGENTS: Record<PresetLayout, number> = {
+  single: 1,
+  vertical: 2,
+  horizontal: 2,
+  grid: 4,
+};
+
+// ── Default step templates ──────────────────────────────────────────
+
+function defaultStepsForTool(toolId: string): LaunchStep[] {
+  const base: LaunchStep[] = [
+    { id: crypto.randomUUID(), type: 'create-terminal', enabled: true, config: {} },
+    { id: crypto.randomUUID(), type: 'wait-idle', enabled: true, config: { idleMs: 2000, timeoutMs: 30000 } },
+  ];
+
+  if (toolId === 'claude') {
+    base.push(
+      { id: crypto.randomUUID(), type: 'wait-ready', enabled: true, config: { marker: 'trust', timeoutMs: 15000 } },
+      { id: crypto.randomUUID(), type: 'send-enter', enabled: true, config: {} },
+      { id: crypto.randomUUID(), type: 'wait-ready', enabled: true, config: { marker: 'ready', timeoutMs: 30000 } },
+      { id: crypto.randomUUID(), type: 'send-prompt', enabled: true, config: {} },
+    );
+  } else if (toolId === 'codex') {
+    base.push(
+      { id: crypto.randomUUID(), type: 'wait-ready', enabled: true, config: { marker: 'ready', timeoutMs: 30000 } },
+      { id: crypto.randomUUID(), type: 'send-prompt', enabled: true, config: {} },
+    );
+  } else {
+    base.push(
+      { id: crypto.randomUUID(), type: 'delay', enabled: true, config: { ms: 3000 } },
+      { id: crypto.randomUUID(), type: 'send-prompt', enabled: true, config: {} },
+    );
+  }
+
+  return base;
+}
+
+// ── Built-in presets ────────────────────────────────────────────────
+
+const BUILT_IN_PRESET_IDS = ['builtin-solo-claude', 'builtin-solo-codex', 'builtin-claude-codex-split'];
+
+function createBuiltInPresets(): QuickClaudePreset[] {
+  return [
+    {
+      id: 'builtin-solo-claude',
+      name: 'Solo Claude',
+      description: 'Single Claude Code session',
+      layout: 'single',
+      agents: [{
+        id: crypto.randomUUID(),
+        toolId: 'claude',
+        label: 'Claude Code',
+        steps: defaultStepsForTool('claude'),
+      }],
+      isDefault: true,
+      createdAt: 0,
+    },
+    {
+      id: 'builtin-solo-codex',
+      name: 'Solo Codex',
+      description: 'Single Codex session',
+      layout: 'single',
+      agents: [{
+        id: crypto.randomUUID(),
+        toolId: 'codex',
+        label: 'Codex',
+        steps: defaultStepsForTool('codex'),
+      }],
+      isDefault: false,
+      createdAt: 0,
+    },
+    {
+      id: 'builtin-claude-codex-split',
+      name: 'Claude + Codex Split',
+      description: 'Claude and Codex side by side',
+      layout: 'vertical',
+      agents: [
+        {
+          id: crypto.randomUUID(),
+          toolId: 'claude',
+          label: 'Claude Code',
+          steps: defaultStepsForTool('claude'),
+        },
+        {
+          id: crypto.randomUUID(),
+          toolId: 'codex',
+          label: 'Codex',
+          steps: defaultStepsForTool('codex'),
+        },
+      ],
+      isDefault: false,
+      createdAt: 0,
+    },
+  ];
+}
+
+// ── Store ───────────────────────────────────────────────────────────
+
+type Subscriber = () => void;
+
+class QuickClaudeSettingsStore {
+  private presets: QuickClaudePreset[] = [];
+  private subscribers: Subscriber[] = [];
+
+  constructor() {
+    this.loadFromStorage();
+    this.ensureBuiltInPresets();
+  }
+
+  // ── Preset CRUD ─────────────────────────────────────────────────
+
+  getPresets(): QuickClaudePreset[] {
+    return this.presets.map(p => structuredClone(p));
+  }
+
+  getPreset(id: string): QuickClaudePreset | undefined {
+    const preset = this.presets.find(p => p.id === id);
+    return preset ? structuredClone(preset) : undefined;
+  }
+
+  getDefaultPreset(): QuickClaudePreset | undefined {
+    const preset = this.presets.find(p => p.isDefault) ?? this.presets[0];
+    return preset ? structuredClone(preset) : undefined;
+  }
+
+  addPreset(preset: QuickClaudePreset): void {
+    if (this.presets.some(p => p.id === preset.id)) return;
+    this.presets.push(structuredClone(preset));
+    this.saveAndNotify();
+  }
+
+  updatePreset(id: string, updates: Partial<Omit<QuickClaudePreset, 'id'>>): void {
+    const preset = this.presets.find(p => p.id === id);
+    if (!preset) return;
+
+    if (updates.name !== undefined) preset.name = updates.name;
+    if (updates.description !== undefined) preset.description = updates.description;
+    if (updates.layout !== undefined) preset.layout = updates.layout;
+    if (updates.agents !== undefined) preset.agents = structuredClone(updates.agents);
+    if (updates.isDefault !== undefined) {
+      if (updates.isDefault) {
+        for (const p of this.presets) p.isDefault = false;
+      }
+      preset.isDefault = updates.isDefault;
+    }
+
+    this.saveAndNotify();
+  }
+
+  deletePreset(id: string): void {
+    if (BUILT_IN_PRESET_IDS.includes(id)) return;
+    const wasDefault = this.presets.find(p => p.id === id)?.isDefault;
+    this.presets = this.presets.filter(p => p.id !== id);
+    if (wasDefault && this.presets.length > 0) {
+      this.presets[0].isDefault = true;
+    }
+    this.saveAndNotify();
+  }
+
+  duplicatePreset(id: string): QuickClaudePreset | undefined {
+    const source = this.presets.find(p => p.id === id);
+    if (!source) return undefined;
+
+    const copy = structuredClone(source);
+    copy.id = crypto.randomUUID();
+    copy.name = `${source.name} (Copy)`;
+    copy.isDefault = false;
+    copy.createdAt = Date.now();
+    // Give new IDs to agents and steps
+    for (const agent of copy.agents) {
+      agent.id = crypto.randomUUID();
+      for (const step of agent.steps) {
+        step.id = crypto.randomUUID();
+      }
+    }
+
+    this.presets.push(copy);
+    this.saveAndNotify();
+    return structuredClone(copy);
+  }
+
+  setDefault(id: string): void {
+    const preset = this.presets.find(p => p.id === id);
+    if (!preset) return;
+    for (const p of this.presets) p.isDefault = false;
+    preset.isDefault = true;
+    this.saveAndNotify();
+  }
+
+  // ── Agent CRUD ──────────────────────────────────────────────────
+
+  addAgent(presetId: string, toolId: string): PresetAgent | undefined {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return undefined;
+    const max = LAYOUT_MAX_AGENTS[preset.layout];
+    if (preset.agents.length >= max) return undefined;
+
+    const agent: PresetAgent = {
+      id: crypto.randomUUID(),
+      toolId,
+      label: toolId === 'claude' ? 'Claude Code' : toolId === 'codex' ? 'Codex' : toolId,
+      steps: defaultStepsForTool(toolId),
+    };
+    preset.agents.push(agent);
+    this.saveAndNotify();
+    return structuredClone(agent);
+  }
+
+  updateAgent(presetId: string, agentId: string, updates: Partial<Omit<PresetAgent, 'id' | 'steps'>>): void {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return;
+    const agent = preset.agents.find(a => a.id === agentId);
+    if (!agent) return;
+    Object.assign(agent, updates);
+    this.saveAndNotify();
+  }
+
+  removeAgent(presetId: string, agentId: string): void {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return;
+    preset.agents = preset.agents.filter(a => a.id !== agentId);
+    this.saveAndNotify();
+  }
+
+  reorderAgents(presetId: string, agentIds: string[]): void {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return;
+    const reordered: PresetAgent[] = [];
+    for (const id of agentIds) {
+      const agent = preset.agents.find(a => a.id === id);
+      if (agent) reordered.push(agent);
+    }
+    preset.agents = reordered;
+    this.saveAndNotify();
+  }
+
+  // ── Step operations ─────────────────────────────────────────────
+
+  updateStep(presetId: string, agentId: string, stepId: string, updates: Partial<Omit<LaunchStep, 'id'>>): void {
+    const step = this.findStep(presetId, agentId, stepId);
+    if (!step) return;
+    Object.assign(step, updates);
+    this.saveAndNotify();
+  }
+
+  reorderSteps(presetId: string, agentId: string, stepIds: string[]): void {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return;
+    const agent = preset.agents.find(a => a.id === agentId);
+    if (!agent) return;
+    const reordered: LaunchStep[] = [];
+    for (const id of stepIds) {
+      const step = agent.steps.find(s => s.id === id);
+      if (step) reordered.push(step);
+    }
+    agent.steps = reordered;
+    this.saveAndNotify();
+  }
+
+  resetStepsToDefault(presetId: string, agentId: string): void {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return;
+    const agent = preset.agents.find(a => a.id === agentId);
+    if (!agent) return;
+    agent.steps = defaultStepsForTool(agent.toolId);
+    this.saveAndNotify();
+  }
+
+  // ── Subscriptions ───────────────────────────────────────────────
+
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.push(fn);
+    return () => {
+      this.subscribers = this.subscribers.filter(s => s !== fn);
+    };
+  }
+
+  // ── Helpers for default steps ───────────────────────────────────
+
+  getDefaultStepsForTool(toolId: string): LaunchStep[] {
+    return defaultStepsForTool(toolId);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────
+
+  private findStep(presetId: string, agentId: string, stepId: string): LaunchStep | undefined {
+    const preset = this.presets.find(p => p.id === presetId);
+    if (!preset) return undefined;
+    const agent = preset.agents.find(a => a.id === agentId);
+    if (!agent) return undefined;
+    return agent.steps.find(s => s.id === stepId);
+  }
+
+  private ensureBuiltInPresets(): void {
+    const existing = new Set(this.presets.map(p => p.id));
+    const builtIns = createBuiltInPresets();
+    let changed = false;
+    for (const preset of builtIns) {
+      if (!existing.has(preset.id)) {
+        this.presets.unshift(preset);
+        changed = true;
+      }
+    }
+    if (changed) this.saveToStorage();
+  }
+
+  private saveAndNotify(): void {
+    this.saveToStorage();
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const fn of this.subscribers) fn();
+  }
+
+  private loadFromStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw) as unknown;
+      if (!Array.isArray(data)) return;
+      this.presets = data.filter(
+        (p): p is QuickClaudePreset =>
+          typeof p === 'object' && p !== null &&
+          typeof p.id === 'string' && typeof p.name === 'string' &&
+          typeof p.layout === 'string' && Array.isArray(p.agents),
+      );
+    } catch {
+      // Corrupt data — use defaults
+    }
+  }
+
+  private saveToStorage(): void {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.presets));
+    } catch {
+      // No localStorage available
+    }
+  }
+}
+
+export const quickClaudeSettingsStore = new QuickClaudeSettingsStore();

--- a/src/state/settings-tab-store.ts
+++ b/src/state/settings-tab-store.ts
@@ -1,6 +1,6 @@
 const STORAGE_KEY = 'godly-settings-tab-order';
 
-const DEFAULT_ORDER: string[] = ['themes', 'terminal', 'notifications', 'plugins', 'shortcuts', 'remote'];
+const DEFAULT_ORDER: string[] = ['themes', 'terminal', 'quick-claude', 'notifications', 'plugins', 'shortcuts', 'remote'];
 
 type Subscriber = () => void;
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2877,3 +2877,193 @@ body.dragging-active * {
   color: var(--danger);
   margin-bottom: 8px;
 }
+
+/* ── Quick Claude Presets ─────────────────────────────── */
+
+.qc-layout-badge {
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 8px;
+}
+
+.qc-default-star {
+  color: var(--warning, #e0af68);
+  font-size: 14px;
+  margin-left: 4px;
+}
+
+.qc-layout-selector {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.qc-layout-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  min-width: 80px;
+}
+
+.qc-layout-option:hover {
+  background: var(--bg-tertiary);
+}
+
+.qc-layout-option-active {
+  border-color: var(--accent);
+  background: rgba(125, 174, 163, 0.08);
+}
+
+.qc-layout-icon {
+  font-size: 20px;
+  color: var(--text-primary);
+}
+
+.qc-layout-label {
+  font-size: 12px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.qc-layout-max {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.qc-agents {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.qc-agent-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.qc-agent-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.qc-agent-position {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-active);
+  min-width: 56px;
+}
+
+.qc-agent-header .flow-select {
+  flex: 1;
+}
+
+.qc-agent-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.qc-agent-field-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  min-width: 110px;
+}
+
+.qc-agent-field .flow-input {
+  flex: 1;
+}
+
+.qc-steps-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+  margin-bottom: 6px;
+}
+
+.qc-step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.qc-step-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--bg-primary);
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+.qc-step-checkbox {
+  margin: 0;
+  cursor: pointer;
+}
+
+.qc-step-type {
+  color: var(--text-primary);
+  font-weight: 500;
+  min-width: 100px;
+}
+
+.qc-step-config {
+  color: var(--text-secondary);
+  font-size: 11px;
+  flex: 1;
+}
+
+.qc-step-config-panel {
+  width: 100%;
+  padding: 8px 0 4px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.qc-config-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.qc-config-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  min-width: 80px;
+}
+
+.qc-config-field .flow-input {
+  font-size: 11px;
+  padding: 3px 6px;
+}
+
+/* Quick Claude dialog preset selector */
+.qc-preset-select {
+  margin-bottom: 8px;
+}
+
+.qc-agent-summary {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+  padding: 6px 10px;
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Summary

- **New "Quick Claude" settings tab** with a preset system for reusable launch configurations
- Each preset defines which agents to launch, their split layout (single/vertical/horizontal/grid), and per-agent launch step sequences
- **Preset selector** added to the Quick Claude dialog — pick a saved configuration or use "Custom..." for manual tool selection
- Ships with 3 built-in presets: Solo Claude, Solo Codex, Claude + Codex Split

### Files changed

| File | Purpose |
|------|---------|
| `src/state/quick-claude-settings-store.ts` | Store: preset/agent/step CRUD, localStorage, built-in preset seeding |
| `src/components/settings/quick-claude-tab.ts` | Settings tab: list view (preset cards) + editor view (agent config, step config) |
| `src/state/quick-claude-settings-store.test.ts` | 21 unit tests for store |
| `src/components/settings/index.ts` | Register QuickClaudeTab |
| `src/state/settings-tab-store.ts` | Add `quick-claude` to DEFAULT_ORDER |
| `src/components/dialogs.ts` | Preset selector in Quick Claude dialog |
| `src/controllers/keyboard-controller.ts` | Preset-based launch path + `buildPresetLayout()` |
| `src/styles/main.css` | CSS for layout selector, agent cards, step rows |

## Test plan

- [x] `pnpm test` — 21 new store tests pass, no regressions in existing unit tests
- [x] `tsc --noEmit` — clean TypeScript build
- [ ] Open Settings → "Quick Claude" tab visible with 3 default presets
- [ ] Edit a preset: change layout, add/remove agents, toggle steps → saves to localStorage
- [ ] Open Quick Claude dialog → preset selector visible, selecting a preset shows agent summary
- [ ] Launch with preset → correct number of terminals created with correct split layout