### PR TITLE
feat: add session recovery commands for native shell (Phase 3 WU-4)

### DIFF
--- a/changelog/unreleased/phase3-wu4-session-recovery.md
+++ b/changelog/unreleased/phase3-wu4-session-recovery.md
@@ -1,0 +1,2 @@
+### Added
+- **Session recovery commands for native shell** — `list_sessions()` discovers surviving daemon sessions on restart, `detach_all_sessions()` for clean shutdown (Phase 3 WU-4)

--- a/src-tauri/native/app-adapter/src/commands.rs
+++ b/src-tauri/native/app-adapter/src/commands.rs
@@ -1,4 +1,4 @@
-use godly_protocol::types::RichGridData;
+use godly_protocol::types::{RichGridData, SessionInfo};
 use godly_protocol::{Request, Response, ShellType};
 
 use crate::daemon_client::NativeDaemonClient;
@@ -160,4 +160,32 @@ pub fn scroll_and_get_snapshot(
         Response::Error { message } => Err(message),
         other => Err(format!("Unexpected scroll+grid response: {:?}", other)),
     }
+}
+
+/// List all live sessions on the daemon.
+///
+/// Used for session recovery on app restart — discovers sessions
+/// that survived from a previous app instance.
+pub fn list_sessions(client: &NativeDaemonClient) -> Result<Vec<SessionInfo>, String> {
+    let response = client.send_request(&Request::ListSessions)?;
+    match response {
+        Response::SessionList { sessions } => Ok(sessions),
+        Response::Error { message } => Err(message),
+        other => Err(format!("Unexpected list response: {:?}", other)),
+    }
+}
+
+/// Detach from all sessions for clean shutdown.
+///
+/// Errors are logged but not propagated — best-effort cleanup.
+pub fn detach_all_sessions(
+    client: &NativeDaemonClient,
+    session_ids: &[String],
+) -> Result<(), String> {
+    for id in session_ids {
+        if let Err(e) = detach_session(client, id) {
+            log::warn!("Failed to detach session {}: {}", id, e);
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `list_sessions()` to discover surviving daemon sessions on app restart (session recovery)
- Add `detach_all_sessions()` for best-effort clean shutdown (logs errors instead of propagating)
- Import `SessionInfo` type from `godly_protocol::types`

Part of Phase 3 native Iced shell work — these commands enable the native frontend to recover sessions from a previous app instance and cleanly detach on shutdown.

## Test plan

- [x] `cargo check -p godly-app-adapter` passes
- [x] `cargo test -p godly-app-adapter` — 9 tests pass
- [x] `cargo check -p godly-protocol -p godly-daemon` — no downstream breakage