### PR TITLE
fix: use fire-and-forget for MCP write_to_terminal to prevent timeout

### DIFF
--- a/changelog/unreleased/534-fix-mcp-write-timeout.md
+++ b/changelog/unreleased/534-fix-mcp-write-timeout.md
@@ -1,0 +1,2 @@
+### Fixed
+- **MCP write_to_terminal timeout under load** — switched MCP handler from blocking `send_request()` to `send_fire_and_forget()` for write operations, preventing 15-second timeouts when the bridge I/O thread is congested (#534)

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 23;
+const BUILD: u32 = 24;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -354,7 +354,9 @@ pub fn handle_mcp_request(
                     session_id: terminal_id.clone(),
                     data: format!("{}\r", cmd).into_bytes(),
                 };
-                let _ = daemon.send_request(&write_req);
+                // Fire-and-forget: response is ignored anyway, and blocking
+                // here risks the same 15s timeout under bridge congestion.
+                let _ = daemon.send_fire_and_forget(&write_req);
             }
 
             // Store metadata
@@ -1114,14 +1116,13 @@ pub fn handle_mcp_request(
                 session_id: terminal_id.clone(),
                 data: converted.as_bytes().to_vec(),
             };
-            match daemon.send_request(&request) {
-                Ok(godly_protocol::Response::Ok) => McpResponse::Ok,
-                Ok(godly_protocol::Response::Error { message }) => {
-                    McpResponse::Error { message }
-                }
-                Ok(other) => McpResponse::Error {
-                    message: format!("Unexpected response: {:?}", other),
-                },
+            // Fire-and-forget: don't block the MCP handler waiting for the
+            // daemon's Ok response. Blocking here caused 15s timeouts under
+            // load because the bridge I/O thread is congested with output
+            // from multiple terminals. Matches the Tauri command handler
+            // pattern in commands/terminal.rs.
+            match daemon.send_fire_and_forget(&request) {
+                Ok(()) => McpResponse::Ok,
                 Err(e) => McpResponse::Error { message: e },
             }
         }


### PR DESCRIPTION
## Summary

Fixes #534

- **MCP `WriteToTerminal` handler** -- changed from blocking `send_request()` to `send_fire_and_forget()`, preventing 15-second timeouts when the bridge I/O thread is congested under load (multiple terminals producing output)
- **MCP `create_terminal` command execution** -- same fix for the initial command write after terminal creation, which also used `send_request()` but ignored the response
- **godly-mcp BUILD bump** -- incremented from 23 to 24 so logs confirm the fix is deployed

## Root Cause

The MCP handler used `daemon.send_request()` for write operations, which goes through the bridge I/O thread with a 15-second timeout. Under load (multiple terminals producing output), the bridge becomes congested and the timeout is hit. The Tauri command handler (`commands/terminal.rs`) already uses `send_fire_and_forget()` for the same operation -- this PR aligns the MCP handler to the same pattern.

## Test plan

- [ ] `cargo check -p godly-mcp` passes (verified locally)
- [ ] CI passes full build and test suite
- [ ] MCP `execute_command` / `write_to_terminal` no longer times out when multiple terminals are active