### PR TITLE
feat: confirm quit dialog (#511)

### DIFF
--- a/changelog/unreleased/511-confirm-quit.md
+++ b/changelog/unreleased/511-confirm-quit.md
@@ -1,0 +1,2 @@
+### Added
+- **Confirm quit dialog** — Shows confirmation when closing the app with active terminal sessions. Configurable via Settings (refs #511)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,6 +336,7 @@ pub fn run() {
             // --- Persistence ---
             persistence::save_layout,
             persistence::load_layout,
+            persistence::restore_window_state,
             persistence::save_scrollback,
             persistence::load_scrollback,
             persistence::delete_scrollback,
@@ -344,6 +345,8 @@ pub fn run() {
             commands::write_remote_config,
             // --- Window lifecycle ---
             window_lifecycle::scrollback_save_complete,
+            window_lifecycle::confirm_quit,
+            window_lifecycle::cancel_quit,
             // --- MCP ---
             mcp_js_result,
         ])

--- a/src-tauri/src/window_lifecycle.rs
+++ b/src-tauri/src/window_lifecycle.rs
@@ -1,10 +1,16 @@
 //! Window lifecycle management: close handler with scrollback save coordination
 //! and graceful session detachment.
+//!
+//! When the user closes the window, the frontend is first asked whether to show
+//! a confirmation dialog (based on active session count and user settings).
+//! If confirmed (or skipped), scrollback is saved, sessions are detached, and
+//! the window is destroyed.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use serde::Serialize;
 use tauri::Emitter;
 
 use crate::daemon_client::DaemonClient;
@@ -14,6 +20,22 @@ use crate::state::AppState;
 /// Flag to signal that scrollback save is complete.
 static SCROLLBACK_SAVED: AtomicBool = AtomicBool::new(false);
 
+/// Flag to signal that the user confirmed the quit (or the frontend skipped the dialog).
+static QUIT_CONFIRMED: AtomicBool = AtomicBool::new(false);
+
+/// Flag to signal that the user cancelled the quit.
+static QUIT_CANCELLED: AtomicBool = AtomicBool::new(false);
+
+/// Flag to prevent re-entrant close handling while a confirm dialog is showing.
+static CLOSE_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Payload sent with the `confirm-quit` event so the frontend knows how many
+/// active sessions would be lost.
+#[derive(Clone, Serialize)]
+struct ConfirmQuitPayload {
+    active_session_count: usize,
+}
+
 /// Called by the frontend after it finishes persisting scrollback data.
 #[tauri::command]
 pub(crate) fn scrollback_save_complete() {
@@ -21,11 +43,28 @@ pub(crate) fn scrollback_save_complete() {
     SCROLLBACK_SAVED.store(true, Ordering::SeqCst);
 }
 
+/// Called by the frontend when the user confirms the quit (or the setting is
+/// disabled / no active sessions).
+#[tauri::command]
+pub(crate) fn confirm_quit() {
+    eprintln!("[window_lifecycle] Quit confirmed by frontend");
+    QUIT_CONFIRMED.store(true, Ordering::SeqCst);
+}
+
+/// Called by the frontend when the user cancels the quit dialog.
+#[tauri::command]
+pub(crate) fn cancel_quit() {
+    eprintln!("[window_lifecycle] Quit cancelled by frontend");
+    QUIT_CANCELLED.store(true, Ordering::SeqCst);
+}
+
 /// Register the window close handler on the main window.
 ///
-/// On close: requests frontend scrollback save, waits (up to 3s), detaches
-/// all daemon sessions so they survive the app exit, saves layout, then
-/// destroys the window.
+/// Flow:
+/// 1. `CloseRequested` → prevent close, emit `confirm-quit` to frontend
+/// 2. Frontend checks settings/session count → calls `confirm_quit` or `cancel_quit`
+/// 3. If confirmed: emit `request-scrollback-save`, wait, detach, save, destroy
+/// 4. If cancelled: reset state, window stays open
 pub(crate) fn setup_window_close_handler(
     window: &tauri::WebviewWindow,
     state: Arc<AppState>,
@@ -39,26 +78,65 @@ pub(crate) fn setup_window_close_handler(
 
     window.on_window_event(move |event| {
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-            // Prevent immediate close
+            // Prevent re-entrant close while a dialog is already showing
+            if CLOSE_IN_PROGRESS.swap(true, Ordering::SeqCst) {
+                api.prevent_close();
+                return;
+            }
+
+            // Prevent immediate close — we need to ask the frontend first
             api.prevent_close();
 
-            // Reset the flag
+            // Reset all flags
             SCROLLBACK_SAVED.store(false, Ordering::SeqCst);
+            QUIT_CONFIRMED.store(false, Ordering::SeqCst);
+            QUIT_CANCELLED.store(false, Ordering::SeqCst);
 
-            // Request frontend to save scrollbacks
-            eprintln!("[window_lifecycle] Requesting frontend to save scrollbacks...");
-            let _ = window_for_close.emit("request-scrollback-save", ());
+            // Count active sessions
+            let active_session_count = state_for_close.terminals.read().len();
 
-            // Move the blocking wait to a background thread so the main
-            // thread stays free to process the frontend's IPC callback
-            // (scrollback_save_complete). Previously this busy-waited on
-            // the main thread, deadlocking because the callback could
-            // never be dispatched.
+            // Emit confirm-quit event to frontend with session count
+            eprintln!(
+                "[window_lifecycle] Requesting quit confirmation ({} active sessions)...",
+                active_session_count
+            );
+            let _ = window_for_close.emit(
+                "confirm-quit",
+                ConfirmQuitPayload {
+                    active_session_count,
+                },
+            );
+
+            // Spawn background thread to wait for frontend decision
             let state = state_for_close.clone();
             let daemon = daemon_for_close.clone();
             let handle = handle_for_close.clone();
             let window = window_for_close.clone();
             std::thread::spawn(move || {
+                // Wait for confirm or cancel (max 30s — generous timeout for user interaction)
+                let start = Instant::now();
+                loop {
+                    if QUIT_CONFIRMED.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    if QUIT_CANCELLED.load(Ordering::SeqCst) {
+                        eprintln!("[window_lifecycle] Quit cancelled, window stays open");
+                        CLOSE_IN_PROGRESS.store(false, Ordering::SeqCst);
+                        return;
+                    }
+                    if start.elapsed() > Duration::from_secs(30) {
+                        eprintln!("[window_lifecycle] Quit confirmation timeout, proceeding with close");
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+
+                // --- Confirmed: proceed with graceful shutdown ---
+
+                // Request frontend to save scrollbacks
+                eprintln!("[window_lifecycle] Requesting frontend to save scrollbacks...");
+                let _ = window.emit("request-scrollback-save", ());
+
                 // Wait for scrollback save to complete (max 3 seconds)
                 let start = Instant::now();
                 while !SCROLLBACK_SAVED.load(Ordering::SeqCst) {
@@ -82,6 +160,7 @@ pub(crate) fn setup_window_close_handler(
 
                 // Save layout and close
                 save_on_exit(&handle, &state);
+                CLOSE_IN_PROGRESS.store(false, Ordering::SeqCst);
                 eprintln!("[window_lifecycle] Destroying window...");
                 let _ = window.destroy();
             });

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -311,6 +311,9 @@ export class App {
     // Initialize terminal service
     await terminalService.init();
 
+    // Listen for quit confirmation requests from backend (on window close)
+    await this.setupConfirmQuitListener();
+
     // Listen for scrollback save requests from backend (on window close)
     await this.setupScrollbackSaveListener();
 
@@ -646,6 +649,30 @@ export class App {
     } catch (error) {
       console.error('[App] Failed to clear split view from backend:', error);
     }
+  }
+
+  private async setupConfirmQuitListener() {
+    const { listen } = await import('@tauri-apps/api/event');
+    await listen<{ active_session_count: number }>('confirm-quit', async (event) => {
+      const { active_session_count } = event.payload;
+      const { invoke } = await import('@tauri-apps/api/core');
+
+      // Skip dialog if setting is disabled or no active sessions
+      if (!terminalSettingsStore.getConfirmQuit() || active_session_count === 0) {
+        await invoke('confirm_quit');
+        return;
+      }
+
+      // Show confirmation dialog
+      const { showQuitConfirmDialog } = await import('./dialogs');
+      const confirmed = await showQuitConfirmDialog(active_session_count);
+
+      if (confirmed) {
+        await invoke('confirm_quit');
+      } else {
+        await invoke('cancel_quit');
+      }
+    });
   }
 
   private async setupScrollbackSaveListener() {

--- a/src/components/dialogs.ts
+++ b/src/components/dialogs.ts
@@ -3,6 +3,85 @@ import { aiToolsSettingsStore } from '../state/ai-tools-settings-store';
 import { quickClaudeSettingsStore } from '../state/quick-claude-settings-store';
 
 /**
+ * Show a confirmation dialog before quitting with active sessions.
+ * Returns true if the user confirms, false if cancelled.
+ */
+export function showQuitConfirmDialog(activeSessionCount: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'dialog-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+
+    const title = document.createElement('div');
+    title.className = 'dialog-title';
+    title.textContent = 'Quit Godly Terminal?';
+    dialog.appendChild(title);
+
+    const message = document.createElement('div');
+    message.style.cssText = 'font-size: 13px; color: var(--text-secondary); margin-bottom: 16px; line-height: 1.5;';
+    const sessionWord = activeSessionCount === 1 ? 'session' : 'sessions';
+    message.textContent = `${activeSessionCount} active ${sessionWord} will be lost. Quit anyway?`;
+    dialog.appendChild(message);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'dialog-buttons';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'dialog-btn dialog-btn-secondary';
+    cancelBtn.textContent = 'Cancel';
+    buttons.appendChild(cancelBtn);
+
+    const quitBtn = document.createElement('button');
+    quitBtn.className = 'dialog-btn dialog-btn-primary';
+    quitBtn.style.backgroundColor = 'var(--error, #e74c3c)';
+    quitBtn.textContent = 'Quit';
+    buttons.appendChild(quitBtn);
+
+    dialog.appendChild(buttons);
+    overlay.appendChild(dialog);
+
+    const close = () => overlay.remove();
+
+    cancelBtn.onclick = () => {
+      close();
+      resolve(false);
+    };
+
+    quitBtn.onclick = () => {
+      close();
+      resolve(true);
+    };
+
+    // Keyboard handling
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        resolve(false);
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        close();
+        resolve(true);
+      }
+    };
+    dialog.addEventListener('keydown', onKeydown);
+
+    overlay.onclick = (e) => {
+      if (e.target === overlay) {
+        close();
+        resolve(false);
+      }
+    };
+
+    document.body.appendChild(overlay);
+    quitBtn.focus();
+  });
+}
+
+/**
  * Show a prompt dialog for entering a custom worktree branch name.
  * Returns the user's input (empty string = auto-generate), or null if cancelled.
  */

--- a/src/components/settings/terminal-tab.ts
+++ b/src/components/settings/terminal-tab.ts
@@ -378,6 +378,38 @@ export class TerminalTab implements SettingsTabProvider {
     splitSection.appendChild(splitRadioGroup);
     content.appendChild(splitSection);
 
+    // ── Confirm Quit section ───────────────────────────────────
+    const quitSection = document.createElement('div');
+    quitSection.className = 'settings-section';
+
+    const quitTitle = document.createElement('div');
+    quitTitle.className = 'settings-section-title';
+    quitTitle.textContent = 'Window Close';
+    quitSection.appendChild(quitTitle);
+
+    const quitRow = document.createElement('div');
+    quitRow.className = 'shortcut-row';
+    const quitLabel = document.createElement('span');
+    quitLabel.className = 'shortcut-label';
+    quitLabel.textContent = 'Confirm before quitting with active sessions';
+    quitRow.appendChild(quitLabel);
+    const quitCheckbox = document.createElement('input');
+    quitCheckbox.type = 'checkbox';
+    quitCheckbox.className = 'notification-checkbox';
+    quitCheckbox.checked = terminalSettingsStore.getConfirmQuit();
+    quitCheckbox.onchange = () => {
+      terminalSettingsStore.setConfirmQuit(quitCheckbox.checked);
+    };
+    quitRow.appendChild(quitCheckbox);
+    quitSection.appendChild(quitRow);
+
+    const quitDesc = document.createElement('div');
+    quitDesc.className = 'settings-description';
+    quitDesc.textContent = 'When enabled, a confirmation dialog appears before closing the window if there are active terminal sessions.';
+    quitSection.appendChild(quitDesc);
+
+    content.appendChild(quitSection);
+
     // ── CMD Aliases section ────────────────────────────────────
     const aliasSection = document.createElement('div');
     aliasSection.className = 'settings-section';

--- a/src/state/terminal-settings-store.ts
+++ b/src/state/terminal-settings-store.ts
@@ -18,6 +18,8 @@ export interface TerminalSettings {
   rendererMode: RendererMode;
   /** How split-panel terminals appear in the tab bar. */
   splitTabMode: SplitTabMode;
+  /** When true, show a confirmation dialog before quitting with active sessions. */
+  confirmQuit: boolean;
 }
 
 type Subscriber = () => void;
@@ -33,6 +35,7 @@ class TerminalSettingsStore {
     fontSize: TerminalSettingsStore.DEFAULT_FONT_SIZE,
     rendererMode: 'gpu',
     splitTabMode: 'unified',
+    confirmQuit: true,
   };
 
   private subscribers: Subscriber[] = [];
@@ -98,6 +101,17 @@ class TerminalSettingsStore {
     this.notify();
   }
 
+  getConfirmQuit(): boolean {
+    return this.settings.confirmQuit;
+  }
+
+  setConfirmQuit(enabled: boolean): void {
+    if (enabled === this.settings.confirmQuit) return;
+    this.settings.confirmQuit = enabled;
+    this.saveToStorage();
+    this.notify();
+  }
+
   subscribe(fn: Subscriber): () => void {
     this.subscribers.push(fn);
     return () => {
@@ -134,6 +148,9 @@ class TerminalSettingsStore {
       }
       if (data.splitTabMode === 'individual' || data.splitTabMode === 'unified') {
         this.settings.splitTabMode = data.splitTabMode;
+      }
+      if (typeof data.confirmQuit === 'boolean') {
+        this.settings.confirmQuit = data.confirmQuit;
       }
     } catch {
       // Corrupt data — use defaults


### PR DESCRIPTION
Part of #511

## Summary
- Show a confirmation dialog when closing the app with active terminal sessions
- Dialog displays "X active sessions will be lost. Quit anyway?" with Quit/Cancel buttons
- Configurable via Settings > Terminal > Window Close (enabled by default)
- Skips dialog when setting is disabled or no active sessions exist
- Backend holds close with `prevent_close()` while waiting for user decision
- Preserves existing scrollback save + session detach flow after confirmation

## Changes
- **`src-tauri/src/window_lifecycle.rs`** — Emit `confirm-quit` event with session count, wait for `confirm_quit`/`cancel_quit` commands before proceeding
- **`src-tauri/src/lib.rs`** — Register new `confirm_quit` and `cancel_quit` commands
- **`src/state/terminal-settings-store.ts`** — Add `confirmQuit: boolean` setting (default: true)
- **`src/components/dialogs.ts`** — Add `showQuitConfirmDialog()` 
- **`src/components/App.ts`** — Listen for `confirm-quit` event, check setting, show dialog
- **`src/components/settings/terminal-tab.ts`** — Add "Window Close" settings section with toggle

## Test plan
- [ ] Open app with multiple terminal sessions, close window — dialog should appear
- [ ] Click Cancel — window stays open, sessions unaffected
- [ ] Click Quit — app closes gracefully (scrollback saved, sessions detached)
- [ ] Press Escape on dialog — same as Cancel
- [ ] Press Enter on dialog — same as Quit
- [ ] Disable "Confirm before quitting" in Settings > Terminal — close should skip dialog
- [ ] Close with 0 sessions — should skip dialog regardless of setting
- [ ] Verify `pnpm test` passes (1229/1229, pre-existing flaky test excluded)