### PR TITLE
feat: refactor TerminalCanvas and add FontMetrics (Phase 2 WU-1)

### DIFF
--- a/changelog/unreleased/phase2-wu1-surface-font-metrics.md
+++ b/changelog/unreleased/phase2-wu1-surface-font-metrics.md
@@ -1,0 +1,5 @@
+### Added
+- **Font metrics auto-detection** — heuristic-based `FontMetrics` struct replaces hardcoded 9x18 cell sizes
+
+### Changed
+- **Terminal canvas refactor** — `TerminalCanvas` now carries grid data on the struct instead of in internal State, enabling per-terminal rendering

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -10,7 +10,7 @@ use godly_app_adapter::daemon_client::{FrontendEventSink, NativeDaemonClient};
 use godly_app_adapter::keys::key_to_pty_bytes;
 use godly_protocol::types::RichGridData;
 
-use godly_terminal_surface::{TerminalCanvas, TerminalCanvasState};
+use godly_terminal_surface::{FontMetrics, TerminalCanvas};
 
 use crate::subscription::DaemonEventMsg;
 
@@ -20,8 +20,10 @@ pub struct GodlyApp {
     client: Option<Arc<NativeDaemonClient>>,
     /// Current session ID.
     session_id: Option<String>,
-    /// Terminal canvas state (shared with Canvas Program).
-    canvas_state: TerminalCanvasState,
+    /// Current grid data from daemon.
+    grid: Option<RichGridData>,
+    /// Font metrics for terminal rendering.
+    font_metrics: FontMetrics,
     /// Window title from terminal.
     terminal_title: String,
     /// Error message to display if initialization failed.
@@ -40,7 +42,8 @@ impl Default for GodlyApp {
         Self {
             client: None,
             session_id: None,
-            canvas_state: TerminalCanvasState::default(),
+            grid: None,
+            font_metrics: FontMetrics::default(),
             terminal_title: String::new(),
             init_error: None,
             grid_rows: 24,
@@ -139,7 +142,7 @@ impl GodlyApp {
             Message::GridFetched(grid) => {
                 self.fetching_grid = false;
                 self.terminal_title = grid.title.clone();
-                self.canvas_state.grid = Some(grid);
+                self.grid = Some(grid);
             }
             Message::GridFetchFailed(e) => {
                 self.fetching_grid = false;
@@ -172,10 +175,13 @@ impl GodlyApp {
             return center(text("Session closed").size(18)).into();
         }
 
-        canvas(TerminalCanvas)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
+        canvas(TerminalCanvas {
+            grid: self.grid.clone(),
+            metrics: self.font_metrics,
+        })
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {

--- a/src-tauri/native/terminal-surface/src/font_metrics.rs
+++ b/src-tauri/native/terminal-surface/src/font_metrics.rs
@@ -1,0 +1,116 @@
+/// Font metrics for monospace terminal rendering.
+///
+/// Provides cell dimensions derived from font size using heuristic ratios.
+/// These are reasonable defaults for monospace fonts and can be replaced
+/// with measured values once actual font shaping is available.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FontMetrics {
+    /// Width of a single cell in pixels.
+    pub cell_width: f32,
+    /// Height of a single cell in pixels.
+    pub cell_height: f32,
+    /// Font size in pixels.
+    pub font_size: f32,
+    /// Vertical offset from cell top to text baseline in pixels.
+    pub baseline_offset: f32,
+}
+
+impl FontMetrics {
+    /// Width-to-font-size ratio for monospace fonts.
+    const WIDTH_RATIO: f32 = 0.6;
+    /// Height-to-font-size ratio for monospace fonts.
+    const HEIGHT_RATIO: f32 = 1.3;
+    /// Baseline position as fraction of cell height.
+    const BASELINE_FRACTION: f32 = 0.75;
+
+    /// Create font metrics from a font size using heuristic ratios.
+    ///
+    /// - `cell_width = font_size * 0.6`
+    /// - `cell_height = font_size * 1.3`
+    /// - `baseline_offset = cell_height * 0.75`
+    pub fn from_font_size(font_size: f32) -> Self {
+        let cell_width = font_size * Self::WIDTH_RATIO;
+        let cell_height = font_size * Self::HEIGHT_RATIO;
+        let baseline_offset = cell_height * Self::BASELINE_FRACTION;
+        Self {
+            cell_width,
+            cell_height,
+            font_size,
+            baseline_offset,
+        }
+    }
+}
+
+impl Default for FontMetrics {
+    fn default() -> Self {
+        Self::from_font_size(14.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_font_size_14() {
+        let m = FontMetrics::from_font_size(14.0);
+        assert!((m.cell_width - 8.4).abs() < 0.01);
+        assert!((m.cell_height - 18.2).abs() < 0.01);
+        assert!((m.font_size - 14.0).abs() < 0.01);
+        assert!((m.baseline_offset - 13.65).abs() < 0.01);
+    }
+
+    #[test]
+    fn from_font_size_16() {
+        let m = FontMetrics::from_font_size(16.0);
+        assert!((m.cell_width - 9.6).abs() < 0.01);
+        assert!((m.cell_height - 20.8).abs() < 0.01);
+        assert!((m.font_size - 16.0).abs() < 0.01);
+        assert!((m.baseline_offset - 15.6).abs() < 0.01);
+    }
+
+    #[test]
+    fn from_font_size_zero() {
+        let m = FontMetrics::from_font_size(0.0);
+        assert!((m.cell_width).abs() < 0.01);
+        assert!((m.cell_height).abs() < 0.01);
+        assert!((m.baseline_offset).abs() < 0.01);
+    }
+
+    #[test]
+    fn default_uses_14() {
+        let m = FontMetrics::default();
+        let expected = FontMetrics::from_font_size(14.0);
+        assert_eq!(m, expected);
+    }
+
+    #[test]
+    fn width_height_ratio_relationship() {
+        // For any font size, width should be narrower than height (monospace convention)
+        for size in [8.0, 12.0, 14.0, 16.0, 20.0, 24.0] {
+            let m = FontMetrics::from_font_size(size);
+            assert!(
+                m.cell_width < m.cell_height,
+                "cell_width ({}) should be less than cell_height ({}) for font_size {}",
+                m.cell_width,
+                m.cell_height,
+                size
+            );
+        }
+    }
+
+    #[test]
+    fn baseline_within_cell() {
+        // Baseline must be within cell bounds for readable text
+        for size in [8.0, 12.0, 14.0, 16.0, 20.0, 24.0] {
+            let m = FontMetrics::from_font_size(size);
+            assert!(
+                m.baseline_offset > 0.0 && m.baseline_offset < m.cell_height,
+                "baseline_offset ({}) should be within (0, {}) for font_size {}",
+                m.baseline_offset,
+                m.cell_height,
+                size
+            );
+        }
+    }
+}

--- a/src-tauri/native/terminal-surface/src/lib.rs
+++ b/src-tauri/native/terminal-surface/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod colors;
+pub mod font_metrics;
 mod surface;
 
+pub use font_metrics::FontMetrics;
 pub use surface::{TerminalCanvas, TerminalCanvasState, DEFAULT_BG, DEFAULT_FG};

--- a/src-tauri/native/terminal-surface/src/surface.rs
+++ b/src-tauri/native/terminal-surface/src/surface.rs
@@ -5,6 +5,7 @@ use iced::{Color, Font, Pixels, Point, Rectangle, Renderer, Size, Theme};
 use godly_protocol::types::RichGridData;
 
 use crate::colors::{dim_color, parse_color};
+use crate::font_metrics::FontMetrics;
 
 /// Default terminal foreground (light gray).
 pub const DEFAULT_FG: Color = Color {
@@ -22,42 +23,52 @@ pub const DEFAULT_BG: Color = Color {
     a: 1.0,
 };
 
-/// Terminal canvas state holding the current grid snapshot and font metrics.
-pub struct TerminalCanvasState {
+/// Minimal internal state for the Canvas `Program`.
+///
+/// Grid data and font metrics live on [`TerminalCanvas`] itself so that the
+/// parent widget can update them directly. This struct exists only to satisfy
+/// the `Program::State` associated type.
+#[derive(Debug, Default)]
+pub struct TerminalCanvasState;
+
+/// Terminal canvas program that renders a RichGridData snapshot.
+///
+/// Grid data and font metrics are carried on the struct, enabling the parent
+/// to set per-terminal data before each render. Drawing uses Iced's Canvas
+/// widget via `Frame::fill_rectangle()` for backgrounds and
+/// `Frame::fill_text()` for cell content.
+pub struct TerminalCanvas {
     /// Current grid data from the daemon.
     pub grid: Option<RichGridData>,
-    /// Width of a single cell in pixels.
-    pub cell_width: f32,
-    /// Height of a single cell in pixels.
-    pub cell_height: f32,
-    /// Font size in pixels.
-    pub font_size: f32,
+    /// Font metrics for cell sizing.
+    pub metrics: FontMetrics,
 }
 
-impl Default for TerminalCanvasState {
+impl Default for TerminalCanvas {
     fn default() -> Self {
         Self {
             grid: None,
-            cell_width: 9.0,
-            cell_height: 18.0,
-            font_size: 14.0,
+            metrics: FontMetrics::default(),
         }
     }
 }
 
-/// Terminal canvas program that renders a RichGridData snapshot.
-///
-/// Uses Iced's Canvas widget with the `Program` trait. Drawing is done
-/// via `Frame::fill_rectangle()` for backgrounds and `Frame::fill_text()`
-/// for cell content.
-pub struct TerminalCanvas;
+impl TerminalCanvas {
+    /// Create a new terminal canvas with the given font metrics.
+    pub fn new(metrics: FontMetrics) -> Self {
+        Self {
+            grid: None,
+            metrics,
+        }
+    }
+}
 
 impl<Message> canvas::Program<Message> for TerminalCanvas {
     type State = TerminalCanvasState;
 
     fn draw(
         &self,
-        state: &Self::State,
+        _state: &Self::State,
         renderer: &Renderer,
         _theme: &Theme,
         bounds: Rectangle,
@@ -68,14 +79,14 @@ impl<Message> canvas::Program<Message> for TerminalCanvas {
         // Fill background
         frame.fill_rectangle(Point::ORIGIN, bounds.size(), DEFAULT_BG);
 
-        let grid = match &state.grid {
+        let grid = match &self.grid {
             Some(g) => g,
             None => return vec![frame.into_geometry()],
         };
 
-        let cell_w = state.cell_width;
-        let cell_h = state.cell_height;
-        let font_size = state.font_size;
+        let cell_w = self.metrics.cell_width;
+        let cell_h = self.metrics.cell_height;
+        let font_size = self.metrics.font_size;
         let monospace = Font::MONOSPACE;
 
         // Draw each cell


### PR DESCRIPTION
## Summary
- **Refactored `TerminalCanvas`** to carry grid data and font metrics on the struct instead of in internal canvas `State`, enabling per-terminal rendering where each terminal instance owns its own grid snapshot and metrics
- **Added `FontMetrics` struct** with heuristic-based cell sizing derived from font size (width=0.6x, height=1.3x, baseline=0.75*height), replacing hardcoded 9x18 cell dimensions
- **Updated `iced-shell` app** to use the new API: grid data and metrics stored on `GodlyApp`, passed to `TerminalCanvas` on each render

## Changes
- `src-tauri/native/terminal-surface/src/surface.rs` — `TerminalCanvas` now holds `grid: Option<RichGridData>` and `metrics: FontMetrics`; `TerminalCanvasState` reduced to empty struct; `draw()` reads from `self` instead of `state`
- `src-tauri/native/terminal-surface/src/font_metrics.rs` — new `FontMetrics` struct with `from_font_size()` constructor and 6 unit tests
- `src-tauri/native/terminal-surface/src/lib.rs` — exports `FontMetrics` module and type
- `src-tauri/native/iced-shell/src/app.rs` — stores `grid` and `font_metrics` directly, constructs `TerminalCanvas` in `view()`

## Test plan
- [x] `cargo check -p godly-terminal-surface` passes
- [x] `cargo test -p godly-terminal-surface` — 11/11 tests pass (5 colors + 6 font_metrics)
- [x] `cargo check -p godly-iced-shell` — downstream consumer compiles
- [x] `cargo check -p godly-protocol -p godly-daemon` — no breakage in unrelated crates