### PR TITLE
feat: Phase 2 multi-terminal + event-driven rendering + tab bar

### DIFF
--- a/changelog/unreleased/phase2-wu3-app-rewrite.md
+++ b/changelog/unreleased/phase2-wu3-app-rewrite.md
@@ -1,0 +1,8 @@
+### Added
+- **Multi-terminal support** — multiple terminal sessions with tab switching in the native Iced shell
+- **Event-driven rendering** — replaced 60fps AtomicBool polling with channel-based daemon event delivery
+- **Window resize handling** — terminal grid auto-resizes when the window is resized
+- **Tab bar UI** — clickable tabs with add/close terminal support
+
+### Changed
+- **App architecture rewrite** — `GodlyApp` now manages `TerminalCollection` instead of a single session

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1,55 +1,48 @@
 use std::sync::Arc;
-use std::time::Duration;
 
+use futures_channel::mpsc;
 use iced::keyboard;
-use iced::widget::{canvas, center, text};
-use iced::{Element, Length, Subscription, Task};
+use iced::widget::{canvas, center, column, text};
+use iced::{event, window, Element, Length, Subscription, Task};
 
 use godly_app_adapter::commands;
-use godly_app_adapter::daemon_client::{FrontendEventSink, NativeDaemonClient};
+use godly_app_adapter::daemon_client::NativeDaemonClient;
 use godly_app_adapter::keys::key_to_pty_bytes;
 use godly_protocol::types::RichGridData;
 
 use godly_terminal_surface::{FontMetrics, TerminalCanvas};
 
-use crate::subscription::DaemonEventMsg;
+use crate::subscription::{daemon_events, ChannelEventSink, DaemonEventMsg};
+use crate::tab_bar::{self, TAB_BAR_HEIGHT};
+use crate::terminal_state::TerminalCollection;
 
-/// Main Iced application state.
+/// Main Iced application state — multi-terminal with event-driven updates.
 pub struct GodlyApp {
     /// Daemon client (shared with bridge thread).
     client: Option<Arc<NativeDaemonClient>>,
-    /// Current session ID.
-    session_id: Option<String>,
-    /// Current grid data from daemon.
-    grid: Option<RichGridData>,
-    /// Font metrics for terminal rendering.
-    font_metrics: FontMetrics,
-    /// Window title from terminal.
-    terminal_title: String,
+    /// All terminal sessions.
+    terminals: TerminalCollection,
     /// Error message to display if initialization failed.
     init_error: Option<String>,
-    /// Grid dimensions in cells.
-    grid_rows: u16,
-    grid_cols: u16,
-    /// Whether a grid fetch is currently in flight.
-    fetching_grid: bool,
-    /// Pending output flag — set by event sink, cleared by grid fetch.
-    has_pending_output: Arc<std::sync::atomic::AtomicBool>,
+    /// Event receiver for the daemon subscription (taken once by the subscription).
+    event_receiver: Arc<parking_lot::Mutex<Option<mpsc::UnboundedReceiver<DaemonEventMsg>>>>,
+    /// Window dimensions in logical pixels.
+    window_width: f32,
+    window_height: f32,
+    /// Font metrics for cell sizing and grid dimension calculations.
+    font_metrics: FontMetrics,
 }
 
 impl Default for GodlyApp {
     fn default() -> Self {
         Self {
             client: None,
-            session_id: None,
-            grid: None,
-            font_metrics: FontMetrics::default(),
-            terminal_title: String::new(),
+            terminals: TerminalCollection::new(),
             init_error: None,
-            grid_rows: 24,
-            grid_cols: 80,
-            fetching_grid: false,
-            has_pending_output: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            event_receiver: Arc::new(parking_lot::Mutex::new(None)),
+            window_width: 1200.0,
+            window_height: 800.0,
+            font_metrics: FontMetrics::default(),
         }
     }
 }
