### PR TITLE
feat: Phase 2 WU-3 — multi-terminal app rewrite with event-driven updates

### DIFF
--- a/changelog/unreleased/phase2-wu3-app-rewrite.md
+++ b/changelog/unreleased/phase2-wu3-app-rewrite.md
@@ -1,0 +1,8 @@
+### Added
+- **Multi-terminal support** — multiple terminal sessions with tab switching in the native Iced shell
+- **Event-driven rendering** — replaced 60fps AtomicBool polling with channel-based daemon event delivery
+- **Window resize handling** — terminal grid auto-resizes when the window is resized
+- **Tab bar UI** — clickable tabs with add/close terminal support
+
+### Changed
+- **App architecture rewrite** — `GodlyApp` now manages `TerminalCollection` instead of a single session

--- a/src-tauri/native/iced-shell/Cargo.toml
+++ b/src-tauri/native/iced-shell/Cargo.toml
@@ -18,3 +18,5 @@ log = "0.4"
 env_logger = "0.11"
 uuid.workspace = true
 futures-channel = "0.3"
+futures = "0.3"
+parking_lot.workspace = true

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1,52 +1,58 @@
 use std::sync::Arc;
-use std::time::Duration;
 
+use futures_channel::mpsc;
 use iced::keyboard;
-use iced::widget::{canvas, center, text};
-use iced::{Element, Length, Subscription, Task};
+use iced::widget::{canvas, center, column, text};
+use iced::{event, window, Element, Length, Subscription, Task};
 
 use godly_app_adapter::commands;
-use godly_app_adapter::daemon_client::{FrontendEventSink, NativeDaemonClient};
+use godly_app_adapter::daemon_client::NativeDaemonClient;
 use godly_app_adapter::keys::key_to_pty_bytes;
 use godly_protocol::types::RichGridData;
 
 use godly_terminal_surface::{TerminalCanvas, TerminalCanvasState};
 
-use crate::subscription::DaemonEventMsg;
+use crate::subscription::{daemon_events, ChannelEventSink, DaemonEventMsg};
+use crate::tab_bar::{self, TAB_BAR_HEIGHT};
+use crate::terminal_state::TerminalCollection;
 
-/// Main Iced application state.
+/// Main Iced application state — multi-terminal with event-driven updates.
 pub struct GodlyApp {
     /// Daemon client (shared with bridge thread).
     client: Option<Arc<NativeDaemonClient>>,
-    /// Current session ID.
-    session_id: Option<String>,
-    /// Terminal canvas state (shared with Canvas Program).
-    canvas_state: TerminalCanvasState,
-    /// Window title from terminal.
-    terminal_title: String,
+    /// All terminal sessions.
+    terminals: TerminalCollection,
     /// Error message to display if initialization failed.
     init_error: Option<String>,
-    /// Grid dimensions in cells.
-    grid_rows: u16,
-    grid_cols: u16,
-    /// Whether a grid fetch is currently in flight.
-    fetching_grid: bool,
-    /// Pending output flag — set by event sink, cleared by grid fetch.
-    has_pending_output: Arc<std::sync::atomic::AtomicBool>,
+    /// Event receiver for the daemon subscription (taken once by the subscription).
+    event_receiver: Arc<parking_lot::Mutex<Option<mpsc::UnboundedReceiver<DaemonEventMsg>>>>,
+    /// Canvas state for the currently active terminal.
+    /// Swapped in/out when switching tabs.
+    canvas_state: TerminalCanvasState,
+    /// Window dimensions in logical pixels.
+    window_width: f32,
+    window_height: f32,
+    /// Font metrics for grid dimension calculations.
+    #[allow(dead_code)]
+    font_size: f32,
+    cell_width: f32,
+    cell_height: f32,
 }
 
 impl Default for GodlyApp {
     fn default() -> Self {
+        let font_size = 14.0;
         Self {
             client: None,
-            session_id: None,
-            canvas_state: TerminalCanvasState::default(),
-            terminal_title: String::new(),
+            terminals: TerminalCollection::new(),
             init_error: None,
-            grid_rows: 24,
-            grid_cols: 80,
-            fetching_grid: false,
-            has_pending_output: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            event_receiver: Arc::new(parking_lot::Mutex::new(None)),
+            canvas_state: TerminalCanvasState::default(),
+            window_width: 1200.0,
+            window_height: 800.0,
+            font_size,
+            cell_width: font_size * 0.6,
+            cell_height: font_size * 1.3,
         }
     }
 }
