### PR TITLE
feat: add shortcuts, scrollback, recovery, and zoom to native shell (Phase 3 WU-5)

### DIFF
--- a/changelog/unreleased/phase3-wu5-integration.md
+++ b/changelog/unreleased/phase3-wu5-integration.md
@@ -1,0 +1,5 @@
+### Added
+- **Keyboard shortcuts in native shell** — Ctrl+T/W for tab management, Ctrl+Tab/Ctrl+Shift+Tab for cycling, Ctrl+Shift+C/V for copy/paste stubs
+- **Mouse wheel scrollback in native shell** — scroll through terminal history with mouse wheel, Shift+PageUp/Down, Ctrl+Home/End
+- **Session recovery on startup** — native shell reconnects to surviving daemon sessions instead of creating new ones
+- **Font zoom in native shell** — Ctrl+= to zoom in, Ctrl+- to zoom out, Ctrl+0 to reset (minimum 8px)

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -73,11 +73,20 @@ pub enum Message {
     TerminalCreated(Result<String, String>),
     /// Window was resized.
     WindowResized { width: f32, height: f32 },
+    /// Mouse wheel scrolled (for scrollback).
+    MouseWheel { delta_y: f32 },
 }
 
+/// Result of initialization — either a fresh terminal or recovered sessions.
 #[derive(Debug, Clone)]