@@ -59,16 +52,27 @@ impl Default for GodlyApp {
 pub enum Message {
     /// Daemon event received from bridge thread.
     DaemonEvent(DaemonEventMsg),
-    /// Grid snapshot fetched after output event.
-    GridFetched(RichGridData),
-    /// Grid fetch failed (log only).
-    GridFetchFailed(String),
+    /// Grid snapshot fetched for a specific session.
+    GridFetched {
+        session_id: String,
+        grid: RichGridData,
+    },
+    /// Grid fetch failed for a specific session.
+    GridFetchFailed { session_id: String, error: String },
     /// Keyboard event from iced.
     KeyboardEvent(keyboard::Event),
     /// Initialization complete.
     Initialized(Result<InitResult, String>),
-    /// Timer tick for polling daemon events.
-    Tick,
+    /// User clicked a tab.
+    TabClicked(String),
+    /// User wants a new terminal.
+    NewTabRequested,
+    /// User wants to close a terminal.
+    CloseTabRequested(String),
+    /// New terminal created by daemon.
+    TerminalCreated(Result<String, String>),
+    /// Window was resized.
+    WindowResized { width: f32, height: f32 },
 }
 
 #[derive(Debug, Clone)]
@@ -76,88 +80,132 @@ pub struct InitResult {
     pub session_id: String,
 }
 
-/// Event sink implementation that sets an atomic flag.
-/// The iced app polls this flag on timer ticks.
-struct AtomicEventSink {
-    has_output: Arc<std::sync::atomic::AtomicBool>,
-}
-
-impl FrontendEventSink for AtomicEventSink {
-    fn on_terminal_output(&self, _session_id: &str) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_session_closed(&self, _session_id: &str, _exit_code: Option<i64>) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_process_changed(&self, _session_id: &str, _process_name: &str) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_grid_diff(&self, _session_id: &str, _diff_bytes: &[u8]) {
-        self.has_output
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn on_bell(&self, _session_id: &str) {}
-}
-
 impl GodlyApp {
     pub fn title(&self) -> String {
-        if !self.terminal_title.is_empty() {
-            format!("{} — Godly Terminal (Native)", self.terminal_title)
-        } else {
-            format!(
-                "Godly Terminal (Native) — contract v{}",
-                godly_protocol::FRONTEND_CONTRACT_VERSION
-            )
+        if let Some(active) = self.terminals.active() {
+            let label: &str = active.tab_label();
+            if label != "Terminal" {
+                return format!("{} — Godly Terminal (Native)", label);
+            }
         }
+        format!(
+            "Godly Terminal (Native) — contract v{}",
+            godly_protocol::FRONTEND_CONTRACT_VERSION
+        )
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::Initialized(Ok(result)) => {
-                self.session_id = Some(result.session_id);
-                return self.fetch_grid();
+                let rows = self.calculate_rows();
+                let cols = self.calculate_cols();
+                self.terminals.add(result.session_id.clone(), rows, cols);
+                return self.fetch_grid(&result.session_id);
             }
             Message::Initialized(Err(e)) => {
                 log::error!("Initialization failed: {}", e);
                 self.init_error = Some(e);
             }
-            Message::Tick => {
-                // Poll for pending output from the daemon event sink
-                if self
-                    .has_pending_output
-                    .swap(false, std::sync::atomic::Ordering::Relaxed)
-                    && !self.fetching_grid
-                {
-                    return self.fetch_grid();
+
+            // --- Daemon events (channel-driven, no polling) ---
+            Message::DaemonEvent(DaemonEventMsg::TerminalOutput { session_id }) => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.dirty = true;
+                }
+                return self.fetch_grid(&session_id);
+            }
+            Message::DaemonEvent(DaemonEventMsg::SessionClosed {
+                session_id,
+                exit_code,
+            }) => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.exited = true;
+                    term.exit_code = exit_code;
+                }
+                log::info!(
+                    "Session {} closed (exit_code={:?})",
+                    session_id,
+                    exit_code
+                );
+            }
+            Message::DaemonEvent(DaemonEventMsg::ProcessChanged {
+                session_id,
+                process_name,
+            }) => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.process_name = process_name;
                 }
             }
-            Message::DaemonEvent(_) => {}
-            Message::GridFetched(grid) => {
-                self.fetching_grid = false;
-                self.terminal_title = grid.title.clone();
-                self.grid = Some(grid);
+            Message::DaemonEvent(DaemonEventMsg::Bell { session_id }) => {
+                log::debug!("Bell from session {}", session_id);
             }
-            Message::GridFetchFailed(e) => {
-                self.fetching_grid = false;
-                log::error!("Grid fetch failed: {}", e);
+
+            // --- Grid fetch results ---
+            Message::GridFetched { session_id, grid } => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.fetching = false;
+                    term.dirty = false;
+                    term.title = grid.title.clone();
+                    term.grid = Some(grid);
+                }
             }
+            Message::GridFetchFailed { session_id, error } => {
+                if let Some(term) = self.terminals.get_mut(&session_id) {
+                    term.fetching = false;
+                }
+                log::error!("Grid fetch failed for {}: {}", session_id, error);
+            }
+
+            // --- Keyboard input ---
             Message::KeyboardEvent(keyboard::Event::KeyPressed {
                 key, modifiers, ..
             }) => {
                 if let Some(bytes) = key_to_pty_bytes(&key, modifiers) {
-                    if let (Some(client), Some(sid)) = (&self.client, &self.session_id) {
-                        let _ = commands::write_to_terminal(client, sid, &bytes);
+                    if let Some(active_id) = self.terminals.active_id().map(str::to_string) {
+                        if let Some(client) = &self.client {
+                            let _ = commands::write_to_terminal(client, &active_id, &bytes);
+                        }
                     }
                 }
             }
             Message::KeyboardEvent(_) => {}
+
+            // --- Tab management ---
+            Message::TabClicked(id) => {
+                self.terminals.set_active(&id);
+            }
+            Message::NewTabRequested => {
+                return self.create_new_terminal();
+            }
+            Message::CloseTabRequested(id) => {
+                return self.close_terminal(&id);
+            }
+            Message::TerminalCreated(Ok(session_id)) => {
+                let rows = self.calculate_rows();
+                let cols = self.calculate_cols();
+                self.terminals.add(session_id.clone(), rows, cols);
+                self.terminals.set_active(&session_id);
+                return self.fetch_grid(&session_id);
+            }
+            Message::TerminalCreated(Err(e)) => {
+                log::error!("Failed to create terminal: {}", e);
+            }
+
+            // --- Window resize ---
+            Message::WindowResized { width, height } => {
+                let old_cols = self.calculate_cols();
+                let old_rows = self.calculate_rows();
+
+                self.window_width = width;
+                self.window_height = height;
+
+                let new_cols = self.calculate_cols();
+                let new_rows = self.calculate_rows();
+
+                if new_cols != old_cols || new_rows != old_rows {
+                    return self.resize_active_terminal(new_rows, new_cols);
+                }
+            }
         }
         Task::none()
     }
