### PR TITLE
fix: prevent MCP duplicate command execution and auto-cleanup worktrees

### DIFF
--- a/changelog/unreleased/534-fix-mcp-command-dup-worktree-cleanup.md
+++ b/changelog/unreleased/534-fix-mcp-command-dup-worktree-cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+- **MCP create_terminal duplicate command execution** — command is now written after waiting for the shell prompt to be ready, preventing the race condition where the command appeared to run twice (#534)
+- **MCP worktree cleanup on terminal close** — closing a terminal that was created with a worktree now automatically removes the worktree in a background thread, preventing disk space accumulation (#534)

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -706,7 +706,7 @@ fn quick_codex_background(
 }
 
 /// Poll until the terminal has been idle for `idle_ms` milliseconds, or timeout.
-fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, timeout_ms: u64) -> bool {
+pub(crate) fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, timeout_ms: u64) -> bool {
     let deadline =
         std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
     let poll_interval = (idle_ms / 4).min(500).max(50);

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -76,6 +76,74 @@ fn auto_focus_terminal(
     let _ = app_handle.emit("focus-terminal", terminal_id.to_string());
 }
 
+/// Clean up a git worktree by its path.
+///
+/// Derives the main repo root from within the worktree (via `--git-common-dir`),
+/// then runs `git worktree remove --force`. Falls back to deleting the directory
+/// directly if the git command fails (e.g., corrupt `.git` file).
+fn cleanup_worktree(wt_path: &str) {
+    use std::path::Path;
+    use std::process::Command;
+
+    #[cfg(windows)]
+    use std::os::windows::process::CommandExt;
+    #[cfg(windows)]
+    use winapi::um::winbase::CREATE_NO_WINDOW;
+
+    eprintln!("[mcp] Cleaning up worktree: {}", wt_path);
+
+    if !Path::new(wt_path).is_dir() {
+        eprintln!("[mcp] Worktree directory already gone: {}", wt_path);
+        return;
+    }
+
+    // Derive the main repo root from the worktree's git common dir.
+    // Inside a worktree, `git rev-parse --path-format=absolute --git-common-dir`
+    // returns e.g. `C:\Users\...\main-repo\.git` — the parent is the repo root.
+    let repo_root = {
+        let mut cmd = Command::new("git");
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd.args(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+        cmd.current_dir(wt_path);
+        match cmd.output() {
+            Ok(output) if output.status.success() => {
+                let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                // Parent of `.git` dir is the repo root
+                Path::new(&git_dir)
+                    .parent()
+                    .map(|p| p.to_string_lossy().to_string())
+            }
+            _ => None,
+        }
+    };
+
+    // Try `git worktree remove --force` from the main repo root
+    if let Some(ref root) = repo_root {
+        let wsl = crate::worktree::WslConfig::from_path(wt_path);
+        match crate::worktree::remove_worktree(root, wt_path, true, wsl.as_ref()) {
+            Ok(()) => {
+                eprintln!("[mcp] Worktree removed successfully: {}", wt_path);
+                return;
+            }
+            Err(e) => {
+                eprintln!("[mcp] git worktree remove failed: {} — falling back to rm", e);
+            }
+        }
+    } else {
+        eprintln!(
+            "[mcp] Could not determine repo root for worktree: {} — falling back to rm",
+            wt_path
+        );
+    }
+
+    // Fallback: delete the directory directly
+    match std::fs::remove_dir_all(wt_path) {
+        Ok(()) => eprintln!("[mcp] Worktree directory deleted: {}", wt_path),
+        Err(e) => eprintln!("[mcp] Failed to delete worktree directory: {}", e),
+    }
+}
+
 /// Execute a JavaScript snippet in the main webview via the JS callback bridge.
 /// Returns McpResponse::Ok on success (the JS result is logged but not returned
 /// as structured data — these tools are fire-and-forget commands).
@@ -348,13 +416,35 @@ pub fn handle_mcp_request(
                 _ => {}
             }
 
-            // Run command if specified
+            // Run command if specified — in a background thread that waits for
+            // the shell prompt to be ready first. Writing immediately after
+            // CreateSession causes a race: the command text arrives before the
+            // shell has finished initialising, so the shell echoes it back during
+            // startup and then executes it again once the prompt appears, making
+            // the command appear to run twice. (Bug #534)
             if let Some(ref cmd) = command {
-                let write_req = godly_protocol::Request::Write {
-                    session_id: terminal_id.clone(),
-                    data: format!("{}\r", cmd).into_bytes(),
-                };
-                let _ = daemon.send_request(&write_req);
+                let daemon_bg = daemon.clone();
+                let terminal_id_bg = terminal_id.clone();
+                let cmd_bg = cmd.clone();
+                std::thread::spawn(move || {
+                    // Wait for the shell to become idle (prompt ready)
+                    let ready = crate::commands::terminal::poll_idle(
+                        &daemon_bg,
+                        &terminal_id_bg,
+                        500,  // idle_ms: 500ms of silence = prompt ready
+                        5_000, // timeout_ms: give up after 5s
+                    );
+                    if !ready {
+                        eprintln!(
+                            "[mcp] Shell did not become idle in time for command, writing anyway"
+                        );
+                    }
+                    let write_req = godly_protocol::Request::Write {
+                        session_id: terminal_id_bg,
+                        data: format!("{}\r", cmd_bg).into_bytes(),
+                    };
+                    let _ = daemon_bg.send_request(&write_req);
+                });
             }
 
             // Store metadata
@@ -629,6 +719,20 @@ pub fn handle_mcp_request(
                     eprintln!("[mcp] Warning: close session error: {}", message);
                 }
                 _ => {}
+            }
+
+            // Read session metadata before removing — if it has a worktree,
+            // clean it up in a background thread. (Bug #534)
+            let worktree_path = {
+                let meta = app_state.session_metadata.read();
+                meta.get(terminal_id).and_then(|m| m.worktree_path.clone())
+            };
+
+            if let Some(wt_path) = worktree_path {
+                let wt_path_clone = wt_path.clone();
+                std::thread::spawn(move || {
+                    cleanup_worktree(&wt_path_clone);
+                });
             }
 
             app_state.remove_session_metadata(terminal_id);


### PR DESCRIPTION
## Summary

Fixes two MCP handler bugs from issue #534:

- **Duplicate command execution (Bug 7)**: `create_terminal` with a `command` parameter wrote the command immediately after session creation, before the shell prompt was ready. The command text arrived during shell startup, got echoed back, and then executed again once the prompt appeared. Now uses `poll_idle` (same pattern as `quick_claude_background`) to wait for shell readiness before writing.

- **Worktree cleanup (Bug 8)**: `CloseTerminal` removed session metadata without checking for an associated worktree, causing worktrees to accumulate on disk (46+ orphaned worktrees reported). Now reads `worktree_path` from session metadata before removing it, and spawns a background cleanup thread that derives the main repo root via `git rev-parse --git-common-dir` and runs `git worktree remove --force`, with a fallback to directory deletion.

## Changes

- `src-tauri/src/commands/terminal.rs`: Made `poll_idle` `pub(crate)` so MCP handler can reuse it
- `src-tauri/src/mcp_server/handler.rs`:
  - Added `cleanup_worktree()` helper that derives repo root from worktree path and removes it
  - `CreateTerminal`: Moved command write to background thread with `poll_idle` wait
  - `CloseTerminal`: Added worktree cleanup before metadata removal

## Test plan

- [ ] Create a terminal with `command` parameter via MCP -- command should execute exactly once
- [ ] Create a terminal with `worktree` parameter, then close it -- worktree directory should be removed
- [ ] Quick Claude flow still works (unchanged, uses same `poll_idle` pattern)
- [ ] CloseTerminal without worktree still works (no-op cleanup path)

refs #534