@@ -56,16 +62,40 @@ impl Default for GodlyApp {
 pub enum Message {
     /// Daemon event received from bridge thread.
     DaemonEvent(DaemonEventMsg),
-    /// Grid snapshot fetched after output event.
-    GridFetched(RichGridData),
-    /// Grid fetch failed (log only).
-    GridFetchFailed(String),
+    /// Grid snapshot fetched for a specific session.
+    GridFetched {
+        session_id: String,
+        grid: RichGridData,
+    },
+    /// Grid fetch failed for a specific session.
+    GridFetchFailed {
+        session_id: String,
+        error: String,
+    },
     /// Keyboard event from iced.
     KeyboardEvent(keyboard::Event),
     /// Initialization complete.
     Initialized(Result<InitResult, String>),
-    /// Timer tick for polling daemon events.
-    Tick,
+    /// User clicked a tab.
+    TabClicked(String),
+    /// User wants a new terminal.
+    NewTabRequested,
+    /// User wants to close a terminal.
+    CloseTabRequested(String),
+    /// New terminal created by daemon.
+    TerminalCreated(Result<String, String>),
+    /// Terminal session exited.
+    SessionExited {
+        session_id: String,
+        exit_code: Option<i64>,
+    },
+    /// Foreground process changed.
+    ProcessChanged {
+        session_id: String,
+        process_name: String,
+    },
+    /// Window was resized.
+    WindowResized { width: f32, height: f32 },
 }
 
 #[derive(Debug, Clone)]
@@ -73,88 +103,184 @@ pub struct InitResult {
     pub session_id: String,
 }
 
-/// Event sink implementation that sets an atomic flag.
-/// The iced app polls this flag on timer ticks.
-struct AtomicEventSink {
-    has_output: Arc<std::sync::atomic::AtomicBool>,
-}
-
-impl FrontendEventSink for AtomicEventSink {
-    fn on_terminal_output(&self, _session_id: &str) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_session_closed(&self, _session_id: &str, _exit_code: Option<i64>) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_process_changed(&self, _session_id: &str, _process_name: &str) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_grid_diff(&self, _session_id: &str, _diff_bytes: &[u8]) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_bell(&self, _session_id: &str) {}
-}
-
 impl GodlyApp {
     pub fn title(&self) -> String {
-        if !self.terminal_title.is_empty() {
-            format!("{} — Godly Terminal (Native)", self.terminal_title)
-        } else {
-            format!(
-                "Godly Terminal (Native) — contract v{}",
-                godly_protocol::FRONTEND_CONTRACT_VERSION
-            )
+        if let Some(active) = self.terminals.active() {
+            let label = active.tab_label();
+            if label != "Terminal" {
+                return format!("{} — Godly Terminal (Native)", label);
+            }
         }
+        format!(
+            "Godly Terminal (Native) — contract v{}",
+            godly_protocol::FRONTEND_CONTRACT_VERSION
+        )
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::Initialized(Ok(result)) => {
-                self.session_id = Some(result.session_id);
-                return self.fetch_grid();
+                let rows = self.calculate_rows();
+                let cols = self.calculate_cols();
+                self.terminals
+                    .add(result.session_id.clone(), rows, cols);
+                return self.fetch_grid(&result.session_id);
             }
             Message::Initialized(Err(e)) => {
                 log::error!("Initialization failed: {}", e);
                 self.init_error = Some(e);
             }
-            Message::Tick => {
-                // Poll for pending output from the daemon event sink
-                if self
-                    .has_pending_output
-                    .swap(false, std::sync::atomic::Ordering::Relaxed)
-                    && !self.fetching_grid
-                {
-                    return self.fetch_grid();
+
+            // --- Daemon events (channel-driven, no polling) ---
+            Message::DaemonEvent(DaemonEventMsg::TerminalOutput { session_id }) => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.dirty = true;
+                }
+                return self.fetch_grid(&session_id);
+            }
+            Message::DaemonEvent(DaemonEventMsg::SessionClosed {
+                session_id,
+                exit_code,
+            }) => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.exited = true;
+                    term.exit_code = exit_code;
+                }
+                log::info!(
+                    "Session {} closed (exit_code={:?})",
+                    session_id,
+                    exit_code
+                );
+            }
+            Message::DaemonEvent(DaemonEventMsg::ProcessChanged {
+                session_id,
+                process_name,
+            }) => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.process_name = process_name;
                 }
             }