@@ -167,62 +215,183 @@ impl GodlyApp {
             return center(text(format!("Initialization error: {}", err)).size(18)).into();
         }
 
-        if self.session_id.is_none() && self.client.is_none() {
+        if self.client.is_none() && self.terminals.count() == 0 {
             return center(text("Connecting to daemon...").size(18)).into();
         }
 
-        if self.session_id.is_none() {
-            return center(text("Session closed").size(18)).into();
-        }
+        let active_id = self.terminals.active_id();
 
-        canvas(TerminalCanvas {
-            grid: self.grid.clone(),
-            metrics: self.font_metrics,
-        })
-        .width(Length::Fill)
-        .height(Length::Fill)
-        .into()
+        // Tab bar.
+        let tab_bar = tab_bar::view_tab_bar(
+            self.terminals.as_slice(),
+            active_id,
+            |id| Message::TabClicked(id),
+            |id| Message::CloseTabRequested(id),
+            Message::NewTabRequested,
+        );
+
+        // Active terminal canvas — TerminalCanvas carries grid data directly.
+        let terminal_view: Element<'_, Message> = if let Some(active) = self.terminals.active() {
+            let tc = TerminalCanvas {
+                grid: active.grid.clone(),
+                metrics: self.font_metrics,
+            };
+            canvas(tc)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        } else {
+            center(text("No active terminal").size(16)).into()
+        };
+
+        column![tab_bar, terminal_view].into()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
         Subscription::batch([
-            // Keyboard events
+            // Keyboard events.
             keyboard::listen().map(Message::KeyboardEvent),
-            // Timer for polling daemon events (~16ms = 60fps)
-            iced::time::every(Duration::from_millis(16)).map(|_| Message::Tick),
+            // Daemon events via channel.
+            daemon_events(Arc::clone(&self.event_receiver)).map(Message::DaemonEvent),
+            // Window resize events.
+            event::listen_with(|ev, _status, _window_id| {
+                if let event::Event::Window(window::Event::Resized(size)) = ev {
+                    Some(Message::WindowResized {
+                        width: size.width,
+                        height: size.height,
+                    })
+                } else {
+                    None
+                }
+            }),
         ])
     }
 
