### PR TITLE
feat: add bold/italic text rendering to native shell (Phase 3 WU-2)

### DIFF
--- a/changelog/unreleased/phase3-wu2-bold-italic.md
+++ b/changelog/unreleased/phase3-wu2-bold-italic.md
@@ -1,0 +1,2 @@
+### Added
+- **Bold and italic text rendering in native shell** — bold cells use heavier font weight with brightened colors, italic cells use italic font style

--- a/src-tauri/native/terminal-surface/src/colors.rs
+++ b/src-tauri/native/terminal-surface/src/colors.rs
@@ -26,6 +26,19 @@ pub fn dim_color(color: Color) -> Color {
     Color::from_rgba(color.r * 0.5, color.g * 0.5, color.b * 0.5, color.a)
 }
 
+/// Brighten a color by 20% (clamped to 1.0).
+///
+/// Used for bold text rendering — most terminal emulators display bold text
+/// with slightly brighter foreground colors.
+pub fn brighten_color(color: Color) -> Color {
+    Color {
+        r: (color.r * 1.2).min(1.0),
+        g: (color.g * 1.2).min(1.0),
+        b: (color.b * 1.2).min(1.0),
+        a: color.a,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -66,5 +79,27 @@ mod tests {
         assert!((c.r - 0.5).abs() < 0.01);
         assert!((c.g - 0.4).abs() < 0.01);
         assert!((c.b - 0.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn brighten_increases_by_20_percent() {
+        let c = brighten_color(Color::from_rgb(0.5, 0.4, 0.3));
+        assert!((c.r - 0.6).abs() < 0.01);
+        assert!((c.g - 0.48).abs() < 0.01);
+        assert!((c.b - 0.36).abs() < 0.01);
+    }
+
+    #[test]
+    fn brighten_clamps_to_1() {
+        let c = brighten_color(Color::from_rgb(0.9, 1.0, 0.85));
+        assert!((c.r - 1.0).abs() < 0.01); // 0.9 * 1.2 = 1.08 → clamped to 1.0
+        assert!((c.g - 1.0).abs() < 0.01); // 1.0 * 1.2 = 1.2 → clamped to 1.0
+        assert!((c.b - 1.0).abs() < 0.01); // 0.85 * 1.2 = 1.02 → clamped to 1.0
+    }
+
+    #[test]
+    fn brighten_preserves_alpha() {
+        let c = brighten_color(Color::from_rgba(0.5, 0.5, 0.5, 0.7));
+        assert!((c.a - 0.7).abs() < 0.01);
     }
 }

--- a/src-tauri/native/terminal-surface/src/surface.rs
+++ b/src-tauri/native/terminal-surface/src/surface.rs
@@ -4,7 +4,7 @@ use iced::{Color, Font, Pixels, Point, Rectangle, Renderer, Size, Theme};
 
 use godly_protocol::types::RichGridData;
 
-use crate::colors::{dim_color, parse_color};
+use crate::colors::{brighten_color, dim_color, parse_color};
 use crate::font_metrics::FontMetrics;
 
 /// Default terminal foreground (light gray).
@@ -119,6 +119,11 @@ impl<Message> canvas::Program<Message> for TerminalCanvas {
                     fg = dim_color(fg);
                 }
 
+                // Bold brightening (most terminals render bold as brighter)
+                if cell.bold {
+                    fg = brighten_color(fg);
+                }
+
                 // Draw background (only if non-default to avoid overdraw)
                 if bg.r != DEFAULT_BG.r || bg.g != DEFAULT_BG.g || bg.b != DEFAULT_BG.b {
                     frame.fill_rectangle(
@@ -128,6 +133,24 @@ impl<Message> canvas::Program<Message> for TerminalCanvas {
                     );
                 }
 
+                // Determine font variant based on cell attributes
+                let cell_font = match (cell.bold, cell.italic) {
+                    (false, false) => monospace,
+                    (true, false) => Font {
+                        weight: iced::font::Weight::Bold,
+                        ..monospace
+                    },
+                    (false, true) => Font {
+                        style: iced::font::Style::Italic,
+                        ..monospace
+                    },
+                    (true, true) => Font {
+                        weight: iced::font::Weight::Bold,
+                        style: iced::font::Style::Italic,
+                        ..monospace
+                    },
+                };
+
                 // Draw text content
                 if !cell.content.is_empty() && cell.content != " " {
                     let text = canvas::Text {
@@ -135,7 +158,7 @@ impl<Message> canvas::Program<Message> for TerminalCanvas {
                         position: Point::new(x, y),
                         color: fg,
                         size: Pixels(font_size),
-                        font: monospace,
+                        font: cell_font,
                         ..canvas::Text::default()
                     };
                     frame.fill_text(text);


### PR DESCRIPTION
## Summary

- Add bold and italic text rendering support to the native Iced terminal surface
- Bold cells use `Font::Weight::Bold` with 20% brighter foreground colors (matching standard terminal behavior)
- Italic cells use `Font::Style::Italic`
- Bold+italic cells combine both attributes
- Add `brighten_color` helper in `colors.rs` alongside existing `dim_color`
- Add 3 unit tests for the new `brighten_color` function (brightness increase, clamping, alpha preservation)

## Test plan

- [x] `cargo check -p godly-terminal-surface` passes
- [x] `cargo test -p godly-terminal-surface` — 14 tests pass (including 3 new brighten tests)
- [x] `cargo check -p godly-protocol` — no breakage
- [x] `cargo check -p godly-daemon` — no breakage

## Changed files

- `src-tauri/native/terminal-surface/src/surface.rs` — font variant selection per cell, bold brightening
- `src-tauri/native/terminal-surface/src/colors.rs` — `brighten_color()` helper + tests
- `changelog/unreleased/phase3-wu2-bold-italic.md` — changelog fragment