### PR TITLE
feat: monitor-aware window state persistence (#511)

### DIFF
--- a/changelog/unreleased/511-monitor-persistence.md
+++ b/changelog/unreleased/511-monitor-persistence.md
@@ -1,0 +1,2 @@
+### Added
+- **Monitor-aware window persistence** — Window position, size, and maximized state are now saved per-monitor. Falls back to primary monitor if the saved display is disconnected (refs #511)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,6 +336,7 @@ pub fn run() {
             // --- Persistence ---
             persistence::save_layout,
             persistence::load_layout,
+            persistence::restore_window_state,
             persistence::save_scrollback,
             persistence::load_scrollback,
             persistence::delete_scrollback,

--- a/src-tauri/src/persistence/layout.rs
+++ b/src-tauri/src/persistence/layout.rs
@@ -63,6 +63,7 @@ pub fn save_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
     let active_workspace_id = state.active_workspace_id.read().clone();
     let split_views = state.get_all_split_views();
     let layout_trees = state.get_all_layout_trees();
+    let window_state = state.window_state.read().clone();
 
     let layout = Layout {
         workspaces,
@@ -70,6 +71,7 @@ pub fn save_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
         active_workspace_id,
         split_views,
         layout_trees,
+        window_state,
     };
 
     let json_value = serde_json::to_value(&layout)
@@ -142,6 +144,15 @@ pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
                 *state.active_workspace_id.write() = Some(active_id.clone());
             }
 
+            // Restore window state to backend state
+            if let Some(ws) = &layout.window_state {
+                log_info(&format!(
+                    "Restored window state: {}x{} at ({},{}) monitor={:?}",
+                    ws.width, ws.height, ws.x, ws.y, ws.monitor_name
+                ));
+                *state.window_state.write() = layout.window_state.clone();
+            }
+
             // Restore layout trees to backend state
             if !layout.layout_trees.is_empty() {
                 for (ws_id, tree) in &layout.layout_trees {
@@ -183,6 +194,89 @@ pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
     }
 }
 
+/// Apply the saved window state to the window, validating that the target
+/// monitor is still connected. Falls back to primary monitor if missing.
+/// Clamps position to the visible area to prevent off-screen restoration.
+#[tauri::command]
+pub fn restore_window_state(
+    window: tauri::WebviewWindow,
+    state: State<Arc<AppState>>,
+) -> Result<(), String> {
+    let saved = state.window_state.read().clone();
+    let saved = match saved {
+        Some(s) => s,
+        None => {
+            log_info("No saved window state to restore");
+            return Ok(());
+        }
+    };
+
+    // Check if the saved monitor is still available
+    let monitors = window.available_monitors().unwrap_or_default();
+    let saved_monitor_available = saved.monitor_name.as_ref().map_or(false, |name| {
+        monitors.iter().any(|m| m.name().map_or(false, |n| n == name))
+    });
+
+    if !saved_monitor_available {
+        if let Some(ref name) = saved.monitor_name {
+            log_info(&format!(
+                "Saved monitor '{}' not found, falling back to primary monitor",
+                name
+            ));
+        }
+        // Fall back to primary — don't set position, let the OS place it
+        if saved.maximized {
+            let _ = window.maximize();
+        }
+        return Ok(());
+    }
+
+    // Find the target monitor's work area for clamping
+    let target_monitor = monitors.iter().find(|m| {
+        m.name().map_or(false, |n| {
+            Some(n.to_string()) == saved.monitor_name
+        })
+    });
+
+    let (mon_x, mon_y, mon_w, mon_h) = if let Some(m) = target_monitor {
+        let pos = m.position();
+        let size = m.size();
+        (
+            pos.x,
+            pos.y,
+            size.width as i32,
+            size.height as i32,
+        )
+    } else {
+        // Shouldn't reach here since we checked above, but fallback
+        return Ok(());
+    };
+
+    // Clamp position so the window is at least partially visible
+    let w = saved.width as i32;
+    let h = saved.height as i32;
+    let min_visible = 100; // at least 100px must be on screen
+    let x = saved.x.max(mon_x - w + min_visible).min(mon_x + mon_w - min_visible);
+    let y = saved.y.max(mon_y).min(mon_y + mon_h - min_visible);
+
+    log_info(&format!(
+        "Restoring window to ({},{}) {}x{} on monitor {:?}",
+        x, y, saved.width, saved.height, saved.monitor_name
+    ));
+
+    let _ = window.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x, y }));
+    let _ = window.set_size(tauri::Size::Physical(tauri::PhysicalSize {
+        width: saved.width,
+        height: saved.height,
+    }));
+
+    if saved.maximized {
+        let _ = window.maximize();
+    }
+
+    Ok(())
+}
+
 #[allow(deprecated)]
 pub fn save_on_exit(app_handle: &AppHandle, state: &Arc<AppState>) {
     log_info("Saving layout on exit...");
@@ -200,6 +294,7 @@ pub fn save_on_exit(app_handle: &AppHandle, state: &Arc<AppState>) {
     let active_workspace_id = state.active_workspace_id.read().clone();
     let split_views = state.get_all_split_views();
     let layout_trees = state.get_all_layout_trees();
+    let window_state = state.window_state.read().clone();
 
     let layout = Layout {
         workspaces,
@@ -207,6 +302,7 @@ pub fn save_on_exit(app_handle: &AppHandle, state: &Arc<AppState>) {
         active_workspace_id,
         split_views,
         layout_trees,
+        window_state,
     };
 
     match serde_json::to_value(&layout) {
@@ -301,6 +397,7 @@ pub fn save_layout_internal(app_handle: &AppHandle, state: &Arc<AppState>) -> Re
     let active_workspace_id = state.active_workspace_id.read().clone();
     let split_views = state.get_all_split_views();
     let layout_trees = state.get_all_layout_trees();
+    let window_state = state.window_state.read().clone();
 
     let layout = Layout {
         workspaces,
@@ -308,6 +405,7 @@ pub fn save_layout_internal(app_handle: &AppHandle, state: &Arc<AppState>) -> Re
         active_workspace_id,
         split_views,
         layout_trees,
+        window_state,
     };
 
     let json_value = serde_json::to_value(&layout)

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -3,7 +3,7 @@ use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 
 #[allow(deprecated)]
-use super::models::{SessionMetadata, SplitView, Terminal, Workspace};
+use super::models::{SessionMetadata, SplitView, Terminal, WindowState, Workspace};
 
 #[allow(deprecated)]
 pub struct AppState {
@@ -26,6 +26,8 @@ pub struct AppState {
     pub zoomed_panes: RwLock<HashMap<String, String>>,
     /// Workspace ID for MCP-created terminals (Agent workspace in separate window)
     pub mcp_workspace_id: RwLock<Option<String>>,
+    /// Window geometry and monitor for cross-session restoration
+    pub window_state: RwLock<Option<WindowState>>,
 }
 
 #[allow(deprecated)]
@@ -43,6 +45,7 @@ impl AppState {
             layout_trees: RwLock::new(HashMap::new()),
             zoomed_panes: RwLock::new(HashMap::new()),
             mcp_workspace_id: RwLock::new(None),
+            window_state: RwLock::new(None),
         }
     }
 

--- a/src-tauri/src/state/models.rs
+++ b/src-tauri/src/state/models.rs
@@ -140,6 +140,9 @@ pub struct Layout {
     /// Recursive layout trees per workspace (replaces flat split_views).
     #[serde(default)]
     pub layout_trees: HashMap<String, LayoutNode>,
+    /// Window geometry and monitor for cross-session restoration.
+    #[serde(default)]
+    pub window_state: Option<WindowState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,6 +158,17 @@ pub struct TerminalInfo {
     pub worktree_path: Option<String>,
     #[serde(default)]
     pub worktree_branch: Option<String>,
+}
+
+/// Window geometry and monitor identity for cross-session restoration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowState {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub maximized: bool,
+    pub monitor_name: Option<String>,
 }
 
 /// Metadata about a daemon session tracked by the Tauri app (for persistence).
@@ -178,6 +192,7 @@ impl Default for Layout {
             active_workspace_id: None,
             split_views: HashMap::new(),
             layout_trees: HashMap::new(),
+            window_state: None,
         }
     }
 }
@@ -346,6 +361,7 @@ mod tests {
             active_workspace_id: Some("ws-1".to_string()),
             split_views: HashMap::new(),
             layout_trees: HashMap::new(),
+            window_state: None,
         };
 
         let json = serde_json::to_string(&layout).unwrap();
@@ -399,6 +415,7 @@ mod tests {
             active_workspace_id: Some("ws-abc123".to_string()),
             split_views: HashMap::new(),
             layout_trees: HashMap::new(),
+            window_state: None,
         };
 
         // Serialize to JSON (simulates save)
@@ -453,6 +470,7 @@ mod tests {
             active_workspace_id: Some("ws-1".to_string()),
             split_views: HashMap::new(),
             layout_trees: HashMap::new(),
+            window_state: None,
         };
 
         let json = serde_json::to_string(&layout).unwrap();
@@ -621,6 +639,7 @@ mod tests {
             active_workspace_id: Some("ws-1".to_string()),
             split_views,
             layout_trees: HashMap::new(),
+            window_state: None,
         };
 
         let json = serde_json::to_string(&layout).unwrap();
@@ -727,6 +746,7 @@ mod tests {
             active_workspace_id: None,
             split_views: HashMap::new(),
             layout_trees: HashMap::new(),
+            window_state: None,
         };
 
         let json = serde_json::to_string(&layout).unwrap();

--- a/src-tauri/src/window_lifecycle.rs
+++ b/src-tauri/src/window_lifecycle.rs
@@ -9,7 +9,7 @@ use tauri::Emitter;
 
 use crate::daemon_client::DaemonClient;
 use crate::persistence::save_on_exit;
-use crate::state::AppState;
+use crate::state::{AppState, WindowState};
 
 /// Flag to signal that scrollback save is complete.
 static SCROLLBACK_SAVED: AtomicBool = AtomicBool::new(false);
@@ -80,6 +80,9 @@ pub(crate) fn setup_window_close_handler(
                 }
                 drop(terminals);
 
+                // Capture window geometry and current monitor before saving
+                capture_window_state(&window, &state);
+
                 // Save layout and close
                 save_on_exit(&handle, &state);
                 eprintln!("[window_lifecycle] Destroying window...");
@@ -87,4 +90,45 @@ pub(crate) fn setup_window_close_handler(
             });
         }
     });
