### PR TITLE
feat: make MCP auto-focus opt-in (default off)

### DIFF
--- a/changelog/unreleased/534-mcp-disable-autofocus.md
+++ b/changelog/unreleased/534-mcp-disable-autofocus.md
@@ -1,0 +1,2 @@
+### Changed
+- **MCP auto-focus disabled by default** — MCP tools (`write_to_terminal`, `execute_command`, `send_keys`, `erase_content`, `create_terminal`) no longer auto-focus the terminal in the UI. Pass `focus: true` to opt in. (#534)

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -179,6 +179,7 @@ impl Backend for DaemonDirectBackend {
                 worktree_name,
                 worktree,
                 command,
+                focus: _,
             } => {
                 // Worktree support requires git operations from the Tauri app
                 if worktree.unwrap_or(false) || worktree_name.is_some() {
@@ -253,7 +254,7 @@ impl Backend for DaemonDirectBackend {
                 }
             }
 
-            McpRequest::WriteToTerminal { terminal_id, data } => {
+            McpRequest::WriteToTerminal { terminal_id, data, focus: _ } => {
                 // Convert \n → \r for PTY (same as handler.rs)
                 let converted = data.replace("\r\n", "\r").replace('\n', "\r");
                 let resp = self.daemon_request(&Request::Write {
@@ -443,7 +444,7 @@ impl Backend for DaemonDirectBackend {
                 }
             }
 
-            McpRequest::SendKeys { terminal_id, keys } => {
+            McpRequest::SendKeys { terminal_id, keys, focus: _ } => {
                 // Convert each key name to bytes and concatenate
                 let mut all_bytes = Vec::new();
                 for key in keys {
@@ -465,7 +466,7 @@ impl Backend for DaemonDirectBackend {
                 }
             }
 
-            McpRequest::EraseContent { terminal_id, count } => {
+            McpRequest::EraseContent { terminal_id, count, focus: _ } => {
                 let backspaces = vec![0x08u8; *count];
                 let resp = self.daemon_request(&Request::Write {
                     session_id: terminal_id.clone(),
@@ -485,6 +486,7 @@ impl Backend for DaemonDirectBackend {
                 command,
                 idle_ms,
                 timeout_ms,
+                focus: _,
             } => {
                 // 1. Snapshot buffer length before command
                 let before_len = match self.daemon_request(&Request::ReadBuffer {

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 24;
+const BUILD: u32 = 25;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -51,6 +51,10 @@ pub fn list_tools() -> Value {
                         "command": {
                             "type": "string",
                             "description": "A command to run in the terminal immediately after creation. A newline (Enter) is appended automatically."
+                        },
+                        "focus": {
+                            "type": "boolean",
+                            "description": "Whether to auto-focus the new terminal in the UI. Default: false."
                         }
                     },
                     "required": ["workspace_id"]
@@ -235,6 +239,10 @@ pub fn list_tools() -> Value {
                         "data": {
                             "type": "string",
                             "description": "Text to send to the terminal. Newlines (\\n) are converted to Enter (CR)."
+                        },
+                        "focus": {
+                            "type": "boolean",
+                            "description": "Whether to auto-focus the terminal in the UI. Default: false."
                         }
                     },
                     "required": ["terminal_id", "data"]
@@ -512,6 +520,10 @@ pub fn list_tools() -> Value {
                             "type": "array",
                             "items": { "type": "string" },
                             "description": "Array of key names to send in sequence. Examples: [\"ctrl+c\"], [\"up\", \"enter\"], [\"tab\"]"
+                        },
+                        "focus": {
+                            "type": "boolean",
+                            "description": "Whether to auto-focus the terminal in the UI. Default: false."
                         }
                     },
                     "required": ["terminal_id", "keys"]
@@ -531,6 +543,10 @@ pub fn list_tools() -> Value {
                             "type": "number",
                             "default": 1,
                             "description": "Number of characters to erase (backspaces to send). Default: 1."
+                        },
+                        "focus": {
+                            "type": "boolean",
+                            "description": "Whether to auto-focus the terminal in the UI. Default: false."
                         }
                     },
                     "required": ["terminal_id"]
@@ -559,6 +575,10 @@ pub fn list_tools() -> Value {
                             "type": "number",
                             "default": 30000,
                             "description": "Maximum time to wait in milliseconds (default: 30000)"
+                        },
+                        "focus": {
+                            "type": "boolean",
+                            "description": "Whether to auto-focus the terminal in the UI. Default: false."
                         }
                     },
                     "required": ["terminal_id", "command"]
@@ -1339,6 +1359,7 @@ pub fn call_tool(
                 .map(String::from);
             let worktree = args.get("worktree").and_then(|v| v.as_bool());
             let command = args.get("command").and_then(|v| v.as_str()).map(String::from);
+            let focus = args.get("focus").and_then(|v| v.as_bool());
             McpRequest::CreateTerminal {
                 workspace_id,
                 shell_type: None,
@@ -1346,6 +1367,7 @@ pub fn call_tool(
                 worktree_name,
                 worktree,
                 command,
+                focus,
             }
         }
 
@@ -1480,7 +1502,8 @@ pub fn call_tool(
                 .and_then(|v| v.as_str())
                 .ok_or("Missing data")?;
             let data = convert_newlines_to_cr(raw_data);
-            McpRequest::WriteToTerminal { terminal_id, data }
+            let focus = args.get("focus").and_then(|v| v.as_bool());
+            McpRequest::WriteToTerminal { terminal_id, data, focus }
         }
 
         "read_terminal" => {
@@ -1694,7 +1717,8 @@ pub fn call_tool(
             if keys.is_empty() {
                 return Err("keys array must not be empty".to_string());
             }
-            McpRequest::SendKeys { terminal_id, keys }
+            let focus = args.get("focus").and_then(|v| v.as_bool());
+            McpRequest::SendKeys { terminal_id, keys, focus }
         }
 
         "erase_content" => {
@@ -1708,7 +1732,8 @@ pub fn call_tool(
                 .and_then(|v| v.as_u64())
                 .map(|n| n as usize)
                 .unwrap_or(1);
-            McpRequest::EraseContent { terminal_id, count }
+            let focus = args.get("focus").and_then(|v| v.as_bool());
+            McpRequest::EraseContent { terminal_id, count, focus }
         }
 
         "execute_command" => {
@@ -1730,11 +1755,13 @@ pub fn call_tool(
                 .get("timeout_ms")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(30000);
+            let focus = args.get("focus").and_then(|v| v.as_bool());
             McpRequest::ExecuteCommand {
                 terminal_id,
                 command,
                 idle_ms,
                 timeout_ms,
+                focus,
             }
         }
 

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -50,6 +50,8 @@ pub enum McpRequest {
         worktree: Option<bool>,
         #[serde(default)]
         command: Option<String>,
+        #[serde(default)]
+        focus: Option<bool>,
     },
     CloseTerminal { terminal_id: String },
     RenameTerminal { terminal_id: String, name: String },
@@ -75,7 +77,12 @@ pub enum McpRequest {
     GetWorkspaceModes { workspace_id: String },
 
     // Terminal I/O
-    WriteToTerminal { terminal_id: String, data: String },
+    WriteToTerminal {
+        terminal_id: String,
+        data: String,
+        #[serde(default)]
+        focus: Option<bool>,
+    },
     ReadTerminal {
         terminal_id: String,
         #[serde(default)]
@@ -122,11 +129,15 @@ pub enum McpRequest {
     SendKeys {
         terminal_id: String,
         keys: Vec<String>,
+        #[serde(default)]
+        focus: Option<bool>,
     },
     EraseContent {
         terminal_id: String,
         #[serde(default = "default_erase_count")]
         count: usize,
+        #[serde(default)]
+        focus: Option<bool>,
     },
     ExecuteCommand {
         terminal_id: String,
@@ -135,6 +146,8 @@ pub enum McpRequest {
         idle_ms: u64,
         #[serde(default = "default_timeout_ms")]
         timeout_ms: u64,
+        #[serde(default)]
+        focus: Option<bool>,
     },
 
     // Split view control (legacy — prefer layout tree commands below)

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -278,6 +278,7 @@ pub fn handle_mcp_request(
             worktree_name,
             worktree,
             command,
+            focus,
         } => {
             use std::collections::HashMap;
             use uuid::Uuid;
@@ -484,8 +485,10 @@ pub fn handle_mcp_request(
                 },
             );
 
-            // Auto-focus the new terminal so the user sees it
-            auto_focus_terminal(&terminal_id, app_state, app_handle);
+            // Auto-focus only if explicitly requested (default: false)
+            if focus.unwrap_or(false) {
+                auto_focus_terminal(&terminal_id, app_state, app_handle);
+            }
 
             McpResponse::Created {
                 id: terminal_id,
@@ -1203,9 +1206,10 @@ pub fn handle_mcp_request(
             }
         }
 
-        McpRequest::WriteToTerminal { terminal_id, data } => {
-            // Auto-focus so the user sees the terminal being typed into
-            auto_focus_terminal(terminal_id, app_state, app_handle);
+        McpRequest::WriteToTerminal { terminal_id, data, focus } => {
+            if focus.unwrap_or(false) {
+                auto_focus_terminal(terminal_id, app_state, app_handle);
+            }
 
             // Convert newlines → \r for PTY: terminals expect CR (Enter), not LF.
             // Also handle literal escape sequences (\\n, \\r\\n) since LLMs often
@@ -1381,7 +1385,7 @@ pub fn handle_mcp_request(
             }
         }
 
-        McpRequest::SendKeys { terminal_id, keys } => {
+        McpRequest::SendKeys { terminal_id, keys, focus } => {
             // Validate terminal exists
             if !app_state.terminals.read().contains_key(terminal_id) {
                 return McpResponse::Error {
@@ -1389,8 +1393,9 @@ pub fn handle_mcp_request(
                 };
             }
 
-            // Auto-focus so the user sees the keystrokes
-            auto_focus_terminal(terminal_id, app_state, app_handle);
+            if focus.unwrap_or(false) {
+                auto_focus_terminal(terminal_id, app_state, app_handle);
+            }
 
             // Convert each key name to bytes and concatenate
             let mut all_bytes = Vec::new();
@@ -1416,7 +1421,7 @@ pub fn handle_mcp_request(
             }
         }
 
-        McpRequest::EraseContent { terminal_id, count } => {
+        McpRequest::EraseContent { terminal_id, count, focus } => {
             // Validate terminal exists
             if !app_state.terminals.read().contains_key(terminal_id) {
                 return McpResponse::Error {
@@ -1424,8 +1429,9 @@ pub fn handle_mcp_request(
                 };
             }
 
-            // Auto-focus so the user sees the erasure
-            auto_focus_terminal(terminal_id, app_state, app_handle);
+            if focus.unwrap_or(false) {
+                auto_focus_terminal(terminal_id, app_state, app_handle);
+            }
 
             let backspaces = vec![0x08u8; *count];
             let request = godly_protocol::Request::Write {
@@ -1449,6 +1455,7 @@ pub fn handle_mcp_request(
             command,
             idle_ms,
             timeout_ms,
+            focus,
         } => {
             // Validate terminal exists
             if !app_state.terminals.read().contains_key(terminal_id) {
@@ -1457,8 +1464,9 @@ pub fn handle_mcp_request(
                 };
             }
 
-            // Auto-focus so the user sees the command executing
-            auto_focus_terminal(terminal_id, app_state, app_handle);
+            if focus.unwrap_or(false) {
+                auto_focus_terminal(terminal_id, app_state, app_handle);
+            }
 
             // 1. Snapshot buffer length before command
             let before_len = match daemon.send_request(&godly_protocol::Request::ReadBuffer {


### PR DESCRIPTION
## Summary

- MCP tools no longer auto-switch the user's terminal focus when agents work in the background
- Add `focus` parameter (default: `false`) to 5 tools: `write_to_terminal`, `execute_command`, `send_keys`, `erase_content`, `create_terminal`
- Pass `focus: true` to opt in to the previous behavior

## Motivation

When MCP agents are orchestrating multiple terminals (e.g., spawning 3 Claude Code instances), every `write_to_terminal` and `execute_command` call would hijack the user's view by auto-focusing the target terminal. This made it impossible to work in one terminal while agents operated in others.

## Changes

- `src-tauri/protocol/src/mcp_messages.rs` — Add `focus: Option<bool>` field to `CreateTerminal`, `WriteToTerminal`, `SendKeys`, `EraseContent`, `ExecuteCommand`
- `src-tauri/src/mcp_server/handler.rs` — Gate `auto_focus_terminal()` behind `focus.unwrap_or(false)`
- `src-tauri/mcp/src/tools.rs` — Add `focus` to tool schemas and argument parsing
- `src-tauri/mcp/src/daemon_direct.rs` — Ignore `focus` field in pattern matches (no UI in direct mode)
- `src-tauri/mcp/src/main.rs` — BUILD bump 24→25

refs #534