-            Message::DaemonEvent(_) => {}
-            Message::GridFetched(grid) => {
-                self.fetching_grid = false;
-                self.terminal_title = grid.title.clone();
-                self.canvas_state.grid = Some(grid);
+            Message::DaemonEvent(DaemonEventMsg::Bell { session_id }) => {
+                log::debug!("Bell from session {}", session_id);
             }
-            Message::GridFetchFailed(e) => {
-                self.fetching_grid = false;
-                log::error!("Grid fetch failed: {}", e);
+
+            // --- Grid fetch results ---
+            Message::GridFetched { session_id, grid } => {
+                // Update the terminal's stored grid.
+                let is_active = self.terminals.active_id() == Some(session_id.as_str());
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.fetching = false;
+                    term.dirty = false;
+                    term.title = grid.title.clone();
+                    term.grid = Some(grid.clone());
+                }
+                // If this is the active terminal, update the canvas state.
+                if is_active {
+                    self.canvas_state.grid = Some(grid);
+                }
             }
+            Message::GridFetchFailed { session_id, error } => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.fetching = false;
+                }
+                log::error!("Grid fetch failed for {}: {}", session_id, error);
+            }
+
+            // --- Keyboard input ---
             Message::KeyboardEvent(keyboard::Event::KeyPressed {
                 key, modifiers, ..
             }) => {
                 if let Some(bytes) = key_to_pty_bytes(&key, modifiers) {
-                    if let (Some(client), Some(sid)) = (&self.client, &self.session_id) {
-                        let _ = commands::write_to_terminal(client, sid, &bytes);
+                    if let Some(active_id) = self.terminals.active_id().map(|s| s.to_string()) {
+                        if let Some(client) = &self.client {
+                            let _ = commands::write_to_terminal(client, &active_id, &bytes);
+                        }
                     }
                 }
             }
             Message::KeyboardEvent(_) => {}
+
+            // --- Tab management ---
+            Message::TabClicked(id) => {
+                // Save current active terminal's grid for later.
+                if let Some(old_active_id) = self.terminals.active_id().map(|s| s.to_string()) {
+                    if old_active_id != id {
+                        // Store the current canvas grid back into the old terminal.
+                        let current_grid = self.canvas_state.grid.take();
+                        if let Some(old_term) = self.terminals.get_mut(&old_active_id) {
+                            old_term.grid = current_grid;
+                        }
+                    }
+                }
+
+                self.terminals.set_active(&id);
+
+                // Load the new active terminal's grid into the canvas.
+                if let Some(active) = self.terminals.active() {
+                    self.canvas_state.grid = active.grid.clone();
+                }
+            }
+            Message::NewTabRequested => {
+                return self.create_new_terminal();
+            }
+            Message::CloseTabRequested(id) => {
+                return self.close_terminal(&id);
+            }
+            Message::TerminalCreated(Ok(session_id)) => {
+                let rows = self.calculate_rows();
+                let cols = self.calculate_cols();
+
+                // Save current active terminal's grid.
+                if let Some(old_active_id) = self.terminals.active_id().map(|s| s.to_string()) {
+                    let current_grid = self.canvas_state.grid.take();
+                    if let Some(old_term) = self.terminals.get_mut(&old_active_id) {
+                        old_term.grid = current_grid;
+                    }
+                }
+
+                self.terminals.add(session_id.clone(), rows, cols);
+                // New terminal becomes active (add sets it for the first, we set_active for rest)
+                self.terminals.set_active(&session_id);
+                self.canvas_state.grid = None;
+                return self.fetch_grid(&session_id);
+            }
+            Message::TerminalCreated(Err(e)) => {
+                log::error!("Failed to create terminal: {}", e);
+            }
+
+            Message::SessionExited {
+                session_id,
+                exit_code,
+            } => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.exited = true;
+                    term.exit_code = exit_code;
+                }
+            }
+            Message::ProcessChanged {
+                session_id,
+                process_name,
+            } => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.process_name = process_name;
+                }
+            }
+
+            // --- Window resize ---
+            Message::WindowResized { width, height } => {
+                let old_cols = self.calculate_cols();
+                let old_rows = self.calculate_rows();
+
+                self.window_width = width;
+                self.window_height = height;
+
+                let new_cols = self.calculate_cols();
+                let new_rows = self.calculate_rows();
+
+                if new_cols != old_cols || new_rows != old_rows {
+                    return self.resize_active_terminal(new_rows, new_cols);
+                }
+            }
         }
         Task::none()
     }
@@ -164,35 +290,76 @@ impl GodlyApp {
             return center(text(format!("Initialization error: {}", err)).size(18)).into();
         }
 
-        if self.session_id.is_none() && self.client.is_none() {
+        if self.client.is_none() && self.terminals.count() == 0 {
             return center(text("Connecting to daemon...").size(18)).into();
         }
 
-        if self.session_id.is_none() {
-            return center(text("Session closed").size(18)).into();
-        }
+        let active_id = self.terminals.active_id();
 
-        canvas(TerminalCanvas)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
+        // Tab bar.
+        let tab_bar = tab_bar::view_tab_bar(
+            self.terminals.as_slice(),
+            active_id,
+            |id| Message::TabClicked(id),
+            |id| Message::CloseTabRequested(id),
+            Message::NewTabRequested,
+        );
+
+        // Active terminal canvas.
+        let terminal_view: Element<'_, Message> = if self.terminals.active().is_some() {
+            canvas(TerminalCanvas)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        } else {
+            center(text("No active terminal").size(16)).into()
+        };
+
+        column![tab_bar, terminal_view].into()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch([
-            // Keyboard events
+        let mut subs = vec![
+            // Keyboard events.
             keyboard::listen().map(Message::KeyboardEvent),
-            // Timer for polling daemon events (~16ms = 60fps)
-            iced::time::every(Duration::from_millis(16)).map(|_| Message::Tick),
-        ])
+            // Daemon events via channel.
+            daemon_events(Arc::clone(&self.event_receiver)).map(Message::DaemonEvent),
+        ];
+
+        // Window resize events.
+        subs.push(
+            event::listen_with(|ev, _status, _window_id| {
+                if let event::Event::Window(window::Event::Resized(size)) = ev {
+                    Some(Message::WindowResized {
+                        width: size.width,
+                        height: size.height,
+                    })
+                } else {
+                    None
+                }
+            }),
+        );
+
+        Subscription::batch(subs)
     }
 