+}
+
+/// Snapshot the window's position, size, maximized flag, and current monitor name
+/// into `AppState::window_state` so it can be persisted on exit.
+fn capture_window_state(window: &tauri::WebviewWindow, state: &AppState) {
+    let position = match window.outer_position() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("[window_lifecycle] Failed to get window position: {}", e);
+            return;
+        }
+    };
+    let size = match window.outer_size() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[window_lifecycle] Failed to get window size: {}", e);
+            return;
+        }
+    };
+    let maximized = window.is_maximized().unwrap_or(false);
+    let monitor_name = window
+        .current_monitor()
+        .ok()
+        .flatten()
+        .and_then(|m| m.name().map(|n| n.to_string()));
+
+    let ws = WindowState {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+        maximized,
+        monitor_name,
+    };
+
+    eprintln!(
+        "[window_lifecycle] Captured window state: {}x{} at ({},{}) maximized={} monitor={:?}",
+        ws.width, ws.height, ws.x, ws.y, ws.maximized, ws.monitor_name
+    );
+
+    *state.window_state.write() = Some(ws);
 }


### PR DESCRIPTION
Part of #511

## Summary
- Add `WindowState` struct with position, size, maximized, and monitor_name fields
- Capture window geometry and current monitor on close via `capture_window_state()`
- Save/load `window_state` in the `Layout` persistence layer (all 3 save paths updated)
- Add `restore_window_state` Tauri command with monitor validation:
  - Checks if saved monitor is still connected via `available_monitors()`
  - Falls back to primary monitor if saved display is disconnected
  - Clamps position to visible area (100px minimum on-screen) to prevent off-screen restoration
  - Restores maximized state after positioning

## Test plan
- [ ] Close app on primary monitor, reopen — window restores to same position
- [ ] Close app on secondary monitor, reopen with monitor connected — restores to secondary
- [ ] Close app on secondary monitor, unplug monitor, reopen — falls back to primary
- [ ] Close app maximized, reopen — window is maximized on correct monitor
- [ ] Verify backward compat: old layout.json without `window_state` field loads without error