-pub struct InitResult {
-    pub session_id: String,
+pub enum InitResult {
+    /// A brand new session was created.
+    Fresh { session_id: String },
+    /// Existing daemon sessions were recovered (app restart / reconnect).
+    Recovered {
+        session_ids: Vec<String>,
+        first_id: String,
+    },
 }
 
 impl GodlyApp {
@@ -96,11 +105,30 @@ impl GodlyApp {
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
+            // --- Initialization ---
             Message::Initialized(Ok(result)) => {
                 let rows = self.calculate_rows();
                 let cols = self.calculate_cols();
-                self.terminals.add(result.session_id.clone(), rows, cols);
-                return self.fetch_grid(&result.session_id);
+
+                match result {
+                    InitResult::Fresh { session_id } => {
+                        self.terminals.add(session_id.clone(), rows, cols);
+                        return self.fetch_grid(&session_id);
+                    }
+                    InitResult::Recovered {
+                        session_ids,
+                        first_id,
+                    } => {
+                        for id in &session_ids {
+                            self.terminals.add(id.clone(), rows, cols);
+                        }
+                        self.terminals.set_active(&first_id);
+                        // Fetch grids for all recovered sessions.
+                        let tasks: Vec<Task<Message>> =
+                            session_ids.iter().map(|id| self.fetch_grid(id)).collect();
+                        return Task::batch(tasks);
+                    }
+                }
             }
             Message::Initialized(Err(e)) => {
                 log::error!("Initialization failed: {}", e);
@@ -146,6 +174,8 @@ impl GodlyApp {
                     term.fetching = false;
                     term.dirty = false;
                     term.title = grid.title.clone();
+                    term.total_scrollback = grid.total_scrollback;
+                    term.scrollback_offset = grid.scrollback_offset;
                     term.grid = Some(grid);
                 }
             }
@@ -156,10 +186,16 @@ impl GodlyApp {
                 log::error!("Grid fetch failed for {}: {}", session_id, error);
             }
 
-            // --- Keyboard input ---
+            // --- Keyboard input (shortcut-first, then forward to PTY) ---
             Message::KeyboardEvent(keyboard::Event::KeyPressed {
                 key, modifiers, ..
             }) => {
+                // Check app shortcuts first.
+                if let Some(action) = check_app_shortcut(&key, modifiers) {
+                    return self.handle_app_action(action);
+                }
+
+                // Forward to PTY.
                 if let Some(bytes) = key_to_pty_bytes(&key, modifiers) {
                     if let Some(active_id) = self.terminals.active_id().map(str::to_string) {
                         if let Some(client) = &self.client {
@@ -169,6 +205,13 @@ impl GodlyApp {
                 }
             }
             Message::KeyboardEvent(_) => {}
+
+            // --- Mouse wheel scrollback ---
+            Message::MouseWheel { delta_y } => {
+                // Scroll up (negative delta) increases offset, scroll down decreases.
+                let lines = -(delta_y * 3.0) as isize; // 3 lines per scroll notch
+                return self.scroll_active(lines);
+            }
 
             // --- Tab management ---
             Message::TabClicked(id) => {
@@ -253,19 +296,177 @@ impl GodlyApp {
             keyboard::listen().map(Message::KeyboardEvent),
             // Daemon events via channel.
             daemon_events(Arc::clone(&self.event_receiver)).map(Message::DaemonEvent),
-            // Window resize events.
-            event::listen_with(|ev, _status, _window_id| {
-                if let event::Event::Window(window::Event::Resized(size)) = ev {
+            // Window resize + mouse wheel events.
+            event::listen_with(|ev, _status, _window_id| match ev {
+                event::Event::Window(window::Event::Resized(size)) => {
                     Some(Message::WindowResized {
                         width: size.width,
                         height: size.height,
                     })
-                } else {
-                    None
                 }
+                event::Event::Mouse(iced::mouse::Event::WheelScrolled { delta }) => {
+                    let delta_y = match delta {
+                        iced::mouse::ScrollDelta::Lines { y, .. } => y,
+                        iced::mouse::ScrollDelta::Pixels { y, .. } => y / 20.0,
+                    };
+                    Some(Message::MouseWheel { delta_y })
+                }
+                _ => None,
             }),
         ])
     }
+
+    // -----------------------------------------------------------------------
+    // App action dispatch
+    // -----------------------------------------------------------------------
+
+    /// Handle an app-level shortcut action.
+    fn handle_app_action(&mut self, action: AppAction) -> Task<Message> {
+        match action {
+            AppAction::NewTab => self.create_new_terminal(),
+            AppAction::CloseTab => {
+                if let Some(id) = self.terminals.active_id().map(str::to_string) {
+                    self.close_terminal(&id)
+                } else {
+                    Task::none()
+                }
+            }
+            AppAction::NextTab => {
+                self.terminals.next();
+                Task::none()
+            }
+            AppAction::PreviousTab => {
+                self.terminals.previous();
+                Task::none()
+            }
+            AppAction::ZoomIn => {
+                self.font_metrics =
+                    FontMetrics::from_font_size(self.font_metrics.font_size + 1.0);
+                self.resize_all_terminals()
+            }
+            AppAction::ZoomOut => {
+                let new_size = (self.font_metrics.font_size - 1.0).max(8.0);
+                self.font_metrics = FontMetrics::from_font_size(new_size);
+                self.resize_all_terminals()
+            }
+            AppAction::ZoomReset => {
+                self.font_metrics = FontMetrics::default();
+                self.resize_all_terminals()
+            }
+            AppAction::ScrollPageUp => {
+                let page = self.calculate_rows() as isize;
+                self.scroll_active(-page)
+            }
+            AppAction::ScrollPageDown => {
+                let page = self.calculate_rows() as isize;
+                self.scroll_active(page)
+            }
+            AppAction::ScrollToTop => self.scroll_to_top(),
+            AppAction::ScrollToBottom => self.scroll_to_bottom(),
+            AppAction::Copy | AppAction::Paste => {
+                // Copy/Paste requires clipboard integration — log for now.
+                log::info!("Copy/Paste not yet implemented in native shell");
+                Task::none()
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scrollback
+    // -----------------------------------------------------------------------
+
+    /// Scroll the active terminal by delta lines (negative = up, positive = down).
+    fn scroll_active(&mut self, delta: isize) -> Task<Message> {
+        let Some(active_id) = self.terminals.active_id().map(str::to_string) else {
+            return Task::none();
+        };
+
+        let Some(term) = self.terminals.get_mut(&active_id) else {
+            return Task::none();
+        };
+
+        let new_offset = if delta < 0 {
+            term.scrollback_offset
+                .saturating_add((-delta) as usize)
+                .min(term.total_scrollback)
+        } else {
+            term.scrollback_offset.saturating_sub(delta as usize)
+        };
+
+        term.scrollback_offset = new_offset;
+
+        self.scroll_fetch(&active_id, new_offset)
+    }
+
+    /// Scroll to the top of scrollback history.
+    fn scroll_to_top(&mut self) -> Task<Message> {
+        let Some(active_id) = self.terminals.active_id().map(str::to_string) else {
+            return Task::none();
+        };
+
+        let max = self
+            .terminals
+            .get(&active_id)
+            .map(|t| t.total_scrollback)
+            .unwrap_or(0);
+
+        if let Some(term) = self.terminals.get_mut(&active_id) {
+            term.scrollback_offset = max;
+        }
+
+        self.scroll_fetch(&active_id, max)
+    }
+
+    /// Scroll to the bottom (live view).
+    fn scroll_to_bottom(&mut self) -> Task<Message> {
+        let Some(active_id) = self.terminals.active_id().map(str::to_string) else {
+            return Task::none();
+        };
+
+        if let Some(term) = self.terminals.get_mut(&active_id) {
+            term.scrollback_offset = 0;
+        }
+
+        self.scroll_fetch(&active_id, 0)
+    }
+
+    /// Set scrollback offset and fetch the grid snapshot for a session.
+    fn scroll_fetch(&self, session_id: &str, offset: usize) -> Task<Message> {
+        let Some(client) = &self.client else {
+            return Task::none();
+        };
+
+        let client = Arc::clone(client);
+        let sid = session_id.to_string();
+        let sid_ok = sid.clone();
+        let sid_err = sid.clone();
+
+        Task::perform(
+            async move {
+                let (tx, rx) = futures_channel::oneshot::channel();
+                std::thread::spawn(move || {
+                    let result = commands::scroll_and_get_snapshot(&client, &sid, offset);
+                    let _ = tx.send(result);
+                });
+                rx.await
+                    .unwrap_or_else(|_| Err("Background thread panicked".into()))
+            },
+            move |result| match result {
+                Ok(grid) => Message::GridFetched {
+                    session_id: sid_ok,
+                    grid,
+                },
+                Err(e) => Message::GridFetchFailed {
+                    session_id: sid_err,
+                    error: e,
+                },
+            },
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Terminal lifecycle
+    // -----------------------------------------------------------------------
 
     /// Fetch the grid snapshot for a specific session.
     fn fetch_grid(&mut self, session_id: &str) -> Task<Message> {
@@ -358,6 +559,10 @@ impl GodlyApp {
         Task::none()
     }
 
+    // -----------------------------------------------------------------------
+    // Resize
+    // -----------------------------------------------------------------------
+
     /// Resize the active terminal on the daemon.
     fn resize_active_terminal(&mut self, rows: u16, cols: u16) -> Task<Message> {
         let Some(active_id) = self.terminals.active_id().map(str::to_string) else {
@@ -377,6 +582,35 @@ impl GodlyApp {
         self.fetch_grid(&active_id)
     }
 
+    /// Resize all terminals after a font size change.
+    fn resize_all_terminals(&mut self) -> Task<Message> {
+        let new_rows = self.calculate_rows();
+        let new_cols = self.calculate_cols();
+
+        let ids: Vec<String> = self.terminals.iter().map(|t| t.id.clone()).collect();
+
+        for id in &ids {
+            if let Some(term) = self.terminals.get_mut(id) {
+                term.rows = new_rows;
+                term.cols = new_cols;
+            }
+            if let Some(client) = &self.client {
+                let _ = commands::resize_terminal(client, id, new_rows, new_cols);
+            }
+        }
+
+        // Fetch grid for active terminal.
+        if let Some(active_id) = self.terminals.active_id().map(str::to_string) {
+            self.fetch_grid(&active_id)
+        } else {
+            Task::none()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Grid dimension calculations
+    // -----------------------------------------------------------------------
+
     /// Calculate terminal columns from window width and font metrics.
     fn calculate_cols(&self) -> u16 {
         (self.window_width / self.font_metrics.cell_width).max(1.0) as u16
@@ -389,7 +623,11 @@ impl GodlyApp {
     }
 }
 
-/// Initialize the app: connect to daemon, set up bridge, create first session.
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+/// Initialize the app: connect to daemon, set up bridge, recover or create sessions.
 pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
     // Connect to daemon.
     let client = match NativeDaemonClient::connect_or_launch() {
@@ -413,9 +651,6 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
 
     app.client = Some(Arc::clone(&client));
 
-    // Create first session.
-    let session_id = uuid::Uuid::new_v4().to_string();
-    let sid = session_id.clone();
     let rows = app.calculate_rows();
     let cols = app.calculate_cols();
 
@@ -423,6 +658,47 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
         async move {
             let (tx, rx) = futures_channel::oneshot::channel();
             std::thread::spawn(move || {
+                // Try to recover existing daemon sessions.
+                let sessions =
+                    match client.send_request(&godly_protocol::Request::ListSessions) {
+                        Ok(godly_protocol::Response::SessionList { sessions }) => sessions,
+                        _ => vec![],
+                    };
+
+                let live_sessions: Vec<_> =
+                    sessions.into_iter().filter(|s| s.running).collect();
+
+                if !live_sessions.is_empty() {
+                    let mut recovered_ids = Vec::new();
+                    for session in &live_sessions {
+                        match commands::attach_session(&client, &session.id) {
+                            Ok(()) => {
+                                log::info!("Recovered session: {}", session.id);
+                                recovered_ids.push(session.id.clone());
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "Failed to recover session {}: {}",
+                                    session.id,
+                                    e
+                                );
+                            }
+                        }
+                    }
+
+                    if !recovered_ids.is_empty() {
+                        let first_id = recovered_ids[0].clone();
+                        let _ = tx.send(Ok(InitResult::Recovered {
+                            session_ids: recovered_ids,
+                            first_id,
+                        }));
+                        return;
+                    }
+                }
+
+                // No sessions to recover — create a new one.
+                let session_id = uuid::Uuid::new_v4().to_string();
+                let sid = session_id.clone();
                 let result = commands::create_terminal(
                     &client,
                     &sid,
@@ -431,7 +707,7 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
                     rows,
                     cols,
                 )
-                .map(|_| InitResult { session_id: sid });
+                .map(|_| InitResult::Fresh { session_id: sid });
                 let _ = tx.send(result);
             });
             rx.await
@@ -439,4 +715,209 @@ pub fn initialize(app: &mut GodlyApp) -> Task<Message> {
         },
         Message::Initialized,
     )
+}
+
+// ---------------------------------------------------------------------------
+// App-level shortcuts (inlined from WU-1 until it merges)
+// ---------------------------------------------------------------------------
+
+/// App-level shortcut check. Returns an `AppAction` if the key+modifiers
+/// match a known shortcut, or `None` to let the key pass through to the PTY.
+fn check_app_shortcut(
+    key: &iced::keyboard::Key,
+    modifiers: iced::keyboard::Modifiers,
+) -> Option<AppAction> {
+    use iced::keyboard::{key::Named, Key};
+
+    match key {
+        Key::Character(ch) => {
+            let s = ch.as_str();
+            if modifiers.control() && !modifiers.shift() {
+                match s {
+                    "t" => Some(AppAction::NewTab),
+                    "w" => Some(AppAction::CloseTab),
+                    "=" | "+" => Some(AppAction::ZoomIn),
+                    "-" => Some(AppAction::ZoomOut),
+                    "0" => Some(AppAction::ZoomReset),
+                    _ => None,
+                }
+            } else if modifiers.control() && modifiers.shift() {
+                match s {
+                    "C" | "c" => Some(AppAction::Copy),
+                    "V" | "v" => Some(AppAction::Paste),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+        Key::Named(named) => match named {
+            Named::Tab if modifiers.control() && !modifiers.shift() => Some(AppAction::NextTab),
+            Named::Tab if modifiers.control() && modifiers.shift() => {
+                Some(AppAction::PreviousTab)
+            }
+            Named::PageUp if modifiers.shift() => Some(AppAction::ScrollPageUp),
+            Named::PageDown if modifiers.shift() => Some(AppAction::ScrollPageDown),
+            Named::Home if modifiers.control() => Some(AppAction::ScrollToTop),
+            Named::End if modifiers.control() => Some(AppAction::ScrollToBottom),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AppAction {
+    NewTab,
+    CloseTab,
+    NextTab,
+    PreviousTab,
+    ZoomIn,
+    ZoomOut,
+    ZoomReset,
+    Copy,
+    Paste,
+    ScrollPageUp,
+    ScrollPageDown,
+    ScrollToTop,
+    ScrollToBottom,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced::keyboard::{key::Named, Key, Modifiers};
+
+    #[test]
+    fn ctrl_t_is_new_tab() {
+        let action = check_app_shortcut(
+            &Key::Character("t".into()),
+            Modifiers::CTRL,
+        );
+        assert!(matches!(action, Some(AppAction::NewTab)));
+    }
+
+    #[test]
+    fn ctrl_w_is_close_tab() {
+        let action = check_app_shortcut(
+            &Key::Character("w".into()),
+            Modifiers::CTRL,
+        );
+        assert!(matches!(action, Some(AppAction::CloseTab)));
+    }
+
+    #[test]
+    fn ctrl_tab_is_next_tab() {
+        let action = check_app_shortcut(&Key::Named(Named::Tab), Modifiers::CTRL);
+        assert!(matches!(action, Some(AppAction::NextTab)));
+    }
+
+    #[test]
+    fn ctrl_shift_tab_is_previous_tab() {
+        let action =
+            check_app_shortcut(&Key::Named(Named::Tab), Modifiers::CTRL | Modifiers::SHIFT);
+        assert!(matches!(action, Some(AppAction::PreviousTab)));
+    }
+
+    #[test]
+    fn ctrl_equals_is_zoom_in() {
+        let action = check_app_shortcut(
+            &Key::Character("=".into()),
+            Modifiers::CTRL,
+        );
+        assert!(matches!(action, Some(AppAction::ZoomIn)));
+    }
+
+    #[test]
+    fn ctrl_plus_is_zoom_in() {
+        let action = check_app_shortcut(
+            &Key::Character("+".into()),
+            Modifiers::CTRL,
+        );
+        assert!(matches!(action, Some(AppAction::ZoomIn)));
+    }
+
+    #[test]
+    fn ctrl_minus_is_zoom_out() {
+        let action = check_app_shortcut(
+            &Key::Character("-".into()),
+            Modifiers::CTRL,
+        );
+        assert!(matches!(action, Some(AppAction::ZoomOut)));
+    }
+
+    #[test]
+    fn ctrl_zero_is_zoom_reset() {
+        let action = check_app_shortcut(
+            &Key::Character("0".into()),
+            Modifiers::CTRL,
+        );
+        assert!(matches!(action, Some(AppAction::ZoomReset)));
+    }
+
+    #[test]
+    fn ctrl_shift_c_is_copy() {
+        let action = check_app_shortcut(
+            &Key::Character("C".into()),
+            Modifiers::CTRL | Modifiers::SHIFT,
+        );
+        assert!(matches!(action, Some(AppAction::Copy)));
+    }
+
+    #[test]
+    fn ctrl_shift_v_is_paste() {
+        let action = check_app_shortcut(
+            &Key::Character("V".into()),
+            Modifiers::CTRL | Modifiers::SHIFT,
+        );
+        assert!(matches!(action, Some(AppAction::Paste)));
+    }
+
+    #[test]
+    fn shift_pageup_is_scroll_page_up() {
+        let action = check_app_shortcut(&Key::Named(Named::PageUp), Modifiers::SHIFT);
+        assert!(matches!(action, Some(AppAction::ScrollPageUp)));
+    }
+
+    #[test]
+    fn shift_pagedown_is_scroll_page_down() {
+        let action = check_app_shortcut(&Key::Named(Named::PageDown), Modifiers::SHIFT);
+        assert!(matches!(action, Some(AppAction::ScrollPageDown)));
+    }
+
+    #[test]
+    fn ctrl_home_is_scroll_to_top() {
+        let action = check_app_shortcut(&Key::Named(Named::Home), Modifiers::CTRL);
+        assert!(matches!(action, Some(AppAction::ScrollToTop)));
+    }
+
+    #[test]
+    fn ctrl_end_is_scroll_to_bottom() {
+        let action = check_app_shortcut(&Key::Named(Named::End), Modifiers::CTRL);
+        assert!(matches!(action, Some(AppAction::ScrollToBottom)));
+    }
+
+    #[test]
+    fn plain_letter_is_not_shortcut() {
+        let action = check_app_shortcut(
+            &Key::Character("a".into()),
+            Modifiers::empty(),
+        );
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn ctrl_a_is_not_shortcut() {
+        let action = check_app_shortcut(
+            &Key::Character("a".into()),
+            Modifiers::CTRL,
+        );
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn unmodified_tab_is_not_shortcut() {
+        let action = check_app_shortcut(&Key::Named(Named::Tab), Modifiers::empty());
+        assert!(action.is_none());
+    }
 }

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -13,6 +13,10 @@ pub struct TerminalInfo {
     pub cols: u16,
     pub exited: bool,
     pub exit_code: Option<i64>,
+    /// Current scrollback offset (0 = live view, >0 = scrolled into history).
+    pub scrollback_offset: usize,
+    /// Total number of scrollback rows available.
+    pub total_scrollback: usize,
 }
 
 impl TerminalInfo {
@@ -69,6 +73,8 @@ impl TerminalCollection {
             cols,
             exited: false,
             exit_code: None,
+            scrollback_offset: 0,
+            total_scrollback: 0,
         });
 
         if is_first {
@@ -153,6 +159,38 @@ impl TerminalCollection {
     /// Returns the active terminal's id, if any.
     pub fn active_id(&self) -> Option<&str> {
         self.active_id.as_deref()
+    }
+
+    /// Switch to the next terminal (wraps around).
+    pub fn next(&mut self) {
+        if self.terminals.len() <= 1 {
+            return;
+        }
+        if let Some(idx) = self.active_index() {
+            let next_idx = (idx + 1) % self.terminals.len();
+            self.active_id = Some(self.terminals[next_idx].id.clone());
+        }
+    }
+
+    /// Switch to the previous terminal (wraps around).
+    pub fn previous(&mut self) {
+        if self.terminals.len() <= 1 {
+            return;
+        }
+        if let Some(idx) = self.active_index() {
+            let prev_idx = if idx == 0 {
+                self.terminals.len() - 1
+            } else {
+                idx - 1
+            };
+            self.active_id = Some(self.terminals[prev_idx].id.clone());
+        }
+    }
+
+    /// Returns the index of the active terminal.
+    fn active_index(&self) -> Option<usize> {
+        let id = self.active_id.as_deref()?;
+        self.terminals.iter().position(|t| t.id == id)
     }
 }
 
@@ -318,5 +356,102 @@ mod tests {
 
         col.active_mut().unwrap().title = "Hello".into();
         assert_eq!(col.active().unwrap().title, "Hello");
+    }
+
+    #[test]
+    fn test_next_wraps_around() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        assert_eq!(col.active_id(), Some("t1"));
+
+        col.next();
+        assert_eq!(col.active_id(), Some("t2"));
+
+        col.next();
+        assert_eq!(col.active_id(), Some("t3"));
+
+        // Wraps around to t1.
+        col.next();
+        assert_eq!(col.active_id(), Some("t1"));
+    }
+
+    #[test]
+    fn test_previous_wraps_around() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        assert_eq!(col.active_id(), Some("t1"));
+
+        // Wraps around to t3.
+        col.previous();
+        assert_eq!(col.active_id(), Some("t3"));
+
+        col.previous();
+        assert_eq!(col.active_id(), Some("t2"));
+
+        col.previous();
+        assert_eq!(col.active_id(), Some("t1"));
+    }
+
+    #[test]
+    fn test_next_single_terminal_is_noop() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+
+        col.next();
+        assert_eq!(col.active_id(), Some("t1"));
+    }
+
+    #[test]
+    fn test_previous_single_terminal_is_noop() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+
+        col.previous();
+        assert_eq!(col.active_id(), Some("t1"));
+    }
+
+    #[test]
+    fn test_next_empty_is_noop() {
+        let mut col = TerminalCollection::new();
+        col.next();
+        assert_eq!(col.active_id(), None);
+    }
+
+    #[test]
+    fn test_previous_empty_is_noop() {
+        let mut col = TerminalCollection::new();
+        col.previous();
+        assert_eq!(col.active_id(), None);
+    }
+
+    #[test]
+    fn test_next_previous_round_trip() {
+        let mut col = TerminalCollection::new();
+        col.add("t1".into(), 24, 80);
+        col.add("t2".into(), 24, 80);
+        col.add("t3".into(), 24, 80);
+
+        col.set_active("t2");
+        assert_eq!(col.active_id(), Some("t2"));
+
+        col.next();
+        assert_eq!(col.active_id(), Some("t3"));
+
+        col.previous();
+        assert_eq!(col.active_id(), Some("t2"));
+    }
+
+    #[test]
+    fn test_scrollback_fields_initialized_to_zero() {
+        let mut col = TerminalCollection::new();
+        let info = col.add("t1".into(), 24, 80);
+        assert_eq!(info.scrollback_offset, 0);
+        assert_eq!(info.total_scrollback, 0);
     }
 }


### PR DESCRIPTION
## Summary

- **Keyboard shortcuts** — intercept app-level shortcuts (Ctrl+T/W for tab management, Ctrl+Tab/Shift+Tab for cycling, Ctrl+Shift+C/V stubs, Ctrl+=/-/0 for zoom) before forwarding keys to PTY
- **Mouse wheel scrollback** — scroll through terminal history with mouse wheel (3 lines per notch), Shift+PageUp/Down, Ctrl+Home/End
- **Session recovery on startup** — native shell queries daemon for surviving sessions and reattaches instead of always creating a fresh terminal
- **Font zoom** — Ctrl+= to zoom in, Ctrl+- to zoom out (min 8px), Ctrl+0 to reset to default (14px); resizes all terminals on zoom

## Implementation details

- `check_app_shortcut()` with `AppAction` enum for shortcut-first dispatch in keyboard handler
- `InitResult` changed from struct to enum (`Fresh`/`Recovered` variants) for recovery flow
- `TerminalInfo` gains `scrollback_offset` and `total_scrollback` fields, updated from `RichGridData`
- `TerminalCollection` gains `next()`/`previous()` with wrapping behavior for tab cycling
- `scroll_fetch()` uses `scroll_and_get_snapshot` for combined set-offset + read in one IPC round-trip
- `resize_all_terminals()` propagates font size changes to all daemon sessions
- Mouse wheel subscription merged into the existing `event::listen_with` handler

## Test plan

- [x] `cargo check -p godly-iced-shell` passes
- [x] `cargo nextest run -p godly-iced-shell` — 82 tests passing (17 new)
- [x] `cargo check -p godly-protocol -p godly-daemon` — no breakage
- [ ] CI full build