-    /// Spawn a background task to fetch the grid snapshot.
-    fn fetch_grid(&mut self) -> Task<Message> {
-        if let (Some(client), Some(sid)) = (&self.client, &self.session_id) {
-            self.fetching_grid = true;
+    /// Fetch the grid snapshot for a specific session.
+    fn fetch_grid(&mut self, session_id: &str) -> Task<Message> {
+        if let Some(client) = &self.client {
+            if let Some(term) = self.terminals.get_mut(session_id) {
+                if term.fetching {
+                    return Task::none();
+                }
+                term.fetching = true;
+            } else {
+                return Task::none();
+            }
+
             let client = Arc::clone(client);
-            let sid = sid.clone();
+            let sid = session_id.to_string();
+            let sid_ok = sid.clone();
+            let sid_err = sid.clone();
+
             Task::perform(
                 async move {
                     let (tx, rx) = futures_channel::oneshot::channel();
@@ -203,20 +370,117 @@ impl GodlyApp {
                     rx.await
                         .unwrap_or_else(|_| Err("Background thread panicked".into()))
                 },
-                |result| match result {
-                    Ok(grid) => Message::GridFetched(grid),
-                    Err(e) => Message::GridFetchFailed(e),
+                move |result| match result {
+                    Ok(grid) => Message::GridFetched {
+                        session_id: sid_ok,
+                        grid,
+                    },
+                    Err(e) => Message::GridFetchFailed {
+                        session_id: sid_err,
+                        error: e,
+                    },
                 },
             )
         } else {
             Task::none()
         }
     }
+
+    /// Create a new terminal session via the daemon.
+    fn create_new_terminal(&self) -> Task<Message> {
+        let Some(client) = &self.client else {
+            return Task::done(Message::TerminalCreated(Err(
+                "No daemon connection".to_string(),
+            )));
+        };
+
+        let client = Arc::clone(client);
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let sid = session_id.clone();
+        let rows = self.calculate_rows();
+        let cols = self.calculate_cols();
+
+        Task::perform(
+            async move {
+                let (tx, rx) = futures_channel::oneshot::channel();
+                std::thread::spawn(move || {
+                    let result = commands::create_terminal(
+                        &client,
+                        &sid,
+                        godly_protocol::ShellType::Windows,
+                        None,
+                        rows,
+                        cols,
+                    )
+                    .map(|_| sid);
+                    let _ = tx.send(result);
+                });
+                rx.await
+                    .unwrap_or_else(|_| Err("Background thread panicked".into()))
+            },
+            Message::TerminalCreated,
+        )
+    }
+
+    /// Close a terminal session.
+    fn close_terminal(&mut self, session_id: &str) -> Task<Message> {
+        // If closing the active terminal, save its grid first.
+        let is_active = self.terminals.active_id() == Some(session_id);
+        if is_active {
+            self.canvas_state.grid = None;
+        }
+
+        self.terminals.remove(session_id);
+
+        // Load the new active terminal's grid, if any.
+        if let Some(active) = self.terminals.active() {
+            self.canvas_state.grid = active.grid.clone();
+        }
+
+        // Close on daemon (fire-and-forget).
+        if let Some(client) = &self.client {
+            let _ = commands::close_terminal(client, session_id);
+        }
+
+        Task::none()
+    }
+
+    /// Resize the active terminal on the daemon.
+    fn resize_active_terminal(&mut self, rows: u16, cols: u16) -> Task<Message> {
+        let Some(active_id) = self.terminals.active_id().map(|s| s.to_string()) else {
+            return Task::none();
+        };
+
+        if let Some(term) = self.terminals.get_mut(&active_id) {
+            term.rows = rows;
+            term.cols = cols;
+        }
+
+        if let Some(client) = &self.client {
+            let _ = commands::resize_terminal(client, &active_id, rows, cols);
+        }
+
+        // Fetch updated grid after resize.
+        self.fetch_grid(&active_id)
+    }
+
+    /// Calculate terminal columns from window width and font metrics.
+    fn calculate_cols(&self) -> u16 {
+        let cols = (self.window_width / self.cell_width) as u16;
+        cols.max(1)
+    }
+
+    /// Calculate terminal rows from window height (minus tab bar) and font metrics.
+    fn calculate_rows(&self) -> u16 {
+        let available_height = (self.window_height - TAB_BAR_HEIGHT).max(0.0);
+        let rows = (available_height / self.cell_height) as u16;
+        rows.max(1)
+    }
 }
 
-/// Initialize the app: connect to daemon, set up bridge, create session.
+/// Initialize the app: connect to daemon, set up bridge, create first session.
 pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
-    // Connect to daemon
+    // Connect to daemon.
     let client = match NativeDaemonClient::connect_or_launch() {
         Ok(c) => Arc::new(c),
         Err(e) => {
@@ -224,21 +488,25 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
         }
     };
 
-    // Set up bridge with atomic flag event sink
-    let sink = Arc::new(AtomicEventSink {
-        has_output: Arc::clone(&app.has_pending_output),
-    });
+    // Create the event channel.
+    let (tx, rx) = mpsc::unbounded();
+
+    // Store receiver for the subscription to pick up.
+    *app.event_receiver.lock() = Some(rx);
+
+    // Set up bridge with channel event sink.
+    let sink = Arc::new(ChannelEventSink::new(tx));
     if let Err(e) = client.setup_bridge(sink) {
         return Task::done(Message::Initialized(Err(e)));
     }
 
     app.client = Some(Arc::clone(&client));
 
-    // Create a session
+    // Create a session.
     let session_id = uuid::Uuid::new_v4().to_string();
     let sid = session_id.clone();
-    let rows = app.grid_rows;
-    let cols = app.grid_cols;
+    let rows = app.calculate_rows();
+    let cols = app.calculate_cols();
 
     Task::perform(
         async move {
@@ -252,9 +520,7 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
                     rows,
                     cols,
                 )
-                .map(|_| InitResult {
-                    session_id: sid,
-                });
+                .map(|_| InitResult { session_id: sid });
                 let _ = tx.send(result);
             });
             rx.await

--- a/src-tauri/native/iced-shell/src/lib.rs
+++ b/src-tauri/native/iced-shell/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod app;
 pub mod subscription;
+pub mod tab_bar;
+pub mod terminal_state;

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -2,6 +2,8 @@ use iced::window;
 
 mod app;
 mod subscription;
+mod tab_bar;
+mod terminal_state;
 
 use app::{GodlyApp, Message};
 

--- a/src-tauri/native/iced-shell/src/subscription.rs
+++ b/src-tauri/native/iced-shell/src/subscription.rs
@@ -1,3 +1,9 @@
+use std::sync::Arc;
+
+use futures_channel::mpsc;
+
+use godly_app_adapter::daemon_client::FrontendEventSink;
+
 /// Events forwarded from the daemon bridge I/O thread to the Iced app.
 #[derive(Debug, Clone)]
 pub enum DaemonEventMsg {
@@ -8,11 +14,184 @@ pub enum DaemonEventMsg {
         session_id: String,
         exit_code: Option<i64>,
     },
-    /// Process name changed (e.g., shell → vim).
+    /// Process name changed (e.g., shell -> vim).
     ProcessChanged {
         session_id: String,
         process_name: String,
     },
     /// Bell character received.
     Bell { session_id: String },
+}
+
+/// Event sink that sends daemon events through an mpsc channel to iced.
+///
+/// Implements `FrontendEventSink` so it can be handed to the bridge I/O thread.
+/// Events are forwarded as `DaemonEventMsg` values through the unbounded sender.
+pub struct ChannelEventSink {
+    sender: mpsc::UnboundedSender<DaemonEventMsg>,
+}
+
+impl ChannelEventSink {
+    pub fn new(sender: mpsc::UnboundedSender<DaemonEventMsg>) -> Self {
+        Self { sender }
+    }
+}
+
+impl FrontendEventSink for ChannelEventSink {
+    fn on_terminal_output(&self, session_id: &str) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::TerminalOutput {
+            session_id: session_id.to_string(),
+        });
+    }
+
+    fn on_session_closed(&self, session_id: &str, exit_code: Option<i64>) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::SessionClosed {
+            session_id: session_id.to_string(),
+            exit_code,
+        });
+    }
+
+    fn on_process_changed(&self, session_id: &str, process_name: &str) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::ProcessChanged {
+            session_id: session_id.to_string(),
+            process_name: process_name.to_string(),
+        });
+    }
+
+    fn on_grid_diff(&self, session_id: &str, _diff_bytes: &[u8]) {
+        // Grid diffs trigger a terminal output event so the app fetches a fresh snapshot.
+        let _ = self.sender.unbounded_send(DaemonEventMsg::TerminalOutput {
+            session_id: session_id.to_string(),
+        });
+    }
+
+    fn on_bell(&self, session_id: &str) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::Bell {
+            session_id: session_id.to_string(),
+        });
+    }
+}
+
+/// Creates an iced Subscription that streams DaemonEventMsg values from a channel receiver.
+///
+/// The receiver is wrapped in an `Arc<parking_lot::Mutex<Option<...>>>` so it can be
+/// taken exactly once by the subscription stream. Subsequent calls (from iced's
+/// subscription deduplication) will produce an empty stream since the receiver is gone.
+pub fn daemon_events(
+    receiver: Arc<parking_lot::Mutex<Option<mpsc::UnboundedReceiver<DaemonEventMsg>>>>,
+) -> iced::Subscription<DaemonEventMsg> {
+    use iced::advanced::subscription::{self, EventStream, Hasher, Recipe};
+    use std::hash::Hash;
+
+    struct DaemonEventRecipe {
+        receiver: Arc<parking_lot::Mutex<Option<mpsc::UnboundedReceiver<DaemonEventMsg>>>>,
+    }
+
+    impl Recipe for DaemonEventRecipe {
+        type Output = DaemonEventMsg;
+
+        fn hash(&self, state: &mut Hasher) {
+            std::any::TypeId::of::<Self>().hash(state);
+        }
+
+        fn stream(self: Box<Self>, _input: EventStream) -> futures::stream::BoxStream<'static, Self::Output> {
+            if let Some(rx) = self.receiver.lock().take() {
+                Box::pin(rx)
+            } else {
+                // Receiver already taken — return an empty stream that never completes.
+                // This keeps the subscription alive (iced won't re-create it).
+                Box::pin(futures::stream::pending())
+            }
+        }
+    }
+
+    subscription::from_recipe(DaemonEventRecipe { receiver })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_event_sink_sends_output() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_terminal_output("sess1");
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::TerminalOutput { session_id })) => {
+                assert_eq!(session_id, "sess1");
+            }
+            other => panic!("Expected TerminalOutput, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_sends_session_closed() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_session_closed("sess2", Some(0));
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::SessionClosed {
+                session_id,
+                exit_code,
+            })) => {
+                assert_eq!(session_id, "sess2");
+                assert_eq!(exit_code, Some(0));
+            }
+            other => panic!("Expected SessionClosed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_sends_process_changed() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_process_changed("sess3", "vim");
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::ProcessChanged {
+                session_id,
+                process_name,
+            })) => {
+                assert_eq!(session_id, "sess3");
+                assert_eq!(process_name, "vim");
+            }
+            other => panic!("Expected ProcessChanged, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_sends_bell() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_bell("sess4");
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::Bell { session_id })) => {
+                assert_eq!(session_id, "sess4");
+            }
+            other => panic!("Expected Bell, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_grid_diff_becomes_output() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_grid_diff("sess5", &[1, 2, 3]);
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::TerminalOutput { session_id })) => {
+                assert_eq!(session_id, "sess5");
+            }
+            other => panic!("Expected TerminalOutput from grid_diff, got: {:?}", other),
+        }
+    }
 }

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -1,0 +1,103 @@
+use iced::widget::{button, container, row, text};
+use iced::{Border, Color, Element, Length, Padding};
+
+use crate::terminal_state::TerminalInfo;
+
+/// Height of the tab bar in logical pixels.
+pub const TAB_BAR_HEIGHT: f32 = 32.0;
+
+// Colors
+const TAB_BAR_BG: Color = Color::from_rgb(0.08, 0.08, 0.10);
+const ACTIVE_TAB_BG: Color = Color::from_rgb(0.2, 0.2, 0.25);
+const INACTIVE_TAB_BG: Color = Color::from_rgb(0.12, 0.12, 0.15);
+const TAB_TEXT_COLOR: Color = Color::from_rgb(0.85, 0.85, 0.85);
+const CLOSE_HOVER_BG: Color = Color::from_rgb(0.35, 0.15, 0.15);
+
+/// Renders the tab bar as a horizontal row of tab buttons.
+///
+/// This function is generic over the message type so it can be used
+/// independently of any specific app `Message` enum.
+pub fn view_tab_bar<'a, M: Clone + 'a>(
+    terminals: &'a [TerminalInfo],
+    active_id: Option<&str>,
+    on_tab_click: impl Fn(String) -> M + 'a,
+    on_close: impl Fn(String) -> M + 'a,
+    on_new: M,
+) -> Element<'a, M> {
+    let mut tabs = row![].spacing(1);
+
+    for terminal in terminals {
+        let is_active = active_id == Some(terminal.id.as_str());
+        let bg = if is_active {
+            ACTIVE_TAB_BG
+        } else {
+            INACTIVE_TAB_BG
+        };
+
+        let label = text(terminal.tab_label())
+            .size(13)
+            .color(TAB_TEXT_COLOR);
+
+        let close_id = terminal.id.clone();
+        let close_btn = button(text("\u{00D7}").size(14).color(TAB_TEXT_COLOR))
+            .on_press(on_close(close_id))
+            .padding(Padding::from([0, 4]))
+            .style(move |_theme, status| {
+                let bg_color = match status {
+                    button::Status::Hovered | button::Status::Pressed => CLOSE_HOVER_BG,
+                    _ => Color::TRANSPARENT,
+                };
+                button::Style {
+                    background: Some(iced::Background::Color(bg_color)),
+                    text_color: TAB_TEXT_COLOR,
+                    border: Border::default(),
+                    ..button::Style::default()
+                }
+            });
+
+        let tab_content = row![label, close_btn]
+            .spacing(4)
+            .align_y(iced::Alignment::Center);
+
+        let tab_id = terminal.id.clone();
+        let tab_btn = button(tab_content)
+            .on_press(on_tab_click(tab_id))
+            .padding(Padding::from([4, 10]))
+            .style(move |_theme, _status| button::Style {
+                background: Some(iced::Background::Color(bg)),
+                text_color: TAB_TEXT_COLOR,
+                border: Border::default(),
+                ..button::Style::default()
+            });
+
+        tabs = tabs.push(tab_btn);
+    }
+
+    // "+" button to add new terminals.
+    let new_btn = button(text("+").size(14).color(TAB_TEXT_COLOR))
+        .on_press(on_new)
+        .padding(Padding::from([4, 10]))
+        .style(|_theme, status| {
+            let bg_color = match status {
+                button::Status::Hovered | button::Status::Pressed => ACTIVE_TAB_BG,
+                _ => Color::TRANSPARENT,
+            };
+            button::Style {
+                background: Some(iced::Background::Color(bg_color)),
+                text_color: TAB_TEXT_COLOR,
+                border: Border::default(),
+                ..button::Style::default()
+            }
+        });
+
+    tabs = tabs.push(new_btn);
+
+    container(tabs)
+        .width(Length::Fill)
+        .height(Length::Fixed(TAB_BAR_HEIGHT))
+        .style(|_theme| container::Style {
+            background: Some(iced::Background::Color(TAB_BAR_BG)),
+            ..container::Style::default()
+        })
+        .into()
+}

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -1,0 +1,322 @@
+use godly_protocol::types::RichGridData;
+
+/// Information about a single terminal session.
+pub struct TerminalInfo {
+    pub id: String,
+    pub title: String,
+    pub process_name: String,
+    pub order: u32,
+    pub grid: Option<RichGridData>,
+    pub dirty: bool,
+    pub fetching: bool,
+    pub rows: u16,
+    pub cols: u16,
+    pub exited: bool,
+    pub exit_code: Option<i64>,
+}
+
+impl TerminalInfo {
+    /// Returns the display label for this terminal's tab.
+    ///
+    /// Priority: title > process_name > "Terminal"
+    pub fn tab_label(&self) -> &str {
+        if !self.title.is_empty() {
+            &self.title
+        } else if !self.process_name.is_empty() {
+            &self.process_name
+        } else {
+            "Terminal"
+        }
+    }
+}
+
+/// Collection of terminal sessions with active tab tracking.
+pub struct TerminalCollection {
+    terminals: Vec<TerminalInfo>,
+    active_id: Option<String>,
+    next_order: u32,
+}
+
+impl TerminalCollection {
+    /// Creates an empty collection.
+    pub fn new() -> Self {
+        Self {
+            terminals: Vec::new(),
+            active_id: None,
+            next_order: 0,
+        }
+    }
+
+    /// Adds a new terminal with the given id and grid dimensions.
+    ///
+    /// Auto-increments the order counter. Sets as active if this is the first terminal.
+    /// Returns a mutable reference to the newly created `TerminalInfo`.
+    pub fn add(&mut self, id: String, rows: u16, cols: u16) -> &mut TerminalInfo {
+        let order = self.next_order;
+        self.next_order += 1;
+
+        let is_first = self.terminals.is_empty();
+
+        self.terminals.push(TerminalInfo {
+            id: id.clone(),
+            title: String::new(),
+            process_name: String::new(),
+            order,
+            grid: None,
+            dirty: false,
+            fetching: false,
+            rows,
+            cols,
+            exited: false,
+            exit_code: None,
+        });
+
+        if is_first {
+            self.active_id = Some(id.clone());
+        }
+
+        // Return mutable reference to the last element (the one we just pushed).
+        self.terminals.last_mut().unwrap()
+    }
+
+    /// Removes the terminal with the given id.
+    ///
+    /// If the removed terminal was active, the next terminal at the same index
+    /// (or the previous one if at the end) becomes active.
+    pub fn remove(&mut self, id: &str) {
+        let Some(idx) = self.terminals.iter().position(|t| t.id == id) else {
+            return;
+        };
+
+        let was_active = self.active_id.as_deref() == Some(id);
+        self.terminals.remove(idx);
+
+        if was_active {
+            if self.terminals.is_empty() {
+                self.active_id = None;
+            } else {
+                // Prefer same index (next terminal), or fall back to previous.
+                let new_idx = if idx < self.terminals.len() {
+                    idx
+                } else {
+                    self.terminals.len() - 1
+                };
+                self.active_id = Some(self.terminals[new_idx].id.clone());
+            }
+        }
+    }
+
+    /// Returns a reference to the active terminal, if any.
+    pub fn active(&self) -> Option<&TerminalInfo> {
+        let id = self.active_id.as_deref()?;
+        self.terminals.iter().find(|t| t.id == id)
+    }
+
+    /// Returns a mutable reference to the active terminal, if any.
+    pub fn active_mut(&mut self) -> Option<&mut TerminalInfo> {
+        let id = self.active_id.as_deref()?.to_owned();
+        self.terminals.iter_mut().find(|t| t.id == id)
+    }
+
+    /// Finds a terminal by id.
+    pub fn get(&self, id: &str) -> Option<&TerminalInfo> {
+        self.terminals.iter().find(|t| t.id == id)
+    }
+
+    /// Finds a terminal by id, mutably.
+    pub fn get_mut(&mut self, id: &str) -> Option<&mut TerminalInfo> {
+        self.terminals.iter_mut().find(|t| t.id == id)
+    }
+
+    /// Sets the active terminal by id. No-op if id not found.
+    pub fn set_active(&mut self, id: &str) {
+        if self.terminals.iter().any(|t| t.id == id) {
+            self.active_id = Some(id.to_owned());
+        }
+    }
+
+    /// Returns the number of terminals in the collection.
+    pub fn count(&self) -> usize {
+        self.terminals.len()
+    }
+
+    /// Iterates over all terminals.
+    pub fn iter(&self) -> impl Iterator<Item = &TerminalInfo> {
+        self.terminals.iter()
+    }
+
+    /// Returns all terminals as a slice.
+    pub fn as_slice(&self) -> &[TerminalInfo] {
+        &self.terminals
+    }
+
+    /// Returns the active terminal's id, if any.
+    pub fn active_id(&self) -> Option<&str> {
+        self.active_id.as_deref()
+    }
+}
+
+impl Default for TerminalCollection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_first_becomes_active() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        assert_eq!(col.active_id(), Some("t1"));
+        assert_eq!(col.count(), 1);
+    }
+
+    #[test]
+    fn test_add_second_does_not_change_active() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        assert_eq!(col.active_id(), Some("t1"));
+        assert_eq!(col.count(), 2);
+    }
+
+    #[test]
+    fn test_remove_active_picks_next() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        // Active is t1 (first added). Remove it -> t2 should become active (same index 0).
+        col.remove("t1");
+        assert_eq!(col.active_id(), Some("t2"));
+        assert_eq!(col.count(), 2);
+
+        // Remove t2 (active) -> t3 should become active.
+        col.remove("t2");
+        assert_eq!(col.active_id(), Some("t3"));
+        assert_eq!(col.count(), 1);
+
+        // Remove last terminal -> no active.
+        col.remove("t3");
+        assert_eq!(col.active_id(), None);
+        assert_eq!(col.count(), 0);
+    }
+
+    #[test]
+    fn test_remove_last_active_picks_previous() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        // Make t3 active, then remove it -> should pick t2 (previous).
+        col.set_active("t3");
+        assert_eq!(col.active_id(), Some("t3"));
+        col.remove("t3");
+        assert_eq!(col.active_id(), Some("t2"));
+    }
+
+    #[test]
+    fn test_remove_non_active_preserves_active() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        // Active is t1. Remove t2 -> active should still be t1.
+        col.remove("t2");
+        assert_eq!(col.active_id(), Some("t1"));
+        assert_eq!(col.count(), 2);
+    }
+
+    #[test]
+    fn test_tab_label_priority() {
+        let mut col = TerminalCollection::new();
+
+        // No title, no process_name -> "Terminal"
+        let info = col.add("t1".into(), 24, 80);
+        assert_eq!(info.tab_label(), "Terminal");
+
+        // process_name set, no title -> process_name
+        info.process_name = "pwsh".into();
+        assert_eq!(info.tab_label(), "pwsh");
+
+        // title set -> title takes priority
+        info.title = "My Shell".into();
+        assert_eq!(info.tab_label(), "My Shell");
+    }
+
+    #[test]
+    fn test_get_and_get_mut() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 30, 100);
+
+        // get
+        let t1 = col.get("t1").unwrap();
+        assert_eq!(t1.rows, 24);
+        assert_eq!(t1.cols, 80);
+
+        let t2 = col.get("t2").unwrap();
+        assert_eq!(t2.rows, 30);
+        assert_eq!(t2.cols, 100);
+
+        assert!(col.get("nonexistent").is_none());
+
+        // get_mut
+        {
+            let t1_mut = col.get_mut("t1").unwrap();
+            t1_mut.dirty = true;
+        }
+        assert!(col.get("t1").unwrap().dirty);
+
+        assert!(col.get_mut("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_set_active_nonexistent_is_noop() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.set_active("nonexistent");
+        assert_eq!(col.active_id(), Some("t1"));
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        let ids: Vec<&str> = col.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["t1", "t2", "t3"]);
+    }
+
+    #[test]
+    fn test_order_auto_increments() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        let orders: Vec<u32> = col.iter().map(|t| t.order).collect();
+        assert_eq!(orders, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_active_and_active_mut() {
+        let mut col = TerminalCollection::new();
+        assert!(col.active().is_none());
+        assert!(col.active_mut().is_none());
+
+        col.add("t1".into(), 24, 80);
+        assert_eq!(col.active().unwrap().id, "t1");
+
+        col.active_mut().unwrap().title = "Hello".into();
+        assert_eq!(col.active().unwrap().title, "Hello");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 Work Unit 3: Rewrites the native Iced shell's `GodlyApp` from a single-terminal, polling-based architecture to a multi-terminal, event-driven one.

- **Multi-terminal support** via `TerminalCollection` — add, remove, switch between sessions with tab bar UI
- **Event-driven rendering** — replaces 60fps `AtomicBool` polling with `ChannelEventSink` that sends `DaemonEventMsg` through an unbounded mpsc channel, consumed by a custom `Recipe`-based iced `Subscription`
- **Window resize handling** — recalculates grid dimensions (cols/rows) using font metrics heuristics (`cell_width = font_size * 0.6`, `cell_height = font_size * 1.3`) and sends `Resize` commands to the daemon when dimensions change
- **Tab bar UI** — clickable tabs with close buttons and "+" add terminal button (from WU-2 inline modules)
- **Grid swap on tab switch** — stores per-terminal grid snapshots, swaps into shared `TerminalCanvasState` on tab change

### Files changed

| File | Action | Description |
|------|--------|-------------|
| `src/app.rs` | Rewrite | Multi-terminal `GodlyApp`, new `Message` enum, tab/resize/event handling |
| `src/subscription.rs` | Rewrite | `ChannelEventSink`, `DaemonEventRecipe`, channel-based subscription |
| `src/main.rs` | Modify | Added `tab_bar` and `terminal_state` module declarations |
| `src/lib.rs` | Modify | Added `tab_bar` and `terminal_state` module exports |
| `src/terminal_state.rs` | New | `TerminalInfo` + `TerminalCollection` (inline from WU-2) |
| `src/tab_bar.rs` | New | Generic `view_tab_bar` function (inline from WU-2) |
| `Cargo.toml` | Modify | Added `futures` and `parking_lot` dependencies |

### Architecture

```
Bridge I/O thread
    |
    v
ChannelEventSink (FrontendEventSink)
    |  unbounded_send(DaemonEventMsg)
    v
mpsc::UnboundedReceiver
    |  consumed by DaemonEventRecipe (iced Recipe)
    v
Subscription::from_recipe -> Message::DaemonEvent
    |
    v
GodlyApp::update -> fetch_grid(session_id) -> Task::perform -> Message::GridFetched
```

## Test plan

- [x] `cargo check -p godly-iced-shell` — compiles cleanly (warnings only for unused WU-2 methods)
- [x] `cargo test -p godly-iced-shell` — 16 tests pass (5 subscription channel tests + 11 terminal_state tests)
- [x] `cargo check -p godly-protocol -p godly-daemon` — no breakage on dependent crates