### PR TITLE
feat: concurrent IPC via pending-map (#511)

### DIFF
--- a/changelog/unreleased/511-concurrent-ipc.md
+++ b/changelog/unreleased/511-concurrent-ipc.md
@@ -1,0 +1,2 @@
+### Changed
+- **Concurrent IPC via pending-map** — Daemon client now supports multiple outstanding requests simultaneously using request IDs, eliminating head-of-line blocking for grid snapshot requests (refs #511)

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
 
-use godly_protocol::{DaemonMessage, Event, Request, Response, read_request, write_daemon_message};
+use godly_protocol::{DaemonMessage, Event, Request, Response, read_request_with_id, write_daemon_message, write_daemon_message_with_id};
 
 use crate::debug_log::daemon_log;
 use crate::handlers;
@@ -445,12 +445,14 @@ async fn handle_client(
     let attached_sessions: Arc<RwLock<Vec<String>>> = Arc::new(RwLock::new(Vec::new()));
 
     // Channel: I/O thread -> async handler (incoming requests from client)
-    let (req_tx, mut req_rx) = mpsc::unbounded_channel::<Request>();
+    // Carries (Request, Option<request_id>) for concurrent IPC routing.
+    let (req_tx, mut req_rx) = mpsc::unbounded_channel::<(Request, Option<u32>)>();
 
     // Channel: async handler -> I/O thread (responses only, HIGH PRIORITY)
     // Responses are always written before events to prevent user input from
     // timing out when the terminal is producing heavy output (e.g. Claude CLI).
-    let (resp_tx, resp_rx) = mpsc::unbounded_channel::<DaemonMessage>();
+    // Carries (DaemonMessage, Option<request_id>) for concurrent IPC routing.
+    let (resp_tx, resp_rx) = mpsc::unbounded_channel::<(DaemonMessage, Option<u32>)>();
 
     // Channel: session forwarding tasks -> I/O thread (output events, NORMAL PRIORITY)
     let (event_tx, event_rx) = mpsc::channel::<DaemonMessage>(1024);
@@ -471,7 +473,7 @@ async fn handle_client(
     // Async handler loop: process requests from the I/O thread
     eprintln!("[daemon] Entering request loop for client");
     daemon_log!("Entering request loop for client");
-    while let Some(request) = req_rx.recv().await {
+    while let Some((request, request_id)) = req_rx.recv().await {
         // If the I/O thread has died (pipe closed/broken), stop processing.
         // Without this check, a stuck handler keeps accumulating when the bridge
         // reconnects — each new client's handler blocks on session locks while
@@ -482,7 +484,7 @@ async fn handle_client(
         }
 
         *last_activity.write() = Instant::now();
-        daemon_log!("Received request: {:?}", request);
+        daemon_log!("Received request: {:?} (request_id={:?})", request, request_id);
 
         let response = handle_request(
             &request,
@@ -495,10 +497,9 @@ async fn handle_client(
         daemon_log!("Sending response for {:?}", std::mem::discriminant(&request));
 
         // Send response to the HIGH PRIORITY channel so it's written before events.
-        // Bug fix: previously responses shared a channel with output events, causing
-        // user input to time out during heavy terminal output (e.g. Claude CLI).
+        // Wraps (DaemonMessage, Option<request_id>) so io_thread can echo the ID.
         let msg = DaemonMessage::Response(response);
-        if resp_tx.send(msg).is_err() {
+        if resp_tx.send((msg, request_id)).is_err() {
             daemon_log!("resp_tx send failed, breaking handler loop");
             break;
         }
@@ -547,8 +548,8 @@ const MAX_WRITES_PER_ITERATION: usize = 128;
 /// This prevents user input responses from being delayed by output event floods.
 fn io_thread(
     mut pipe: std::fs::File,
-    req_tx: mpsc::UnboundedSender<Request>,
-    mut resp_rx: mpsc::UnboundedReceiver<DaemonMessage>,
+    req_tx: mpsc::UnboundedSender<(Request, Option<u32>)>,
+    mut resp_rx: mpsc::UnboundedReceiver<(DaemonMessage, Option<u32>)>,
     mut event_rx: mpsc::Receiver<DaemonMessage>,
     io_running: Arc<AtomicBool>,
     server_running: Arc<AtomicBool>,
@@ -574,8 +575,8 @@ fn io_thread(
             PeekResult::Data => {
                 // Read the request from the pipe
                 let read_start = Instant::now();
-                match read_request(&mut pipe) {
-                    Ok(Some(request)) => {
+                match read_request_with_id(&mut pipe) {
+                    Ok(Some((request, request_id))) => {
                         total_reads += 1;
                         let elapsed = read_start.elapsed();
                         if elapsed > Duration::from_millis(50) {
@@ -594,7 +595,7 @@ fn io_thread(
                             Request::Resize { session_id, rows, cols } => {
                                 let response = handlers::resize::handle_raw(&sessions, session_id, *rows, *cols);
                                 let msg = DaemonMessage::Response(response);
-                                if write_daemon_message(&mut pipe, &msg).is_err() {
+                                if write_daemon_message_with_id(&mut pipe, &msg, request_id).is_err() {
                                     daemon_log!("Write error on direct Resize response, stopping");
                                     io_running.store(false, Ordering::Relaxed);
                                     break;
@@ -606,7 +607,7 @@ fn io_thread(
                             Request::PauseSession { session_id } => {
                                 let response = handlers::pause_session::handle_raw(&sessions, session_id);
                                 let msg = DaemonMessage::Response(response);
-                                if write_daemon_message(&mut pipe, &msg).is_err() {
+                                if write_daemon_message_with_id(&mut pipe, &msg, request_id).is_err() {
                                     daemon_log!("Write error on direct PauseSession response, stopping");
                                     io_running.store(false, Ordering::Relaxed);
                                     break;
@@ -618,7 +619,7 @@ fn io_thread(
                             Request::ResumeSession { session_id } => {
                                 let response = handlers::resume_session::handle_raw(&sessions, session_id);
                                 let msg = DaemonMessage::Response(response);
-                                if write_daemon_message(&mut pipe, &msg).is_err() {
+                                if write_daemon_message_with_id(&mut pipe, &msg, request_id).is_err() {
                                     daemon_log!("Write error on direct ResumeSession response, stopping");
                                     io_running.store(false, Ordering::Relaxed);
                                     break;
@@ -629,7 +630,8 @@ fn io_thread(
                             }
                             _ => {
                                 // All other requests go through the async handler
-                                if req_tx.send(request).is_err() {
+                                // Thread request_id alongside the request
+                                if req_tx.send((request, request_id)).is_err() {
                                     eprintln!("[daemon-io] Request channel closed, stopping");
                                     daemon_log!("Request channel closed, stopping");
                                     break;
@@ -668,9 +670,9 @@ fn io_thread(
         // directly in step 1, so this handles only async-handler responses.
         loop {
             match resp_rx.try_recv() {
-                Ok(msg) => {
+                Ok((msg, request_id)) => {
                     let write_start = Instant::now();
-                    if write_daemon_message(&mut pipe, &msg).is_err() {
+                    if write_daemon_message_with_id(&mut pipe, &msg, request_id).is_err() {
                         eprintln!("[daemon-io] Write error on response, stopping");
                         daemon_log!("Write error on response, stopping");
                         io_running.store(false, Ordering::Relaxed);
@@ -903,8 +905,8 @@ mod tests {
         let client_file = client_thread.join().unwrap();
 
         // Set up channels
-        let (req_tx, _req_rx) = mpsc::unbounded_channel::<Request>();
-        let (resp_tx, resp_rx) = mpsc::unbounded_channel::<DaemonMessage>();
+        let (req_tx, _req_rx) = mpsc::unbounded_channel::<(Request, Option<u32>)>();
+        let (resp_tx, resp_rx) = mpsc::unbounded_channel::<(DaemonMessage, Option<u32>)>();
         let (event_tx, event_rx) = mpsc::channel::<DaemonMessage>(1024);
         let io_running = Arc::new(AtomicBool::new(true));
         let server_running = Arc::new(AtomicBool::new(true));
@@ -920,7 +922,7 @@ mod tests {
                 .unwrap();
         }
         resp_tx
-            .send(DaemonMessage::Response(Response::Pong))
+            .send((DaemonMessage::Response(Response::Pong), None))
             .unwrap();
 
         // Run io_thread — it will write to the server side of the pipe

--- a/src-tauri/protocol/src/frame.rs
+++ b/src-tauri/protocol/src/frame.rs
@@ -3,7 +3,10 @@ use std::io;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::binary_diff::{decode_grid_diff, encode_grid_diff_into};
-use crate::messages::{DaemonMessage, Event, Request, Response};
+use crate::messages::{
+    DaemonMessage, DaemonMessageReadEnvelope, DaemonMessageWriteEnvelope, Event, Request,
+    RequestEnvelope, Response,
+};
 
 // ── Binary frame type tags ──────────────────────────────────────────────
 // JSON payloads always start with '{' (0x7B) due to #[serde(tag = ...)].
@@ -121,23 +124,43 @@ pub fn read_message<R: io::Read, T: DeserializeOwned>(reader: &mut R) -> io::Res
 /// - `Event::GridDiff` → binary (tag 0x04) — compact binary diff, ~10x smaller than JSON
 /// - Everything else → JSON
 pub fn write_daemon_message<W: io::Write>(writer: &mut W, msg: &DaemonMessage) -> io::Result<()> {
+    write_daemon_message_with_id(writer, msg, None)
+}
+
+/// Write a DaemonMessage with an optional request_id for concurrent IPC routing.
+///
+/// When `request_id` is `Some`, the JSON envelope includes it so the client
+/// can match responses to requests without relying on FIFO ordering.
+/// Binary frames (Event::Output, Event::GridDiff, legacy Response::Buffer)
+/// never carry request_id.
+pub fn write_daemon_message_with_id<W: io::Write>(
+    writer: &mut W,
+    msg: &DaemonMessage,
+    request_id: Option<u32>,
+) -> io::Result<()> {
     match msg {
         DaemonMessage::Event(Event::Output { session_id, data }) => {
             let frame = encode_binary_frame(TAG_EVENT_OUTPUT, session_id, data);
             write_length_prefixed(writer, &frame)
         }
         DaemonMessage::Event(Event::GridDiff { session_id, diff }) => {
-            // Binary-encode the diff, then wrap in our binary frame format.
             let mut diff_bytes = Vec::new();
             encode_grid_diff_into(diff, &mut diff_bytes);
             let frame = encode_binary_frame(TAG_EVENT_GRID_DIFF, session_id, &diff_bytes);
             write_length_prefixed(writer, &frame)
         }
-        DaemonMessage::Response(Response::Buffer { session_id, data }) => {
+        DaemonMessage::Response(Response::Buffer { session_id, data }) if request_id.is_none() => {
+            // Binary framing for legacy (no request_id) Buffer responses
             let frame = encode_binary_frame(TAG_RESPONSE_BUFFER, session_id, data);
             write_length_prefixed(writer, &frame)
         }
-        _ => write_message(writer, msg),
+        _ => {
+            let envelope = DaemonMessageWriteEnvelope {
+                request_id,
+                message: msg,
+            };
+            write_message(writer, &envelope)
+        }
     }
 }
 
@@ -147,8 +170,15 @@ pub fn write_daemon_message<W: io::Write>(writer: &mut W, msg: &DaemonMessage) -
 /// to the DiffStreamRegistry without deserializing + re-encoding.
 #[derive(Debug)]
 pub enum ReadResult {
-    /// A fully parsed DaemonMessage.
+    /// A fully parsed DaemonMessage (events only — responses use `Response` variant).
     Message(DaemonMessage),
+    /// A response with an optional request_id for concurrent IPC routing.
+    /// All Response-type messages (both JSON and binary) are returned through
+    /// this variant so the bridge can route by request_id.
+    Response {
+        response: Response,
+        request_id: Option<u32>,
+    },
     /// A binary-encoded GridDiff frame. Contains the session_id and raw binary
     /// diff bytes (already in the compact `encode_grid_diff` format) that can
     /// be pushed directly to the diff stream registry.
@@ -181,12 +211,18 @@ pub fn read_daemon_message_ext<R: io::Read>(reader: &mut R) -> io::Result<ReadRe
     }
 
     if buf[0] == 0x7B {
-        // JSON message
-        let msg = serde_json::from_slice(&buf)
+        // JSON message — deserialize via envelope to extract optional request_id
+        let envelope: DaemonMessageReadEnvelope = serde_json::from_slice(&buf)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok(ReadResult::Message(msg))
+        match envelope.message {
+            DaemonMessage::Response(response) => Ok(ReadResult::Response {
+                response,
+                request_id: envelope.request_id,
+            }),
+            other => Ok(ReadResult::Message(other)),
+        }
     } else {
-        // Binary frame
+        // Binary frame (no request_id — legacy path)
         let (tag, session_id, data) = decode_binary_frame(&buf)?;
         match tag {
             TAG_EVENT_OUTPUT => Ok(ReadResult::Message(DaemonMessage::Event(Event::Output {
@@ -200,12 +236,13 @@ pub fn read_daemon_message_ext<R: io::Read>(reader: &mut R) -> io::Result<ReadRe
                     binary_diff: data.to_vec(),
                 })
             }
-            TAG_RESPONSE_BUFFER => Ok(ReadResult::Message(DaemonMessage::Response(
-                Response::Buffer {
+            TAG_RESPONSE_BUFFER => Ok(ReadResult::Response {
+                response: Response::Buffer {
                     session_id: session_id.to_string(),
                     data: data.to_vec(),
                 },
-            ))),
+                request_id: None,
+            }),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Unknown daemon binary frame tag: 0x{:02X}", tag),
@@ -224,6 +261,7 @@ pub fn read_daemon_message_ext<R: io::Read>(reader: &mut R) -> io::Result<ReadRe
 pub fn read_daemon_message<R: io::Read>(reader: &mut R) -> io::Result<Option<DaemonMessage>> {
     match read_daemon_message_ext(reader)? {
         ReadResult::Message(msg) => Ok(Some(msg)),
+        ReadResult::Response { response, .. } => Ok(Some(DaemonMessage::Response(response))),
         ReadResult::RawGridDiff {
             session_id,
             binary_diff,
@@ -249,20 +287,49 @@ pub fn read_daemon_message<R: io::Read>(reader: &mut R) -> io::Result<Option<Dae
 /// - `Request::Write` → binary (tag 0x02)
 /// - Everything else → JSON
 pub fn write_request<W: io::Write>(writer: &mut W, msg: &Request) -> io::Result<()> {
+    write_request_with_id(writer, msg, None)
+}
+
+/// Write a Request with an optional request_id for concurrent IPC routing.
+///
+/// When `request_id` is `Some`, the JSON envelope includes it so the daemon
+/// can echo it back in the response. Binary frames (Request::Write) never
+/// carry request_id since they are fire-and-forget.
+pub fn write_request_with_id<W: io::Write>(
+    writer: &mut W,
+    msg: &Request,
+    request_id: Option<u32>,
+) -> io::Result<()> {
     match msg {
         Request::Write { session_id, data } => {
             let frame = encode_binary_frame(TAG_REQUEST_WRITE, session_id, data);
             write_length_prefixed(writer, &frame)
         }
-        _ => write_message(writer, msg),
+        _ => {
+            let envelope = RequestEnvelope {
+                request_id,
+                request: msg.clone(),
+            };
+            write_message(writer, &envelope)
+        }
     }
 }
 
 /// Read a Request, auto-detecting binary vs JSON by first byte.
 ///
-/// - First byte == 0x7B ('{') → JSON
-/// - First byte is a type tag → binary frame
+/// Backward-compatible: discards the request_id. Use `read_request_with_id`
+/// to receive the request_id for concurrent IPC routing.
 pub fn read_request<R: io::Read>(reader: &mut R) -> io::Result<Option<Request>> {
+    Ok(read_request_with_id(reader)?.map(|(req, _id)| req))
+}
+
+/// Read a Request and its optional request_id for concurrent IPC routing.
+///
+/// - First byte == 0x7B ('{') → JSON (may include request_id)
+/// - First byte is a type tag → binary frame (request_id is always None)
+pub fn read_request_with_id<R: io::Read>(
+    reader: &mut R,
+) -> io::Result<Option<(Request, Option<u32>)>> {
     let buf = match read_length_prefixed(reader)? {
         Some(buf) => buf,
         None => return Ok(None),
@@ -276,18 +343,21 @@ pub fn read_request<R: io::Read>(reader: &mut R) -> io::Result<Option<Request>> 
     }
 
     if buf[0] == 0x7B {
-        // JSON message
-        let msg = serde_json::from_slice(&buf)
+        // JSON message — deserialize as RequestEnvelope to extract optional request_id
+        let envelope: RequestEnvelope = serde_json::from_slice(&buf)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok(Some(msg))
+        Ok(Some((envelope.request, envelope.request_id)))
     } else {
-        // Binary frame
+        // Binary frame — no request_id (fire-and-forget path)
         let (tag, session_id, data) = decode_binary_frame(&buf)?;
         match tag {
-            TAG_REQUEST_WRITE => Ok(Some(Request::Write {
-                session_id: session_id.to_string(),
-                data: data.to_vec(),
-            })),
+            TAG_REQUEST_WRITE => Ok(Some((
+                Request::Write {
+                    session_id: session_id.to_string(),
+                    data: data.to_vec(),
+                },
+                None,
+            ))),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Unknown request binary frame tag: 0x{:02X}", tag),

--- a/src-tauri/protocol/src/lib.rs
+++ b/src-tauri/protocol/src/lib.rs
@@ -8,14 +8,14 @@ pub mod messages;
 pub mod types;
 pub mod whisper;
 
-pub use frame::{read_daemon_message, read_daemon_message_ext, read_message, read_request, write_daemon_message, write_message, write_request, ReadResult};
+pub use frame::{read_daemon_message, read_daemon_message_ext, read_message, read_request, read_request_with_id, write_daemon_message, write_daemon_message_with_id, write_message, write_request, write_request_with_id, ReadResult};
 pub use frame::{
     read_shim_frame, write_shim_binary, write_shim_json, ShimFrame,
     TAG_SHIM_WRITE, TAG_SHIM_BUFFER_DATA, TAG_SHIM_OUTPUT,
 };
 pub use layout_tree::{LayoutNode, SplitDirection};
 pub use mcp_messages::{McpRequest, McpResponse, McpTerminalInfo, McpWorkspaceInfo};
-pub use messages::{DaemonMessage, Event, Request, Response};
+pub use messages::{DaemonMessage, Event, Request, RequestEnvelope, Response};
 pub use messages::{ShimRequest, ShimResponse};
 pub use types::{GridData, SessionInfo, ShellType};
 pub use types::ShimMetadata;

--- a/src-tauri/protocol/src/messages.rs
+++ b/src-tauri/protocol/src/messages.rs
@@ -172,6 +172,40 @@ pub enum DaemonMessage {
     Event(Event),
 }
 
+// ── Wire-format envelopes for concurrent IPC ────────────────────────────
+//
+// These wrapper types carry an optional `request_id` alongside the inner
+// Request/DaemonMessage on the wire. They are used only by the frame layer
+// (frame.rs) for serialization; the rest of the codebase continues to use
+// the plain Request/Response/DaemonMessage types.
+
+/// Wire-format envelope for requests (carries optional request_id for concurrent IPC).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestEnvelope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<u32>,
+    #[serde(flatten)]
+    pub request: Request,
+}
+
+/// Wire-format envelope for serializing DaemonMessage with optional request_id.
+#[derive(Serialize)]
+pub(crate) struct DaemonMessageWriteEnvelope<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<u32>,
+    #[serde(flatten)]
+    pub message: &'a DaemonMessage,
+}
+
+/// Wire-format envelope for deserializing DaemonMessage with optional request_id.
+#[derive(Deserialize)]
+pub(crate) struct DaemonMessageReadEnvelope {
+    #[serde(default)]
+    pub request_id: Option<u32>,
+    #[serde(flatten)]
+    pub message: DaemonMessage,
+}
+
 /// Requests sent from the daemon to a pty-shim process
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -360,5 +394,64 @@ mod tests {
             }
             other => panic!("Expected ShellExited, got {:?}", other),
         }
+    }
+
+    // ── RequestEnvelope tests ───────────────────────────────────────────
+
+    #[test]
+    fn request_envelope_with_id_roundtrip() {
+        let envelope = RequestEnvelope {
+            request_id: Some(42),
+            request: Request::Ping,
+        };
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(json.contains("\"request_id\":42"));
+        assert!(json.contains("\"type\":\"Ping\""));
+        let deserialized: RequestEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.request_id, Some(42));
+        assert!(matches!(deserialized.request, Request::Ping));
+    }
+
+    #[test]
+    fn request_envelope_without_id_backward_compat() {
+        let json = r#"{"type":"Ping"}"#;
+        let deserialized: RequestEnvelope = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.request_id, None);
+        assert!(matches!(deserialized.request, Request::Ping));
+    }
+
+    #[test]
+    fn request_envelope_none_id_omits_field() {
+        let envelope = RequestEnvelope {
+            request_id: None,
+            request: Request::Ping,
+        };
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(!json.contains("request_id"));
+    }
+
+    #[test]
+    fn daemon_message_envelope_response_with_id() {
+        let msg = DaemonMessage::Response(Response::Pong);
+        let envelope = DaemonMessageWriteEnvelope {
+            request_id: Some(7),
+            message: &msg,
+        };
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(json.contains("\"request_id\":7"));
+        assert!(json.contains("\"kind\":\"Response\""));
+        assert!(json.contains("\"type\":\"Pong\""));
+
+        let read_env: DaemonMessageReadEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(read_env.request_id, Some(7));
+        assert!(matches!(read_env.message, DaemonMessage::Response(Response::Pong)));
+    }
+
+    #[test]
+    fn daemon_message_envelope_backward_compat() {
+        let json = r#"{"kind":"Response","type":"Pong"}"#;
+        let read_env: DaemonMessageReadEnvelope = serde_json::from_str(json).unwrap();
+        assert_eq!(read_env.request_id, None);
+        assert!(matches!(read_env.message, DaemonMessage::Response(Response::Pong)));
     }
 }

--- a/src-tauri/src/daemon_client/bridge.rs
+++ b/src-tauri/src/daemon_client/bridge.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tauri::{AppHandle, Emitter};
 
-use godly_protocol::{DaemonMessage, Event, Request, Response, ReadResult, read_daemon_message_ext, write_request};
+use godly_protocol::{DaemonMessage, Event, Request, Response, ReadResult, read_daemon_message_ext, write_request_with_id};
 
 // ── Per-session output stream registry ──────────────────────────────────
 //
@@ -569,6 +569,7 @@ impl WakeEvent {
 /// Fire-and-forget writes set `response_tx = None` to avoid tracking dead channels.
 pub struct BridgeRequest {
     pub request: Request,
+    pub request_id: Option<u32>,
     pub response_tx: Option<std::sync::mpsc::Sender<Response>>,
 }
 
@@ -635,9 +636,13 @@ impl DaemonBridge {
             let raw_handle = get_raw_handle(&reader);
             blog!("Pipe handle={}", raw_handle);
 
-            // FIFO queue of response channels — one per in-flight request.
-            // Responses from the daemon arrive in the same order as requests.
-            let mut pending_responses: VecDeque<std::sync::mpsc::Sender<Response>> =
+            // Pending-map: keyed by request_id for concurrent IPC routing.
+            // When a response arrives with a request_id, the matching sender is
+            // looked up and removed. This eliminates head-of-line blocking.
+            let mut pending_map: HashMap<u32, std::sync::mpsc::Sender<Response>> =
+                HashMap::new();
+            // Legacy FIFO queue for requests without request_id (backward compat).
+            let mut legacy_pending: VecDeque<std::sync::mpsc::Sender<Response>> =
                 VecDeque::new();
 
             // Stats for periodic logging
@@ -672,13 +677,19 @@ impl DaemonBridge {
                         Ok(bridge_req) => {
                             update_phase(&health, PHASE_WRITE);
                             let write_start = Instant::now();
-                            match write_request(&mut writer, &bridge_req.request) {
+                            match write_request_with_id(&mut writer, &bridge_req.request, bridge_req.request_id) {
                                 Ok(()) => {
                                     total_requests_sent += 1;
                                     did_work = true;
 
                                     match bridge_req.response_tx {
-                                        Some(tx) => pending_responses.push_back(tx),
+                                        Some(tx) => {
+                                            if let Some(id) = bridge_req.request_id {
+                                                pending_map.insert(id, tx);
+                                            } else {
+                                                legacy_pending.push_back(tx);
+                                            }
+                                        }
                                         None => orphan_responses += 1,
                                     }
 
@@ -751,11 +762,17 @@ impl DaemonBridge {
                                                 // Keep reading — response hasn't arrived yet
                                                 continue;
                                             }
-                                            Ok(ReadResult::Message(DaemonMessage::Response(response))) => {
+                                            Ok(ReadResult::Response { response, request_id }) => {
                                                 total_responses += 1;
                                                 if orphan_responses > 0 {
                                                     orphan_responses -= 1;
-                                                } else if let Some(tx) = pending_responses.pop_front() {
+                                                } else if let Some(id) = request_id {
+                                                    if let Some(tx) = pending_map.remove(&id) {
+                                                        let _ = tx.send(response);
+                                                    } else {
+                                                        blog!("WARNING: response for unknown request_id={}", id);
+                                                    }
+                                                } else if let Some(tx) = legacy_pending.pop_front() {
                                                     let _ = tx.send(response);
                                                 } else {
                                                     eprintln!("[bridge] Got response but no pending request");
@@ -896,12 +913,18 @@ impl DaemonBridge {
                                         blog!("DROPPED EVENT (channel full, total dropped={})", dropped_events);
                                     }
                                 }
-                                Ok(ReadResult::Message(DaemonMessage::Response(response))) => {
+                                Ok(ReadResult::Response { response, request_id }) => {
                                     total_responses += 1;
                                     did_work = true;
                                     if orphan_responses > 0 {
                                         orphan_responses -= 1;
-                                    } else if let Some(tx) = pending_responses.pop_front() {
+                                    } else if let Some(id) = request_id {
+                                        if let Some(tx) = pending_map.remove(&id) {
+                                            let _ = tx.send(response);
+                                        } else {
+                                            blog!("WARNING: response for unknown request_id={}", id);
+                                        }
+                                    } else if let Some(tx) = legacy_pending.pop_front() {
                                         let _ = tx.send(response);
                                     } else {
                                         eprintln!(

--- a/src-tauri/src/daemon_client/client.rs
+++ b/src-tauri/src/daemon_client/client.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,6 +46,8 @@ pub struct DaemonClient {
     /// Per-session binary-encoded grid diff registry for stream://localhost/terminal-diff/.
     /// Set via `set_diff_registry()` before `setup_bridge()`.
     diff_registry: Mutex<Option<Arc<DiffStreamRegistry>>>,
+    /// Monotonically incrementing counter for concurrent IPC request IDs.
+    next_request_id: AtomicU32,
 }
 
 impl DaemonClient {
@@ -192,6 +195,7 @@ impl DaemonClient {
             wake_event: Mutex::new(None),
             output_registry: Mutex::new(None),
             diff_registry: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         })
     }
 
@@ -584,9 +588,11 @@ impl DaemonClient {
 
         // Create a one-shot channel for this request's response
         let (response_tx, response_rx) = mpsc::channel();
+        let request_id = Some(self.next_request_id.fetch_add(1, AtomicOrdering::Relaxed));
 
         tx.send(BridgeRequest {
             request: request.clone(),
+            request_id,
             response_tx: Some(response_tx),
         })
         .map_err(|e| format!("Failed to send request to bridge: {}", e))?;
@@ -627,6 +633,7 @@ impl DaemonClient {
 
         tx.send(BridgeRequest {
             request: request.clone(),
+            request_id: None,
             response_tx: None,
         })
         .map_err(|e| format!("Failed to send request to bridge: {}", e))?;


### PR DESCRIPTION
Part of #511

## Summary
- Add `request_id: Option<u32>` field to Request/Response protocol messages via wire-format envelope types
- Replace FIFO `VecDeque` with `HashMap<u32, Sender>` pending-map in bridge for concurrent request routing
- Client assigns monotonically incrementing request IDs via `AtomicU32`
- Daemon echoes `request_id` from incoming request into outgoing response
- Backward compatible: `None` request_id falls back to legacy FIFO `VecDeque`
- All existing function signatures preserved (`write_request`, `read_request`, `write_daemon_message`) — new `_with_id` variants added for concurrent IPC callers

## Test plan
- [x] `cargo check` passes for protocol, daemon crates
- [x] `cargo check` for terminal crate compiles Rust code (build script fails on missing sidecar binary — pre-existing, unrelated)
- [x] All 182 protocol tests pass (`cargo nextest run -p godly-protocol`)
- [ ] Manual testing: verify terminal responsiveness under concurrent grid snapshots