### PR TITLE
fix: MCP workspace_id resolution for worktree and CWD operations (#511)

### DIFF
--- a/changelog/unreleased/511-mcp-worktree-fix.md
+++ b/changelog/unreleased/511-mcp-worktree-fix.md
@@ -1,0 +1,5 @@
+### Fixed
+- **MCP worktree workspace resolution** — `create_terminal` and `quick_claude` now use the user-supplied `workspace_id` to resolve the folder path for CWD and worktree operations, instead of silently overriding it with the Agent workspace UUID. Fixes misleading "Workspace not found" errors when using worktree parameters (refs #511)
+
+### Changed
+- **MCP tool descriptions** — Fixed inaccurate `create_terminal` description that claimed CWD defaults to home directory (it actually defaults to the workspace's folder path). Clarified `workspace_id` behavior in both `create_terminal` and `quick_claude` tool descriptions

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 22;
+const BUILD: u32 = 23;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -28,7 +28,7 @@ pub fn list_tools() -> Value {
             },
             {
                 "name": "create_terminal",
-                "description": "Create a new terminal in a workspace.\n\nIMPORTANT: New terminals open in the user's home directory by default, NOT in the project directory. Always pass `cwd` with the project path when creating terminals for running project commands (build, test, git, etc.). Omitting `cwd` is the #1 cause of 'command not found' or 'no such file' errors.\n\nIf you use `command` to run something at creation time, verify it succeeded by calling `read_terminal` or `execute_command` afterward — the command output is not returned inline.",
+                "description": "Create a new terminal in a workspace.\n\nThe terminal's working directory defaults to the workspace's folder path (the project directory). Pass `cwd` to override with a specific path, or use `worktree`/`worktree_name` to create a git worktree from the workspace's repo.\n\nThe `workspace_id` determines which workspace's folder path is used for CWD and worktree operations. The terminal is always displayed in the Agent workspace tab.\n\nIf you use `command` to run something at creation time, verify it succeeded by calling `read_terminal` or `execute_command` afterward — the command output is not returned inline.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -38,7 +38,7 @@ pub fn list_tools() -> Value {
                         },
                         "cwd": {
                             "type": "string",
-                            "description": "Working directory for the new terminal. Defaults to user home if omitted — always set this to the project path when running project commands."
+                            "description": "Working directory for the new terminal. Defaults to the workspace's folder path if omitted. Mutually exclusive with worktree/worktree_name."
                         },
                         "worktree_name": {
                             "type": "string",
@@ -566,7 +566,7 @@ pub fn list_tools() -> Value {
             },
             {
                 "name": "quick_claude",
-                "description": "Spawn a new Claude Code session with a prompt. Creates a terminal with a git worktree (skipping fetch by default for speed), starts Claude Code, waits for it to be ready, and writes the prompt — all in background. Returns immediately with the terminal ID. Fire multiple calls in rapid succession for quick idea capture.",
+                "description": "Spawn a new Claude Code session with a prompt. Creates a terminal with a git worktree (skipping fetch by default for speed), starts Claude Code, waits for it to be ready, and writes the prompt — all in background. Returns immediately with the terminal ID. Fire multiple calls in rapid succession for quick idea capture.\n\nThe `workspace_id` determines which workspace's folder path is used as the git repo root for worktree creation. The terminal is displayed in the Agent workspace tab.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -204,7 +204,7 @@ pub fn handle_mcp_request(
         }
 
         McpRequest::CreateTerminal {
-            workspace_id: _original_workspace_id,
+            workspace_id: original_workspace_id,
             shell_type,
             cwd,
             worktree_name,
@@ -214,8 +214,16 @@ pub fn handle_mcp_request(
             use std::collections::HashMap;
             use uuid::Uuid;
 
-            // MCP terminals always go into the Agent workspace (separate window)
-            let workspace_id = &ensure_mcp_workspace(app_state);
+            // MCP terminals are displayed in the Agent workspace (avoids WebView2
+            // broadcast storm — issue #204), but we use the *original* workspace_id
+            // to resolve folder_path for CWD and worktree operations.
+            let agent_workspace_id = ensure_mcp_workspace(app_state);
+
+            // Resolve the source workspace for folder_path: prefer original, fall back to Agent
+            let source_folder = app_state
+                .get_workspace(&original_workspace_id)
+                .or_else(|| app_state.get_workspace(&agent_workspace_id))
+                .map(|ws| ws.folder_path.clone());
 
             let want_worktree = worktree.unwrap_or(false) || worktree_name.is_some();
 
@@ -233,30 +241,32 @@ pub fn handle_mcp_request(
             let mut worktree_branch_result: Option<String> = None;
 
             let working_dir = if want_worktree {
-                // Worktree mode: workspace must exist and be a git repo
-                let ws = match app_state.get_workspace(workspace_id) {
-                    Some(ws) => ws,
+                let folder = match &source_folder {
+                    Some(f) => f.clone(),
                     None => {
                         return McpResponse::Error {
-                            message: format!("Workspace {} not found", workspace_id),
+                            message: format!(
+                                "Workspace '{}' not found and no fallback available",
+                                original_workspace_id
+                            ),
                         };
                     }
                 };
 
-                if !crate::worktree::is_git_repo(&ws.folder_path, None) {
+                if !crate::worktree::is_git_repo(&folder, None) {
                     return McpResponse::Error {
                         message: format!(
                             "Workspace folder is not a git repo: {}",
-                            ws.folder_path
+                            folder
                         ),
                     };
                 }
 
-                let repo_root = match crate::worktree::get_repo_root(&ws.folder_path, None) {
+                let repo_root = match crate::worktree::get_repo_root(&folder, None) {
                     Ok(r) => r,
                     Err(e) => {
                         return McpResponse::Error {
-                            message: format!("Failed to get repo root: {}", e),
+                            message: format!("Failed to get repo root for '{}': {}", folder, e),
                         };
                     }
                 };
@@ -280,10 +290,10 @@ pub fn handle_mcp_request(
             } else if let Some(dir) = cwd {
                 Some(dir.clone())
             } else {
-                app_state
-                    .get_workspace(workspace_id)
-                    .map(|ws| ws.folder_path)
+                source_folder.clone()
             };
+
+            let workspace_id = &agent_workspace_id;
 
             // Determine shell type
             let shell = shell_type
@@ -393,7 +403,7 @@ pub fn handle_mcp_request(
         }
 
         McpRequest::QuickClaude {
-            workspace_id: _original_workspace_id,
+            workspace_id: original_workspace_id,
             prompt,
             branch_name,
             skip_fetch,
@@ -422,8 +432,15 @@ pub fn handle_mcp_request(
                 branch_name.clone()
             };
 
-            // MCP terminals always go into the Agent workspace (separate window)
-            let workspace_id = &ensure_mcp_workspace(app_state);
+            // MCP terminals are displayed in the Agent workspace (avoids WebView2
+            // broadcast storm — issue #204), but we use the *original* workspace_id
+            // to resolve folder_path for worktree operations.
+            let agent_workspace_id = ensure_mcp_workspace(app_state);
+
+            // Resolve the source workspace for folder_path: prefer original, fall back to Agent
+            let source_ws = app_state
+                .get_workspace(&original_workspace_id)
+                .or_else(|| app_state.get_workspace(&agent_workspace_id));
 
             let terminal_id = Uuid::new_v4().to_string();
 
@@ -431,11 +448,14 @@ pub fn handle_mcp_request(
             let mut worktree_branch_result: Option<String> = None;
 
             let working_dir = {
-                let ws = match app_state.get_workspace(workspace_id) {
+                let ws = match source_ws {
                     Some(ws) => ws,
                     None => {
                         return McpResponse::Error {
-                            message: format!("Workspace {} not found", workspace_id),
+                            message: format!(
+                                "Workspace '{}' not found and no fallback available",
+                                original_workspace_id
+                            ),
                         };
                     }
                 };
@@ -478,6 +498,9 @@ pub fn handle_mcp_request(
                     Some(ws.folder_path.clone())
                 }
             };
+
+            // Terminal is displayed in the Agent workspace
+            let workspace_id = &agent_workspace_id;
 
             // Determine shell type
             let shell = app_state


### PR DESCRIPTION
Part of #511

## Summary
- `create_terminal` and `quick_claude` now use the user-supplied `workspace_id` to resolve the folder path for CWD and worktree operations, instead of silently overriding it with the Agent workspace UUID
- Fixes the misleading "Workspace <uuid> not found" error when using worktree parameters — the UUID was the auto-generated Agent workspace, not the user's workspace
- Error messages now show actual folder paths instead of opaque UUIDs  
- Fixed inaccurate tool descriptions: CWD defaults to workspace folder path, not home directory
- Terminals are still displayed in the Agent workspace (preserving the WebView2 fix from issue #204)
- Bumped godly-mcp BUILD to 23

## Root cause
Both `CreateTerminal` and `QuickClaude` handlers renamed the incoming `workspace_id` to `_original_workspace_id` (underscore = ignored) and immediately replaced it with `ensure_mcp_workspace()` — the auto-generated Agent workspace. This meant:
1. Worktree operations used the Agent workspace's `folder_path` (which is just the first workspace's path at startup) instead of the requested workspace's path
2. If the Agent workspace hadn't been created yet, the "not found" error showed the Agent UUID instead of anything meaningful

## Fix
Use the original `workspace_id` to look up `folder_path` for CWD/worktree resolution, falling back to the Agent workspace if the original isn't found. The Agent workspace is still used as the display container for the terminal.

## Test plan
- [x] `cargo check -p godly-mcp` passes
- [x] No Rust compilation errors in handler.rs changes
- [ ] CI full build + tests