### PR TITLE
feat: terminal state model + tab bar widget (Phase 2, WU-2)

### DIFF
--- a/changelog/unreleased/phase2-wu2-terminal-state-tabbar.md
+++ b/changelog/unreleased/phase2-wu2-terminal-state-tabbar.md
@@ -1,0 +1,3 @@
+### Added
+- **Multi-terminal state model** — `TerminalCollection` tracks multiple terminal sessions with active tab selection, auto-order, and tab label priority (title > process_name > fallback)
+- **Tab bar widget** — generic Iced tab bar component with add/close/switch tab support, active tab highlighting, and dark theme styling

--- a/src-tauri/native/iced-shell/Cargo.toml
+++ b/src-tauri/native/iced-shell/Cargo.toml
@@ -18,3 +18,5 @@ log = "0.4"
 env_logger = "0.11"
 uuid.workspace = true
 futures-channel = "0.3"
+futures = "0.3"
+parking_lot.workspace = true

--- a/src-tauri/native/iced-shell/src/lib.rs
+++ b/src-tauri/native/iced-shell/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod app;
 pub mod subscription;
+pub mod tab_bar;
+pub mod terminal_state;

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -1,0 +1,103 @@
+use iced::widget::{button, container, row, text};
+use iced::{Border, Color, Element, Length, Padding};
+
+use crate::terminal_state::TerminalInfo;
+
+/// Height of the tab bar in logical pixels.
+pub const TAB_BAR_HEIGHT: f32 = 32.0;
+
+// Colors
+const TAB_BAR_BG: Color = Color::from_rgb(0.08, 0.08, 0.10);
+const ACTIVE_TAB_BG: Color = Color::from_rgb(0.2, 0.2, 0.25);
+const INACTIVE_TAB_BG: Color = Color::from_rgb(0.12, 0.12, 0.15);
+const TAB_TEXT_COLOR: Color = Color::from_rgb(0.85, 0.85, 0.85);
+const CLOSE_HOVER_BG: Color = Color::from_rgb(0.35, 0.15, 0.15);
+
+/// Renders the tab bar as a horizontal row of tab buttons.
+///
+/// This function is generic over the message type so it can be used
+/// independently of any specific app `Message` enum.
+pub fn view_tab_bar<'a, M: Clone + 'a>(
+    terminals: &'a [TerminalInfo],
+    active_id: Option<&str>,
+    on_tab_click: impl Fn(String) -> M + 'a,
+    on_close: impl Fn(String) -> M + 'a,
+    on_new: M,
+) -> Element<'a, M> {
+    let mut tabs = row![].spacing(1);
+
+    for terminal in terminals {
+        let is_active = active_id == Some(terminal.id.as_str());
+        let bg = if is_active {
+            ACTIVE_TAB_BG
+        } else {
+            INACTIVE_TAB_BG
+        };
+
+        let label = text(terminal.tab_label())
+            .size(13)
+            .color(TAB_TEXT_COLOR);
+
+        let close_id = terminal.id.clone();
+        let close_btn = button(text("\u{00D7}").size(14).color(TAB_TEXT_COLOR))
+            .on_press(on_close(close_id))
+            .padding(Padding::from([0, 4]))
+            .style(move |_theme, status| {
+                let bg_color = match status {
+                    button::Status::Hovered | button::Status::Pressed => CLOSE_HOVER_BG,
+                    _ => Color::TRANSPARENT,
+                };
+                button::Style {
+                    background: Some(iced::Background::Color(bg_color)),
+                    text_color: TAB_TEXT_COLOR,
+                    border: Border::default(),
+                    ..button::Style::default()
+                }
+            });
+
+        let tab_content = row![label, close_btn]
+            .spacing(4)
+            .align_y(iced::Alignment::Center);
+
+        let tab_id = terminal.id.clone();
+        let tab_btn = button(tab_content)
+            .on_press(on_tab_click(tab_id))
+            .padding(Padding::from([4, 10]))
+            .style(move |_theme, _status| button::Style {
+                background: Some(iced::Background::Color(bg)),
+                text_color: TAB_TEXT_COLOR,
+                border: Border::default(),
+                ..button::Style::default()
+            });
+
+        tabs = tabs.push(tab_btn);
+    }
+
+    // "+" button to add new terminals.
+    let new_btn = button(text("+").size(14).color(TAB_TEXT_COLOR))
+        .on_press(on_new)
+        .padding(Padding::from([4, 10]))
+        .style(|_theme, status| {
+            let bg_color = match status {
+                button::Status::Hovered | button::Status::Pressed => ACTIVE_TAB_BG,
+                _ => Color::TRANSPARENT,
+            };
+            button::Style {
+                background: Some(iced::Background::Color(bg_color)),
+                text_color: TAB_TEXT_COLOR,
+                border: Border::default(),
+                ..button::Style::default()
+            }
+        });
+
+    tabs = tabs.push(new_btn);
+
+    container(tabs)
+        .width(Length::Fill)
+        .height(Length::Fixed(TAB_BAR_HEIGHT))
+        .style(|_theme| container::Style {
+            background: Some(iced::Background::Color(TAB_BAR_BG)),
+            ..container::Style::default()
+        })
+        .into()
+}

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -1,0 +1,322 @@
+use godly_protocol::types::RichGridData;
+
+/// Information about a single terminal session.
+pub struct TerminalInfo {
+    pub id: String,
+    pub title: String,
+    pub process_name: String,
+    pub order: u32,
+    pub grid: Option<RichGridData>,
+    pub dirty: bool,
+    pub fetching: bool,
+    pub rows: u16,
+    pub cols: u16,
+    pub exited: bool,
+    pub exit_code: Option<i64>,
+}
+
+impl TerminalInfo {
+    /// Returns the display label for this terminal's tab.
+    ///
+    /// Priority: title > process_name > "Terminal"
+    pub fn tab_label(&self) -> &str {
+        if !self.title.is_empty() {
+            &self.title
+        } else if !self.process_name.is_empty() {
+            &self.process_name
+        } else {
+            "Terminal"
+        }
+    }
+}
+
+/// Collection of terminal sessions with active tab tracking.
+pub struct TerminalCollection {
+    terminals: Vec<TerminalInfo>,
+    active_id: Option<String>,
+    next_order: u32,
+}
+
+impl TerminalCollection {
+    /// Creates an empty collection.
+    pub fn new() -> Self {
+        Self {
+            terminals: Vec::new(),
+            active_id: None,
+            next_order: 0,
+        }
+    }
+
+    /// Adds a new terminal with the given id and grid dimensions.
+    ///
+    /// Auto-increments the order counter. Sets as active if this is the first terminal.
+    /// Returns a mutable reference to the newly created `TerminalInfo`.
+    pub fn add(&mut self, id: String, rows: u16, cols: u16) -> &mut TerminalInfo {
+        let order = self.next_order;
+        self.next_order += 1;
+
+        let is_first = self.terminals.is_empty();
+
+        self.terminals.push(TerminalInfo {
+            id: id.clone(),
+            title: String::new(),
+            process_name: String::new(),
+            order,
+            grid: None,
+            dirty: false,
+            fetching: false,
+            rows,
+            cols,
+            exited: false,
+            exit_code: None,
+        });
+
+        if is_first {
+            self.active_id = Some(id.clone());
+        }
+
+        // Return mutable reference to the last element (the one we just pushed).
+        self.terminals.last_mut().unwrap()
+    }
+
+    /// Removes the terminal with the given id.
+    ///
+    /// If the removed terminal was active, the next terminal at the same index
+    /// (or the previous one if at the end) becomes active.
+    pub fn remove(&mut self, id: &str) {
+        let Some(idx) = self.terminals.iter().position(|t| t.id == id) else {
+            return;
+        };
+
+        let was_active = self.active_id.as_deref() == Some(id);
+        self.terminals.remove(idx);
+
+        if was_active {
+            if self.terminals.is_empty() {
+                self.active_id = None;
+            } else {
+                // Prefer same index (next terminal), or fall back to previous.
+                let new_idx = if idx < self.terminals.len() {
+                    idx
+                } else {
+                    self.terminals.len() - 1
+                };
+                self.active_id = Some(self.terminals[new_idx].id.clone());
+            }
+        }
+    }
+
+    /// Returns a reference to the active terminal, if any.
+    pub fn active(&self) -> Option<&TerminalInfo> {
+        let id = self.active_id.as_deref()?;
+        self.terminals.iter().find(|t| t.id == id)
+    }
+
+    /// Returns a mutable reference to the active terminal, if any.
+    pub fn active_mut(&mut self) -> Option<&mut TerminalInfo> {
+        let id = self.active_id.as_deref()?.to_owned();
+        self.terminals.iter_mut().find(|t| t.id == id)
+    }
+
+    /// Finds a terminal by id.
+    pub fn get(&self, id: &str) -> Option<&TerminalInfo> {
+        self.terminals.iter().find(|t| t.id == id)
+    }
+
+    /// Finds a terminal by id, mutably.
+    pub fn get_mut(&mut self, id: &str) -> Option<&mut TerminalInfo> {
+        self.terminals.iter_mut().find(|t| t.id == id)
+    }
+
+    /// Sets the active terminal by id. No-op if id not found.
+    pub fn set_active(&mut self, id: &str) {
+        if self.terminals.iter().any(|t| t.id == id) {
+            self.active_id = Some(id.to_owned());
+        }
+    }
+
+    /// Returns the number of terminals in the collection.
+    pub fn count(&self) -> usize {
+        self.terminals.len()
+    }
+
+    /// Iterates over all terminals.
+    pub fn iter(&self) -> impl Iterator<Item = &TerminalInfo> {
+        self.terminals.iter()
+    }
+
+    /// Returns all terminals as a slice.
+    pub fn as_slice(&self) -> &[TerminalInfo] {
+        &self.terminals
+    }
+
+    /// Returns the active terminal's id, if any.
+    pub fn active_id(&self) -> Option<&str> {
+        self.active_id.as_deref()
+    }
+}
+
+impl Default for TerminalCollection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_first_becomes_active() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        assert_eq!(col.active_id(), Some("t1"));
+        assert_eq!(col.count(), 1);
+    }
+
+    #[test]
+    fn test_add_second_does_not_change_active() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        assert_eq!(col.active_id(), Some("t1"));
+        assert_eq!(col.count(), 2);
+    }
+
+    #[test]
+    fn test_remove_active_picks_next() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        // Active is t1 (first added). Remove it -> t2 should become active (same index 0).
+        col.remove("t1");
+        assert_eq!(col.active_id(), Some("t2"));
+        assert_eq!(col.count(), 2);
+
+        // Remove t2 (active) -> t3 should become active.
+        col.remove("t2");
+        assert_eq!(col.active_id(), Some("t3"));
+        assert_eq!(col.count(), 1);
+
+        // Remove last terminal -> no active.
+        col.remove("t3");
+        assert_eq!(col.active_id(), None);
+        assert_eq!(col.count(), 0);
+    }
+
+    #[test]
+    fn test_remove_last_active_picks_previous() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        // Make t3 active, then remove it -> should pick t2 (previous).
+        col.set_active("t3");
+        assert_eq!(col.active_id(), Some("t3"));
+        col.remove("t3");
+        assert_eq!(col.active_id(), Some("t2"));
+    }
+
+    #[test]
+    fn test_remove_non_active_preserves_active() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        // Active is t1. Remove t2 -> active should still be t1.
+        col.remove("t2");
+        assert_eq!(col.active_id(), Some("t1"));
+        assert_eq!(col.count(), 2);
+    }
+
+    #[test]
+    fn test_tab_label_priority() {
+        let mut col = TerminalCollection::new();
+
+        // No title, no process_name -> "Terminal"
+        let info = col.add("t1".into(), 24, 80);
+        assert_eq!(info.tab_label(), "Terminal");
+
+        // process_name set, no title -> process_name
+        info.process_name = "pwsh".into();
+        assert_eq!(info.tab_label(), "pwsh");
+
+        // title set -> title takes priority
+        info.title = "My Shell".into();
+        assert_eq!(info.tab_label(), "My Shell");
+    }
+
+    #[test]
+    fn test_get_and_get_mut() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 30, 100);
+
+        // get
+        let t1 = col.get("t1").unwrap();
+        assert_eq!(t1.rows, 24);
+        assert_eq!(t1.cols, 80);
+
+        let t2 = col.get("t2").unwrap();
+        assert_eq!(t2.rows, 30);
+        assert_eq!(t2.cols, 100);
+
+        assert!(col.get("nonexistent").is_none());
+
+        // get_mut
+        {
+            let t1_mut = col.get_mut("t1").unwrap();
+            t1_mut.dirty = true;
+        }
+        assert!(col.get("t1").unwrap().dirty);
+
+        assert!(col.get_mut("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_set_active_nonexistent_is_noop() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.set_active("nonexistent");
+        assert_eq!(col.active_id(), Some("t1"));
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        let ids: Vec<&str> = col.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids, vec!["t1", "t2", "t3"]);
+    }
+
+    #[test]
+    fn test_order_auto_increments() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        let orders: Vec<u32> = col.iter().map(|t| t.order).collect();
+        assert_eq!(orders, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_active_and_active_mut() {
+        let mut col = TerminalCollection::new();
+        assert!(col.active().is_none());
+        assert!(col.active_mut().is_none());
+
+        col.add("t1".into(), 24, 80);
+        assert_eq!(col.active().unwrap().id, "t1");
+
+        col.active_mut().unwrap().title = "Hello".into();
+        assert_eq!(col.active().unwrap().title, "Hello");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 Work Unit 2 of the native Iced shell: terminal state model and tab bar widget.

- **`terminal_state.rs`** — `TerminalCollection` data model tracking multiple terminal sessions with active tab selection, auto-incrementing order, and tab label priority (title > process_name > "Terminal" fallback). Includes `TerminalInfo` struct with grid state, dirty/fetching flags, and exit tracking.
- **`tab_bar.rs`** — Generic `view_tab_bar()` function using Iced built-in widgets (`button`, `text`, `row`, `container`). Dark theme styling with active/inactive tab colors, close buttons per tab, and a "+" new-tab button. Generic over message type for independent compilation.
- **`lib.rs`** — Added `pub mod tab_bar` and `pub mod terminal_state` declarations.
- **`Cargo.toml`** — Added `futures` and `parking_lot` dependencies (needed by existing `subscription.rs` for test compilation).

## Tests

11 unit tests covering:
- First terminal auto-becomes active
- Adding subsequent terminals preserves active selection
- Removing active terminal picks next (or previous if at end)
- Removing non-active terminal preserves active
- Tab label priority: title > process_name > "Terminal"
- `get`/`get_mut` by ID
- `set_active` with nonexistent ID is a no-op
- Iterator and order auto-increment
- `active()`/`active_mut()` accessors

## Verification

- `cargo check -p godly-iced-shell` passes
- `cargo test -p godly-iced-shell` — 11 tests pass
- `cargo check -p godly-protocol -p godly-daemon` — no breakage