-    /// Spawn a background task to fetch the grid snapshot.
-    fn fetch_grid(&mut self) -> Task<Message> {
-        if let (Some(client), Some(sid)) = (&self.client, &self.session_id) {
-            self.fetching_grid = true;
-            let client = Arc::clone(client);
-            let sid = sid.clone();
-            Task::perform(
-                async move {
-                    let (tx, rx) = futures_channel::oneshot::channel();
-                    std::thread::spawn(move || {
-                        let result = commands::get_grid_snapshot(&client, &sid);
-                        let _ = tx.send(result);
-                    });
-                    rx.await
-                        .unwrap_or_else(|_| Err("Background thread panicked".into()))
-                },
-                |result| match result {
-                    Ok(grid) => Message::GridFetched(grid),
-                    Err(e) => Message::GridFetchFailed(e),
-                },
-            )
+    /// Fetch the grid snapshot for a specific session.
+    fn fetch_grid(&mut self, session_id: &str) -> Task<Message> {
+        let Some(client) = &self.client else {
+            return Task::none();
+        };
+
+        if let Some(term) = self.terminals.get_mut(session_id) {
+            if term.fetching {
+                return Task::none();
+            }
+            term.fetching = true;
         } else {
-            Task::none()
+            return Task::none();
         }
+
+        let client = Arc::clone(client);
+        let sid = session_id.to_string();
+        let sid_ok = sid.clone();
+        let sid_err = sid.clone();
+
+        Task::perform(
+            async move {
+                let (tx, rx) = futures_channel::oneshot::channel();
+                std::thread::spawn(move || {
+                    let result = commands::get_grid_snapshot(&client, &sid);
+                    let _ = tx.send(result);
+                });
+                rx.await
+                    .unwrap_or_else(|_| Err("Background thread panicked".into()))
+            },
+            move |result| match result {
+                Ok(grid) => Message::GridFetched {
+                    session_id: sid_ok,
+                    grid,
+                },
+                Err(e) => Message::GridFetchFailed {
+                    session_id: sid_err,
+                    error: e,
+                },
+            },
+        )
+    }
+
+    /// Create a new terminal session via the daemon.
+    fn create_new_terminal(&self) -> Task<Message> {
+        let Some(client) = &self.client else {
+            return Task::done(Message::TerminalCreated(Err(
+                "No daemon connection".to_string(),
+            )));
+        };
+
+        let client = Arc::clone(client);
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let sid = session_id.clone();
+        let rows = self.calculate_rows();
+        let cols = self.calculate_cols();
+
+        Task::perform(
+            async move {
+                let (tx, rx) = futures_channel::oneshot::channel();
+                std::thread::spawn(move || {
+                    let result = commands::create_terminal(
+                        &client,
+                        &sid,
+                        godly_protocol::ShellType::Windows,
+                        None,
+                        rows,
+                        cols,
+                    )
+                    .map(|_| sid);
+                    let _ = tx.send(result);
+                });
+                rx.await
+                    .unwrap_or_else(|_| Err("Background thread panicked".into()))
+            },
+            Message::TerminalCreated,
+        )
+    }
+
+    /// Close a terminal session.
+    fn close_terminal(&mut self, session_id: &str) -> Task<Message> {
+        self.terminals.remove(session_id);
+
+        // Close on daemon (fire-and-forget).
+        if let Some(client) = &self.client {
+            let _ = commands::close_terminal(client, session_id);
+        }
+
+        Task::none()
+    }
+
+    /// Resize the active terminal on the daemon.
+    fn resize_active_terminal(&mut self, rows: u16, cols: u16) -> Task<Message> {
+        let Some(active_id) = self.terminals.active_id().map(str::to_string) else {
+            return Task::none();
+        };
+
+        if let Some(term) = self.terminals.get_mut(&active_id) {
+            term.rows = rows;
+            term.cols = cols;
+        }
+
+        if let Some(client) = &self.client {
+            let _ = commands::resize_terminal(client, &active_id, rows, cols);
+        }
+
+        // Fetch updated grid after resize.
+        self.fetch_grid(&active_id)
+    }
+
+    /// Calculate terminal columns from window width and font metrics.
+    fn calculate_cols(&self) -> u16 {
+        (self.window_width / self.font_metrics.cell_width).max(1.0) as u16
+    }
+
+    /// Calculate terminal rows from window height (minus tab bar) and font metrics.
+    fn calculate_rows(&self) -> u16 {
+        let available = (self.window_height - TAB_BAR_HEIGHT).max(0.0);
+        (available / self.font_metrics.cell_height).max(1.0) as u16
     }
 }
 
-/// Initialize the app: connect to daemon, set up bridge, create session.
+/// Initialize the app: connect to daemon, set up bridge, create first session.
 pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
-    // Connect to daemon
+    // Connect to daemon.
     let client = match NativeDaemonClient::connect_or_launch() {
         Ok(c) => Arc::new(c),
         Err(e) => {
@@ -230,21 +399,25 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
         }
     };
 
-    // Set up bridge with atomic flag event sink
-    let sink = Arc::new(AtomicEventSink {
-        has_output: Arc::clone(&app.has_pending_output),
-    });
+    // Create the event channel.
+    let (tx, rx) = mpsc::unbounded();
+
+    // Store receiver for the subscription to pick up.
+    *app.event_receiver.lock() = Some(rx);
+
+    // Set up bridge with channel event sink.
+    let sink = Arc::new(ChannelEventSink::new(tx));
     if let Err(e) = client.setup_bridge(sink) {
         return Task::done(Message::Initialized(Err(e)));
     }
 
     app.client = Some(Arc::clone(&client));
 
-    // Create a session
+    // Create first session.
     let session_id = uuid::Uuid::new_v4().to_string();
     let sid = session_id.clone();
-    let rows = app.grid_rows;
-    let cols = app.grid_cols;
+    let rows = app.calculate_rows();
+    let cols = app.calculate_cols();
 
     Task::perform(
         async move {
@@ -258,9 +431,7 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
                     rows,
                     cols,
                 )
-                .map(|_| InitResult {
-                    session_id: sid,
-                });
+                .map(|_| InitResult { session_id: sid });
                 let _ = tx.send(result);
             });
             rx.await

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -2,6 +2,8 @@ use iced::window;
 
 mod app;
 mod subscription;
