### PR TITLE
feat: pinned tabs (#511)

### DIFF
--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -347,7 +347,13 @@ export class TabBar {
   private render() {
     const state = store.getState();
     const wsId = state.activeWorkspaceId || '';
-    const terminals = store.getWorkspaceTerminals(wsId);
+    const rawTerminals = store.getWorkspaceTerminals(wsId);
+    // Sort pinned tabs first, preserving relative order within each group
+    const terminals = [...rawTerminals].sort((a, b) => {
+      const ap = a.pinned ? 0 : 1;
+      const bp = b.pinned ? 0 : 1;
+      return ap - bp;
+    });
     const items = this.buildRenderItems(terminals, wsId);
 
     const currentIds = items.map(item => item.id);
@@ -440,15 +446,36 @@ export class TabBar {
       }
     }
 
+    // Pinned state
+    const isPinned = !!terminal.pinned;
+    tab.classList.toggle('pinned', isPinned);
+
+    // Pin indicator
+    let pinIndicator = tab.querySelector('.tab-pin-indicator') as HTMLElement | null;
+    if (isPinned && !pinIndicator) {
+      pinIndicator = document.createElement('span');
+      pinIndicator.className = 'tab-pin-indicator';
+      pinIndicator.textContent = '\uD83D\uDCCC'; // 📌
+      tab.insertBefore(pinIndicator, tab.firstChild);
+    } else if (!isPinned && pinIndicator) {
+      pinIndicator.remove();
+    }
+
+    // Hide close button on pinned tabs
+    const closeBtn = tab.querySelector('.tab-close') as HTMLElement | null;
+    if (closeBtn) {
+      closeBtn.style.display = isPinned ? 'none' : '';
+    }
+
     const hasBadge = notificationStore.hasBadge(terminal.id) && !isActive;
     const existingBadge = tab.querySelector('.tab-notification-badge');
     if (hasBadge && !existingBadge) {
       const badge = document.createElement('span');
       badge.className = 'tab-notification-badge';
       // Insert before close button
-      const closeBtn = tab.querySelector('.tab-close');
-      if (closeBtn) {
-        tab.insertBefore(badge, closeBtn);
+      const closeBtnRef = tab.querySelector('.tab-close');
+      if (closeBtnRef) {
+        tab.insertBefore(badge, closeBtnRef);
       } else {
         tab.appendChild(badge);
       }
@@ -471,6 +498,19 @@ export class TabBar {
     }
     tab.dataset.terminalId = terminal.id;
 
+    const isPinned = !!terminal.pinned;
+    if (isPinned) {
+      tab.classList.add('pinned');
+    }
+
+    // Pin indicator (before title)
+    if (isPinned) {
+      const pinIndicator = document.createElement('span');
+      pinIndicator.className = 'tab-pin-indicator';
+      pinIndicator.textContent = '\uD83D\uDCCC'; // 📌
+      tab.appendChild(pinIndicator);
+    }
+
     const displayName = getDisplayName(terminal);
 
     const title = document.createElement('span');
@@ -487,6 +527,9 @@ export class TabBar {
     const closeBtn = document.createElement('span');
     closeBtn.className = 'tab-close';
     closeBtn.textContent = '\u00d7';
+    if (isPinned) {
+      closeBtn.style.display = 'none';
+    }
     closeBtn.onclick = (e) => {
       e.stopPropagation();
       this.handleCloseTab(terminal.id);
@@ -717,6 +760,8 @@ export class TabBar {
 
   private async handleCloseTab(terminalId: string) {
     const terminal = store.getState().terminals.find(t => t.id === terminalId);
+    // Pinned tabs cannot be closed
+    if (terminal?.pinned) return;
     // Figma panes have no daemon session — just remove from store
     if (terminal?.paneType !== 'figma') {
       await terminalService.closeTerminal(terminalId);
@@ -782,6 +827,16 @@ export class TabBar {
       }
     };
     menu.appendChild(renameItem);
+
+    // Pin/Unpin option
+    const pinItem = document.createElement('div');
+    pinItem.className = 'context-menu-item';
+    pinItem.textContent = terminal.pinned ? 'Unpin Tab' : 'Pin Tab';
+    pinItem.onclick = () => {
+      menu.remove();
+      store.togglePinTab(terminal.id);
+    };
+    menu.appendChild(pinItem);
 
     // Split options
     const state = store.getState();
@@ -854,18 +909,21 @@ export class TabBar {
     };
     menu.appendChild(copyInfoItem);
 
-    const separator = document.createElement('div');
-    separator.className = 'context-menu-separator';
-    menu.appendChild(separator);
+    // Only show close option for unpinned tabs
+    if (!terminal.pinned) {
+      const separator = document.createElement('div');
+      separator.className = 'context-menu-separator';
+      menu.appendChild(separator);
 
-    const closeItem = document.createElement('div');
-    closeItem.className = 'context-menu-item danger';
-    closeItem.textContent = 'Close';
-    closeItem.onclick = () => {
-      menu.remove();
-      this.handleCloseTab(terminal.id);
-    };
-    menu.appendChild(closeItem);
+      const closeItem = document.createElement('div');
+      closeItem.className = 'context-menu-item danger';
+      closeItem.textContent = 'Close';
+      closeItem.onclick = () => {
+        menu.remove();
+        this.handleCloseTab(terminal.id);
+      };
+      menu.appendChild(closeItem);
+    }
 
     document.body.appendChild(menu);
 

--- a/src/controllers/keyboard-controller.ts
+++ b/src/controllers/keyboard-controller.ts
@@ -104,6 +104,8 @@ export function setupKeyboardShortcuts(deps: KeyboardDeps): void {
         e.preventDefault();
         if (state.activeTerminalId) {
           const terminal = state.terminals.find(t => t.id === state.activeTerminalId);
+          // Pinned tabs cannot be closed via keyboard shortcut
+          if (terminal?.pinned) break;
           if (terminal?.paneType !== 'figma') {
             await terminalService.closeTerminal(state.activeTerminalId);
           }

--- a/src/state/store-terminal.ts
+++ b/src/state/store-terminal.ts
@@ -75,9 +75,12 @@ export function updateTerminalImpl(store: Store, id: string, updates: Partial<Te
   });
 }
 
-export function removeTerminalImpl(store: Store, id: string): void {
+export function removeTerminalImpl(store: Store, id: string, force = false): void {
   const state = store.getState();
   const terminal = state.terminals.find(t => t.id === id);
+
+  // Pinned tabs cannot be closed unless explicitly forced (unpin first)
+  if (terminal?.pinned && !force) return;
   const remainingTerminals = state.terminals.filter(t => t.id !== id);
 
   let newActiveId = state.activeTerminalId;
@@ -297,4 +300,19 @@ export function reorderTerminalsImpl(store: Store, workspaceId: string, tabOrder
     }),
   });
   store.enforceSplitAdjacency(workspaceId);
+}
+
+export function togglePinTabImpl(store: Store, terminalId: string): void {
+  const state = store.getState();
+  const terminal = state.terminals.find(t => t.id === terminalId);
+  if (!terminal) return;
+
+  const newPinned = !terminal.pinned;
+
+  // Update the pinned state
+  store.setState({
+    terminals: state.terminals.map(t =>
+      t.id === terminalId ? { ...t, pinned: newPinned } : t
+    ),
+  });
 }

--- a/src/state/store.pinned-tabs.test.ts
+++ b/src/state/store.pinned-tabs.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { store, Terminal, Workspace } from './store';
+
+function workspace(id = 'ws-1'): Workspace {
+  return {
+    id,
+    name: 'Test',
+    folderPath: '/tmp',
+    tabOrder: [],
+    shellType: { type: 'windows' },
+    worktreeMode: false,
+    aiToolMode: 'none',
+  };
+}
+
+function terminal(overrides: Partial<Terminal> = {}): Terminal {
+  return {
+    id: 't-1',
+    workspaceId: 'ws-1',
+    name: 'Terminal',
+    processName: 'powershell',
+    order: 0,
+    ...overrides,
+  };
+}
+
+describe('Pinned tabs', () => {
+  beforeEach(() => {
+    store.reset();
+    store.addWorkspace(workspace());
+    store.setActiveWorkspace('ws-1');
+  });
+
+  describe('togglePinTab', () => {
+    it('pins an unpinned tab', () => {
+      store.addTerminal(terminal({ id: 't-1' }));
+
+      store.togglePinTab('t-1');
+
+      const t = store.getState().terminals.find(t => t.id === 't-1');
+      expect(t?.pinned).toBe(true);
+    });
+
+    it('unpins a pinned tab', () => {
+      store.addTerminal(terminal({ id: 't-1', pinned: true }));
+
+      store.togglePinTab('t-1');
+
+      const t = store.getState().terminals.find(t => t.id === 't-1');
+      expect(t?.pinned).toBe(false);
+    });
+
+    it('does nothing for a non-existent terminal', () => {
+      store.addTerminal(terminal({ id: 't-1' }));
+      const before = store.getState().terminals;
+
+      store.togglePinTab('t-nonexistent');
+
+      expect(store.getState().terminals).toEqual(before);
+    });
+  });
+
+  describe('removeTerminal respects pinned status', () => {
+    it('refuses to remove a pinned tab (default)', () => {
+      store.addTerminal(terminal({ id: 't-1', pinned: true }));
+
+      store.removeTerminal('t-1');
+
+      // Terminal should still exist
+      expect(store.getState().terminals).toHaveLength(1);
+      expect(store.getState().terminals[0].id).toBe('t-1');
+    });
+
+    it('removes a pinned tab when force=true', () => {
+      store.addTerminal(terminal({ id: 't-1', pinned: true }));
+
+      store.removeTerminal('t-1', true);
+
+      expect(store.getState().terminals).toHaveLength(0);
+    });
+
+    it('removes an unpinned tab normally', () => {
+      store.addTerminal(terminal({ id: 't-1' }));
+
+      store.removeTerminal('t-1');
+
+      expect(store.getState().terminals).toHaveLength(0);
+    });
+
+    it('removes an explicitly unpinned (pinned=false) tab normally', () => {
+      store.addTerminal(terminal({ id: 't-1', pinned: false }));
+
+      store.removeTerminal('t-1');
+
+      expect(store.getState().terminals).toHaveLength(0);
+    });
+  });
+
+  describe('pinned tabs sort first in getWorkspaceTerminals', () => {
+    it('pinned tabs appear before unpinned tabs', () => {
+      // Add in order: unpinned, pinned, unpinned
+      store.addTerminal(terminal({ id: 't-1', order: 0 }));
+      store.addTerminal(terminal({ id: 't-2', order: 1, pinned: true }), { background: true });
+      store.addTerminal(terminal({ id: 't-3', order: 2 }), { background: true });
+
+      // getWorkspaceTerminals sorts by order — pinned should come first
+      // via the TabBar render sort (store itself just sorts by order)
+      const all = store.getWorkspaceTerminals('ws-1');
+      // Store returns by order, TabBar re-sorts with pinned first
+      // Verify the pinned field is preserved
+      const pinned = all.filter(t => t.pinned);
+      const unpinned = all.filter(t => !t.pinned);
+      expect(pinned).toHaveLength(1);
+      expect(unpinned).toHaveLength(2);
+      expect(pinned[0].id).toBe('t-2');
+    });
+  });
+});

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -19,6 +19,7 @@ import {
   setActiveTerminalImpl,
   moveTerminalToWorkspaceImpl,
   reorderTerminalsImpl,
+  togglePinTabImpl,
 } from './store-terminal';
 import {
   getLayoutTreeImpl,
@@ -54,6 +55,7 @@ export interface Terminal {
   figmaUrl?: string;
   exited?: boolean;
   exitCode?: number;
+  pinned?: boolean;
 }
 
 export type ShellType =
@@ -229,10 +231,11 @@ export class Store {
 
   addTerminal(terminal: Terminal, opts?: { background?: boolean }) { addTerminalImpl(this, terminal, opts); }
   updateTerminal(id: string, updates: Partial<Terminal>) { updateTerminalImpl(this, id, updates); }
-  removeTerminal(id: string) { removeTerminalImpl(this, id); }
+  removeTerminal(id: string, force = false) { removeTerminalImpl(this, id, force); }
   setActiveTerminal(id: string | null) { setActiveTerminalImpl(this, id); }
   moveTerminalToWorkspace(terminalId: string, workspaceId: string) { moveTerminalToWorkspaceImpl(this, terminalId, workspaceId); }
   reorderTerminals(workspaceId: string, tabOrder: string[]) { reorderTerminalsImpl(this, workspaceId, tabOrder); }
+  togglePinTab(terminalId: string) { togglePinTabImpl(this, terminalId); }
 
   // ---------------------------------------------------------------------------
   // Layout tree operations (delegated to store-layout.ts)


### PR DESCRIPTION
Part of #511

## Summary
- Add `pinned` field to Terminal interface
- Pinned tabs sort first, show pin indicator, have no close button
- Context menu pin/unpin toggle
- Protected from close operations (keyboard shortcut, context menu, `removeTerminal`)
- `removeTerminal` accepts `force` param to bypass pin protection when needed
- 8 new unit tests covering pin/unpin, close protection, and force close

## Test plan
- [x] `pnpm test` passes (1306/1307 — 1 pre-existing flaky integration test)
- [ ] CI full build + tests