### PR TITLE
fix: FPS counter shows 0 in performance overlay

### DIFF
--- a/changelog/unreleased/531-fix-fps-counter.md
+++ b/changelog/unreleased/531-fix-fps-counter.md
@@ -1,0 +1,2 @@
+### Fixed
+- **FPS counter always 0 in performance overlay** — PerfOverlay now runs its own requestAnimationFrame loop to count actual display frames instead of relying on data-driven render events (#531)

--- a/src/components/PerfOverlay.fps-counter.test.ts
+++ b/src/components/PerfOverlay.fps-counter.test.ts
@@ -3,21 +3,26 @@
  * Reproduction tests for bug #531: FPS counter in PerfOverlay always shows 0
  * when idle, and shows artificially low values when typing.
  *
- * Root cause: perfTracer.tick() is only called from TerminalRenderer.render(),
- * which only fires when the daemon pushes new output. The FPS counter has no
- * independent animation frame loop, so it reads 0 whenever no data flows.
+ * Root cause: perfTracer.tick() was only called from TerminalRenderer.render(),
+ * which only fires when the daemon pushes new output. The FPS counter had no
+ * independent animation frame loop, so it read 0 whenever no data flowed.
+ *
+ * Fix: PerfOverlay now runs its own rAF loop that calls perfTracer.tick() on
+ * every animation frame, independent of data-driven renders.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { perfTracer } from '../utils/PerfTracer';
 import { PerfOverlay } from './PerfOverlay';
 
-// Fake timers including performance.now() for deterministic FPS calculation
+// Fake timers including rAF and performance.now() for deterministic FPS
 const FAKE_TIMER_OPTS = {
   toFake: [
     'setTimeout',
     'clearTimeout',
     'setInterval',
     'clearInterval',
+    'requestAnimationFrame',
+    'cancelAnimationFrame',
     'performance',
   ] as const,
 };
@@ -52,68 +57,75 @@ describe('PerfOverlay FPS counter (bug #531)', () => {
    * Bug #531: FPS shows 0 when idle because perfTracer.tick() is never called
    * unless the daemon pushes output triggering TerminalRenderer.render().
    *
-   * Expected: FPS should be non-zero even when no terminal output is flowing,
-   * because the display is still refreshing at the monitor's refresh rate.
+   * With the fix, the PerfOverlay runs its own rAF loop that calls tick()
+   * on every animation frame (~60/sec), so FPS should show ~60 even when idle.
    */
   it('should show non-zero FPS even when no terminal output is flowing', () => {
     overlay.mount(container);
 
-    // Advance 1 second — triggers the PerfOverlay refresh interval
-    // No calls to perfTracer.tick() (terminal is idle)
+    // Advance 1 second — rAF callbacks fire at ~16ms intervals (~60 ticks),
+    // then the 1000ms setInterval triggers refresh() which reads the count.
     vi.advanceTimersByTime(1000);
 
     const fps = readFps();
-    // Bug: FPS = 0 because tick() was never called
-    // Expected: FPS > 0 (display is still refreshing)
+    // With a continuous rAF loop, FPS should reflect display refresh rate
     expect(fps).toBeGreaterThan(0);
   });
 
   /**
-   * Bug #531 (part 2): Even during typing, FPS is artificially low because
-   * tick() counts data-driven renders (gated by IPC latency), not animation
-   * frames. With a 60Hz display, FPS should show ~60, not ~10.
+   * Bug #531 (part 2): FPS should reflect animation frame rate (~60), not
+   * the number of data-driven renders. The rAF loop ticks independently
+   * of terminal output.
    */
   it('should report FPS based on animation frames, not data-driven render count', () => {
     overlay.mount(container);
 
-    // Simulate typing: 10 renders over 1 second (realistic for keystroke echo).
-    // Each keystroke triggers a daemon round-trip → perfTracer.tick().
-    for (let i = 0; i < 10; i++) {
-      perfTracer.tick();
-    }
-
+    // Advance 1 second — rAF loop produces ~60 ticks regardless of output
     vi.advanceTimersByTime(1000);
 
     const fps = readFps();
-    // Bug: FPS = 10 (counts only data-driven renders)
-    // Expected: FPS ~60 (should count actual animation frames, not data events)
+    // Should be close to 60 (rAF fires at ~16ms intervals)
     expect(fps).toBeGreaterThan(30);
   });
 
   /**
-   * Bug #531 (part 3): After a burst of typing followed by idle, FPS drops
-   * immediately to 0. A real FPS counter should show ~60 as long as the
-   * display is refreshing, regardless of data flow.
+   * Bug #531 (part 3): After a burst of typing followed by idle, FPS should
+   * NOT drop to 0. The rAF loop keeps ticking regardless of data flow.
    */
   it('should not drop to 0 FPS after terminal output stops', () => {
     overlay.mount(container);
 
-    // First second: some terminal output (30 renders)
-    for (let i = 0; i < 30; i++) {
-      perfTracer.tick();
-    }
+    // First second: rAF loop ticking
     vi.advanceTimersByTime(1000);
 
-    // Verify first interval had non-zero FPS
-    const fpsAfterOutput = readFps();
-    expect(fpsAfterOutput).toBeGreaterThan(0);
+    const fpsFirstSecond = readFps();
+    expect(fpsFirstSecond).toBeGreaterThan(0);
 
-    // Second second: terminal goes idle (no tick calls)
+    // Second second: still ticking (rAF loop is independent of data)
     vi.advanceTimersByTime(1000);
 
-    const fpsAfterIdle = readFps();
-    // Bug: FPS drops to 0 because no tick() calls in the second interval
-    // Expected: FPS > 0 (display is still refreshing)
-    expect(fpsAfterIdle).toBeGreaterThan(0);
+    const fpsSecondSecond = readFps();
+    // Should still be non-zero — rAF loop doesn't stop when data stops
+    expect(fpsSecondSecond).toBeGreaterThan(0);
+  });
+
+  /**
+   * The rAF loop must stop when the overlay is destroyed to avoid leaking
+   * animation frame callbacks.
+   */
+  it('should stop the rAF loop when destroyed', () => {
+    overlay.mount(container);
+    vi.advanceTimersByTime(500);
+
+    const countBefore = perfTracer.getFrameCount();
+    expect(countBefore).toBeGreaterThan(0);
+
+    overlay.destroy();
+
+    // Advance more time — no more ticks should accumulate
+    const countAfterDestroy = perfTracer.getFrameCount();
+    vi.advanceTimersByTime(500);
+    const countLater = perfTracer.getFrameCount();
+    expect(countLater).toBe(countAfterDestroy);
   });
 });

--- a/src/components/PerfOverlay.ts
+++ b/src/components/PerfOverlay.ts
@@ -37,6 +37,7 @@ export class PerfOverlay {
   private tableBody: HTMLElement;
   private fpsLine: HTMLElement;
   private interval: ReturnType<typeof setInterval> | null = null;
+  private rafId: ReturnType<typeof requestAnimationFrame> | null = null;
   private lastTickTime = performance.now();
   private lastFrameCount = 0;
 
@@ -89,16 +90,30 @@ export class PerfOverlay {
     parent.appendChild(this.el);
     this.lastTickTime = performance.now();
     this.lastFrameCount = perfTracer.getFrameCount();
+    this.startFrameCounter();
     this.interval = setInterval(() => this.refresh(), 1000);
     this.refresh();
   }
 
   destroy(): void {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
     if (this.interval) {
       clearInterval(this.interval);
       this.interval = null;
     }
     this.el.remove();
+  }
+
+  /** Continuous rAF loop that counts actual animation frames for FPS. */
+  private startFrameCounter(): void {
+    const loop = () => {
+      perfTracer.tick();
+      this.rafId = requestAnimationFrame(loop);
+    };
+    this.rafId = requestAnimationFrame(loop);
   }
 
   private refresh(): void {

--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -283,7 +283,6 @@ export class TerminalRenderer {
           this.paintOverlay();
           perfTracer.measure('paint_duration', 'paint_start');
           perfTracer.measure('keydown_to_paint', 'keydown');
-          perfTracer.tick();
         }
       });
     }


### PR DESCRIPTION
## Summary

- **FPS counter in PerfOverlay (Ctrl+Shift+P) always showed 0** when the terminal was idle, and showed artificially low values (~10) when typing
- Root cause: `perfTracer.tick()` was only called from `TerminalRenderer.render()`, which only fires on data-driven events (daemon pushes output). No independent frame counting loop existed.
- Fix: PerfOverlay now runs its own `requestAnimationFrame` loop that calls `tick()` on every animation frame (~60/sec), independent of terminal data flow. The rAF loop starts on `mount()` and stops on `destroy()`.
- Removed misplaced `perfTracer.tick()` from `TerminalRenderer` since FPS counting is now owned by PerfOverlay.

## Test plan
- [x] New unit test suite (`PerfOverlay.fps-counter.test.ts`) with 4 tests:
  - FPS > 0 when idle (no terminal output)
  - FPS > 30 (measures animation frames, not data-driven renders)
  - FPS stays > 0 after terminal output stops
  - rAF loop stops when overlay is destroyed (no leak)
- [x] Existing PerfTracer tests pass (12/12)
- [x] Full unit test suite passes (1268/1269 — 1 pre-existing flaky failure in terminal-service reconnect)

fixes #531