### PR TITLE
feat: add agent definitions section to Quick Claude settings tab

### DIFF
--- a/changelog/unreleased/agent-definitions.md
+++ b/changelog/unreleased/agent-definitions.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Agent definitions section** in Quick Claude settings tab — edit built-in agents (Claude Code, Codex) binary path, args, and branch suffix, or create custom agents with full configuration.

--- a/src/components/settings/quick-claude-tab.ts
+++ b/src/components/settings/quick-claude-tab.ts
@@ -7,7 +7,7 @@ import {
   type LaunchStep,
   type LaunchStepType,
 } from '../../state/quick-claude-settings-store';
-import { aiToolsSettingsStore } from '../../state/ai-tools-settings-store';
+import { aiToolsSettingsStore, type AgentDefinition } from '../../state/ai-tools-settings-store';
 import type { SettingsTabProvider, SettingsDialogContext } from './types';
 
 // ── Step type metadata ──────────────────────────────────────────────
@@ -51,6 +51,7 @@ export class QuickClaudeTab implements SettingsTabProvider {
     const renderList = () => {
       editingPresetId = null;
       content.textContent = '';
+      this.renderAgentsSection(content);
       this.renderPresetList(content, (presetId) => {
         editingPresetId = presetId;
         renderEditor();
@@ -68,9 +69,198 @@ export class QuickClaudeTab implements SettingsTabProvider {
     const unsub = quickClaudeSettingsStore.subscribe(() => {
       if (!editingPresetId) renderList();
     });
-    (content as any).__qcUnsub = unsub;
+    const unsub2 = aiToolsSettingsStore.subscribe(() => {
+      if (!editingPresetId) renderList();
+    });
+    (content as any).__qcUnsub = () => { unsub(); unsub2(); };
 
     return content;
+  }
+
+  // ── Agents Section ─────────────────────────────────────────────────
+
+  private renderAgentsSection(container: HTMLElement): void {
+    const section = document.createElement('div');
+    section.className = 'settings-section';
+    section.style.marginBottom = '24px';
+
+    const header = document.createElement('div');
+    header.className = 'flow-list-header';
+
+    const title = document.createElement('div');
+    title.className = 'settings-section-title';
+    title.textContent = 'Agents';
+    title.style.marginBottom = '0';
+    header.appendChild(title);
+
+    const headerActions = document.createElement('div');
+    headerActions.className = 'flow-header-actions';
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'flow-btn flow-btn-primary';
+    addBtn.textContent = 'New Agent';
+    addBtn.addEventListener('click', () => {
+      const id = `custom-${Date.now()}`;
+      aiToolsSettingsStore.addCustomTool({
+        id,
+        name: '',
+        binaryPath: '',
+        launchCommand: '',
+        branchSuffix: '',
+      });
+    });
+    headerActions.appendChild(addBtn);
+    header.appendChild(headerActions);
+    section.appendChild(header);
+
+    const desc = document.createElement('div');
+    desc.className = 'settings-description';
+    desc.textContent = 'Configure AI agents available for Quick Claude presets. Edit built-in agents or add your own custom tools.';
+    section.appendChild(desc);
+
+    const agentsList = document.createElement('div');
+    agentsList.className = 'qc-agents-list';
+
+    const agents = aiToolsSettingsStore.getAllAgentDefinitions();
+
+    for (const agent of agents) {
+      agentsList.appendChild(this.createAgentDefinitionCard(agent));
+    }
+
+    section.appendChild(agentsList);
+    container.appendChild(section);
+  }
+
+  private createAgentDefinitionCard(agent: AgentDefinition): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'qc-agent-def-card';
+
+    // Header row: name + badge + actions
+    const headerRow = document.createElement('div');
+    headerRow.className = 'qc-agent-def-header';
+
+    const nameCol = document.createElement('div');
+    nameCol.className = 'qc-agent-def-name-col';
+
+    if (agent.builtin) {
+      const nameLabel = document.createElement('span');
+      nameLabel.className = 'qc-agent-def-name';
+      nameLabel.textContent = agent.name;
+      nameCol.appendChild(nameLabel);
+
+      const badge = document.createElement('span');
+      badge.className = 'qc-agent-def-badge';
+      badge.textContent = 'Built-in';
+      nameCol.appendChild(badge);
+    } else {
+      const nameInput = document.createElement('input');
+      nameInput.type = 'text';
+      nameInput.className = 'flow-input';
+      nameInput.value = agent.name;
+      nameInput.placeholder = 'Agent name';
+      nameInput.style.fontWeight = '600';
+      nameInput.addEventListener('change', () => {
+        aiToolsSettingsStore.updateCustomTool(agent.id, { name: nameInput.value.trim() });
+      });
+      nameCol.appendChild(nameInput);
+    }
+    headerRow.appendChild(nameCol);
+
+    // Delete button for custom agents
+    if (!agent.builtin) {
+      const delBtn = document.createElement('button');
+      delBtn.className = 'flow-btn flow-btn-icon flow-btn-danger-icon';
+      delBtn.title = 'Remove agent';
+      delBtn.textContent = '\u2715';
+      delBtn.addEventListener('click', () => {
+        aiToolsSettingsStore.removeCustomTool(agent.id);
+      });
+      headerRow.appendChild(delBtn);
+    }
+
+    card.appendChild(headerRow);
+
+    // Fields grid
+    const fields = document.createElement('div');
+    fields.className = 'qc-agent-def-fields';
+
+    // Binary path
+    const binaryRow = this.createAgentDefField(
+      'Binary',
+      agent.binaryPath,
+      agent.builtin ? agent.binaryPath : 'e.g. aider.exe',
+      (val) => {
+        if (agent.builtin) {
+          aiToolsSettingsStore.setBuiltInOverride(agent.id, { binaryPath: val });
+        } else {
+          aiToolsSettingsStore.updateCustomTool(agent.id, { binaryPath: val });
+        }
+      },
+    );
+    fields.appendChild(binaryRow);
+
+    // Args
+    const argsRow = this.createAgentDefField(
+      'Args',
+      agent.args,
+      agent.builtin ? '(default)' : 'e.g. --prompt "{prompt}"',
+      (val) => {
+        if (agent.builtin) {
+          aiToolsSettingsStore.setBuiltInOverride(agent.id, { args: val });
+        } else {
+          aiToolsSettingsStore.updateCustomTool(agent.id, { launchCommand: val });
+        }
+      },
+    );
+    fields.appendChild(argsRow);
+
+    // Branch suffix
+    const suffixRow = this.createAgentDefField(
+      'Branch Suffix',
+      agent.branchSuffix,
+      'e.g. -cc',
+      (val) => {
+        aiToolsSettingsStore.setBranchSuffix(agent.id, val);
+        if (!agent.builtin) {
+          aiToolsSettingsStore.updateCustomTool(agent.id, { branchSuffix: val });
+        }
+      },
+      '100px',
+    );
+    fields.appendChild(suffixRow);
+
+    card.appendChild(fields);
+    return card;
+  }
+
+  private createAgentDefField(
+    label: string,
+    value: string,
+    placeholder: string,
+    onChange: (val: string) => void,
+    width?: string,
+  ): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'qc-agent-def-field';
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'qc-agent-def-field-label';
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'flow-input';
+    input.value = value;
+    input.placeholder = placeholder;
+    if (width) input.style.width = width;
+    else input.style.flex = '1';
+    input.addEventListener('change', () => {
+      onChange(input.value.trim());
+    });
+    row.appendChild(input);
+
+    return row;
   }
 
   // ── List View ─────────────────────────────────────────────────────

--- a/src/state/ai-tools-settings-store.ts
+++ b/src/state/ai-tools-settings-store.ts
@@ -8,15 +8,37 @@ export interface CustomAiTool {
   branchSuffix: string;
 }
 
+/** Overrides for built-in agents (claude, codex). Empty strings = use default. */
+export interface BuiltInOverride {
+  binaryPath: string;
+  args: string;
+}
+
+/** Unified view of any agent (built-in or custom). */
+export interface AgentDefinition {
+  id: string;
+  name: string;
+  builtin: boolean;
+  binaryPath: string;
+  args: string;
+  branchSuffix: string;
+}
+
 export interface AiToolsSettings {
   customTools: CustomAiTool[];
   maxSimultaneous: number;
   branchSuffixes: Record<string, string>;
+  builtInOverrides: Record<string, BuiltInOverride>;
 }
 
 const BUILT_IN_SUFFIXES: Record<string, string> = {
   claude: '-cc',
   codex: '-c',
+};
+
+const BUILT_IN_DEFAULTS: Record<string, { name: string; binaryPath: string; args: string }> = {
+  claude: { name: 'Claude Code', binaryPath: 'claude', args: '' },
+  codex: { name: 'Codex', binaryPath: 'codex', args: '' },
 };
 
 type Subscriber = () => void;
@@ -29,6 +51,7 @@ class AiToolsSettingsStore {
     customTools: [],
     maxSimultaneous: 2,
     branchSuffixes: { ...BUILT_IN_SUFFIXES },
+    builtInOverrides: {},
   };
 
   private subscribers: Subscriber[] = [];
@@ -109,6 +132,77 @@ class AiToolsSettingsStore {
     return options;
   }
 
+  // ── Built-in overrides ──────────────────────────────────────────
+
+  getBuiltInOverride(toolId: string): BuiltInOverride {
+    return this.settings.builtInOverrides[toolId] ?? { binaryPath: '', args: '' };
+  }
+
+  setBuiltInOverride(toolId: string, override: Partial<BuiltInOverride>): void {
+    if (!BUILT_IN_DEFAULTS[toolId]) return;
+    const current = this.settings.builtInOverrides[toolId] ?? { binaryPath: '', args: '' };
+    this.settings.builtInOverrides[toolId] = { ...current, ...override };
+    this.saveToStorage();
+    this.notify();
+  }
+
+  // ── Unified agent definitions ───────────────────────────────────
+
+  /** Returns a unified AgentDefinition for any tool (built-in or custom). */
+  getAgentDefinition(toolId: string): AgentDefinition | undefined {
+    const builtIn = BUILT_IN_DEFAULTS[toolId];
+    if (builtIn) {
+      const override = this.settings.builtInOverrides[toolId];
+      return {
+        id: toolId,
+        name: builtIn.name,
+        builtin: true,
+        binaryPath: override?.binaryPath || builtIn.binaryPath,
+        args: override?.args || builtIn.args,
+        branchSuffix: this.settings.branchSuffixes[toolId] ?? '',
+      };
+    }
+    const custom = this.settings.customTools.find(t => t.id === toolId);
+    if (custom) {
+      return {
+        id: custom.id,
+        name: custom.name,
+        builtin: false,
+        binaryPath: custom.binaryPath,
+        args: custom.launchCommand,
+        branchSuffix: custom.branchSuffix,
+      };
+    }
+    return undefined;
+  }
+
+  /** Returns all agent definitions (built-in + custom), excluding meta-options like 'both'. */
+  getAllAgentDefinitions(): AgentDefinition[] {
+    const agents: AgentDefinition[] = [];
+    for (const [id, defaults] of Object.entries(BUILT_IN_DEFAULTS)) {
+      const override = this.settings.builtInOverrides[id];
+      agents.push({
+        id,
+        name: defaults.name,
+        builtin: true,
+        binaryPath: override?.binaryPath || defaults.binaryPath,
+        args: override?.args || defaults.args,
+        branchSuffix: this.settings.branchSuffixes[id] ?? '',
+      });
+    }
+    for (const tool of this.settings.customTools) {
+      agents.push({
+        id: tool.id,
+        name: tool.name,
+        builtin: false,
+        binaryPath: tool.binaryPath,
+        args: tool.launchCommand,
+        branchSuffix: tool.branchSuffix,
+      });
+    }
+    return agents;
+  }
+
   subscribe(fn: Subscriber): () => void {
     this.subscribers.push(fn);
     return () => {
@@ -145,6 +239,18 @@ class AiToolsSettingsStore {
           ...BUILT_IN_SUFFIXES,
           ...data.branchSuffixes,
         };
+      }
+      if (data.builtInOverrides && typeof data.builtInOverrides === 'object') {
+        const overrides: Record<string, BuiltInOverride> = {};
+        for (const [key, val] of Object.entries(data.builtInOverrides)) {
+          if (val && typeof val === 'object' && typeof (val as any).binaryPath === 'string') {
+            overrides[key] = {
+              binaryPath: (val as BuiltInOverride).binaryPath,
+              args: typeof (val as BuiltInOverride).args === 'string' ? (val as BuiltInOverride).args : '',
+            };
+          }
+        }
+        this.settings.builtInOverrides = overrides;
       }
     } catch {
       // Corrupt data — use defaults

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1085,6 +1085,17 @@ body.dragging-active * {
   text-decoration: line-through;
 }
 
+/* Pinned tab indicator */
+.tab.pinned {
+  border-left: 2px solid var(--accent);
+}
+
+.tab-pin-indicator {
+  font-size: 10px;
+  margin-right: 4px;
+  flex-shrink: 0;
+}
+
 /* Figma tab indicator */
 .tab.figma-tab .tab-title::before {
   content: '\25C6 ';
@@ -3066,4 +3077,69 @@ body.dragging-active * {
   padding: 6px 10px;
   background: var(--bg-tertiary);
   border-radius: 6px;
+}
+
+/* ── Agent Definitions ───────────────────────────────── */
+
+.qc-agents-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.qc-agent-def-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.qc-agent-def-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.qc-agent-def-name-col {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.qc-agent-def-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-active);
+}
+
+.qc-agent-def-badge {
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.qc-agent-def-name-col .flow-input {
+  max-width: 200px;
+}
+
+.qc-agent-def-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.qc-agent-def-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.qc-agent-def-field-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  min-width: 90px;
 }


### PR DESCRIPTION
## Summary

- **New "Agents" section** in the Quick Claude settings tab showing all agents (built-in + custom) with editable configuration
- **Built-in agents** (Claude Code, Codex) now have editable binary path, args, and branch suffix — override defaults or leave blank to use defaults
- **Custom agents** can be created with full configuration (name, binary path, args, branch suffix) and deleted
- Extends `aiToolsSettingsStore` with `builtInOverrides`, `getAgentDefinition()`, and `getAllAgentDefinitions()` APIs

## Test plan

- [x] `tsc --noEmit` — clean TypeScript build
- [x] `pnpm test` — 21 store tests pass + no regressions (1298 passed)
- [ ] Open Settings > Quick Claude — "Agents" section visible above presets
- [ ] Claude Code and Codex cards show with "Built-in" badge, editable binary/args/suffix
- [ ] Click "New Agent" — empty custom card appears, fill in fields and verify persistence
- [ ] Delete a custom agent — card disappears
- [ ] Agent dropdown in preset editor reflects all agents (built-in + custom)