+mod tab_bar;
+mod terminal_state;
 
 use app::{GodlyApp, Message};
 

--- a/src-tauri/native/iced-shell/src/subscription.rs
+++ b/src-tauri/native/iced-shell/src/subscription.rs
@@ -1,3 +1,9 @@
+use std::sync::Arc;
+
+use futures_channel::mpsc;
+
+use godly_app_adapter::daemon_client::FrontendEventSink;
+
 /// Events forwarded from the daemon bridge I/O thread to the Iced app.
 #[derive(Debug, Clone)]
 pub enum DaemonEventMsg {
@@ -8,11 +14,187 @@ pub enum DaemonEventMsg {
         session_id: String,
         exit_code: Option<i64>,
     },
-    /// Process name changed (e.g., shell → vim).
+    /// Process name changed (e.g., shell -> vim).
     ProcessChanged {
         session_id: String,
         process_name: String,
     },
     /// Bell character received.
     Bell { session_id: String },
+}
+
+/// Event sink that sends daemon events through an mpsc channel to iced.
+///
+/// Implements `FrontendEventSink` so it can be handed to the bridge I/O thread.
+/// Events are forwarded as `DaemonEventMsg` values through the unbounded sender.
+pub struct ChannelEventSink {
+    sender: mpsc::UnboundedSender<DaemonEventMsg>,
+}
+
+impl ChannelEventSink {
+    pub fn new(sender: mpsc::UnboundedSender<DaemonEventMsg>) -> Self {
+        Self { sender }
+    }
+}
+
+impl FrontendEventSink for ChannelEventSink {
+    fn on_terminal_output(&self, session_id: &str) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::TerminalOutput {
+            session_id: session_id.to_string(),
+        });
+    }
+
+    fn on_session_closed(&self, session_id: &str, exit_code: Option<i64>) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::SessionClosed {
+            session_id: session_id.to_string(),
+            exit_code,
+        });
+    }
+
+    fn on_process_changed(&self, session_id: &str, process_name: &str) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::ProcessChanged {
+            session_id: session_id.to_string(),
+            process_name: process_name.to_string(),
+        });
+    }
+
+    fn on_grid_diff(&self, session_id: &str, _diff_bytes: &[u8]) {
+        // Grid diffs trigger a terminal output event so the app fetches a fresh snapshot.
+        let _ = self.sender.unbounded_send(DaemonEventMsg::TerminalOutput {
+            session_id: session_id.to_string(),
+        });
+    }
+
+    fn on_bell(&self, session_id: &str) {
+        let _ = self.sender.unbounded_send(DaemonEventMsg::Bell {
+            session_id: session_id.to_string(),
+        });
+    }
+}
+
+/// Creates an iced Subscription that streams DaemonEventMsg values from a channel receiver.
+///
+/// The receiver is wrapped in an `Arc<parking_lot::Mutex<Option<...>>>` so it can be
+/// taken exactly once by the subscription stream. Subsequent calls (from iced's
+/// subscription deduplication) will produce an empty stream since the receiver is gone.
+pub fn daemon_events(
+    receiver: Arc<parking_lot::Mutex<Option<mpsc::UnboundedReceiver<DaemonEventMsg>>>>,
+) -> iced::Subscription<DaemonEventMsg> {
+    use iced::advanced::subscription::{self, EventStream, Hasher, Recipe};
+    use std::hash::Hash;
+
+    struct DaemonEventRecipe {
+        receiver: Arc<parking_lot::Mutex<Option<mpsc::UnboundedReceiver<DaemonEventMsg>>>>,
+    }
+
+    impl Recipe for DaemonEventRecipe {
+        type Output = DaemonEventMsg;
+
+        fn hash(&self, state: &mut Hasher) {
+            std::any::TypeId::of::<Self>().hash(state);
+        }
+
+        fn stream(
+            self: Box<Self>,
+            _input: EventStream,
+        ) -> futures::stream::BoxStream<'static, Self::Output> {
+            if let Some(rx) = self.receiver.lock().take() {
+                Box::pin(rx)
+            } else {
+                // Receiver already taken — return an empty stream that never completes.
+                // This keeps the subscription alive (iced won't re-create it).
+                Box::pin(futures::stream::pending())
+            }
+        }
+    }
+
+    subscription::from_recipe(DaemonEventRecipe { receiver })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_event_sink_sends_output() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_terminal_output("sess1");
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::TerminalOutput { session_id })) => {
+                assert_eq!(session_id, "sess1");
+            }
+            other => panic!("Expected TerminalOutput, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_sends_session_closed() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_session_closed("sess2", Some(0));
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::SessionClosed {
+                session_id,
+                exit_code,
+            })) => {
+                assert_eq!(session_id, "sess2");
+                assert_eq!(exit_code, Some(0));
+            }
+            other => panic!("Expected SessionClosed, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_sends_process_changed() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_process_changed("sess3", "vim");
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::ProcessChanged {
+                session_id,
+                process_name,
+            })) => {
+                assert_eq!(session_id, "sess3");
+                assert_eq!(process_name, "vim");
+            }
+            other => panic!("Expected ProcessChanged, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_sends_bell() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_bell("sess4");
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::Bell { session_id })) => {
+                assert_eq!(session_id, "sess4");
+            }
+            other => panic!("Expected Bell, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn channel_event_sink_grid_diff_becomes_output() {
+        let (tx, mut rx) = mpsc::unbounded();
+        let sink = ChannelEventSink::new(tx);
+
+        sink.on_grid_diff("sess5", &[1, 2, 3]);
+
+        match rx.try_next() {
+            Ok(Some(DaemonEventMsg::TerminalOutput { session_id })) => {
+                assert_eq!(session_id, "sess5");
+            }
+            other => panic!("Expected TerminalOutput from grid_diff, got: {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **Multi-terminal support** — `GodlyApp` manages `TerminalCollection` instead of a single session, with per-session grid fetching
- **Event-driven rendering** — replaced 60fps `AtomicBool` polling with `ChannelEventSink` + `mpsc` channel subscription (zero CPU when idle)
- **Tab bar UI** — clickable tabs with add/close/switch terminal support via generic `view_tab_bar` component
- **Window resize handling** — terminal grid auto-resizes using `FontMetrics` heuristic when the window is resized

Integrates on top of PR #545 (surface refactor + font metrics) and PR #546 (terminal state model + tab bar widget).

Supersedes #544 which was built in a parallel worktree and didn't account for the WU-1 API changes.

## Test plan
- [x] `cargo check -p godly-iced-shell` — compiles cleanly
- [x] `cargo test -p godly-iced-shell` — 16/16 tests pass (lib + bin)
- [x] `cargo check -p godly-protocol -p godly-daemon` — no breakage
- [ ] Manual: `cargo build -p godly-daemon && cargo run -p godly-iced-shell` → verify terminal renders
- [ ] Manual: Click "+" to add a second tab, switch between tabs
- [ ] Manual: Close a tab with "x"
- [ ] Manual: Resize window — terminal should resize with it