### PR TITLE
feat: add split pane tree mutation methods (Phase 4 WU-5)

### DIFF
--- a/changelog/unreleased/phase4-wu5-split-mutations.md
+++ b/changelog/unreleased/phase4-wu5-split-mutations.md
@@ -1,0 +1,2 @@
+### Added
+- **Split pane mutations** — `split_leaf()`, `unsplit_leaf()`, and `next_leaf_id()` operations on the layout tree

--- a/src-tauri/native/iced-shell/src/split_pane.rs
+++ b/src-tauri/native/iced-shell/src/split_pane.rs
@@ -62,6 +62,95 @@ impl LayoutNode {
             }
         }
     }
+
+    /// Splits the leaf with `target_id` into a `Split` node containing
+    /// the original leaf as `first` and a new leaf (`new_id`) as `second`.
+    ///
+    /// Uses ratio 0.5 (equal split). Returns `true` if the target was found
+    /// and split, `false` otherwise.
+    pub fn split_leaf(
+        &mut self,
+        target_id: &str,
+        new_id: String,
+        direction: SplitDirection,
+    ) -> bool {
+        match self {
+            LayoutNode::Leaf { terminal_id } if terminal_id == target_id => {
+                let old =
+                    std::mem::replace(self, LayoutNode::Leaf { terminal_id: String::new() });
+                *self = LayoutNode::Split {
+                    direction,
+                    ratio: 0.5,
+                    first: Box::new(old),
+                    second: Box::new(LayoutNode::Leaf {
+                        terminal_id: new_id,
+                    }),
+                };
+                true
+            }
+            LayoutNode::Leaf { .. } => false,
+            LayoutNode::Split { first, second, .. } => {
+                first.split_leaf(target_id, new_id.clone(), direction)
+                    || second.split_leaf(target_id, new_id, direction)
+            }
+        }
+    }
+
+    /// Removes the leaf with `target_id` from its parent split and promotes
+    /// the sibling to take the parent's place.
+    ///
+    /// Returns `Some(removed_id)` if found, `None` otherwise.
+    /// Cannot unsplit the root leaf (if the entire tree is a single leaf, returns `None`).
+    pub fn unsplit_leaf(&mut self, target_id: &str) -> Option<String> {
+        match self {
+            LayoutNode::Leaf { .. } => None,
+            LayoutNode::Split { first, second, .. } => {
+                // Check if first child is the target leaf
+                if let LayoutNode::Leaf { terminal_id } = first.as_ref() {
+                    if terminal_id == target_id {
+                        let removed = terminal_id.clone();
+                        let sibling = std::mem::replace(
+                            second.as_mut(),
+                            LayoutNode::Leaf {
+                                terminal_id: String::new(),
+                            },
+                        );
+                        *self = sibling;
+                        return Some(removed);
+                    }
+                }
+                // Check if second child is the target leaf
+                if let LayoutNode::Leaf { terminal_id } = second.as_ref() {
+                    if terminal_id == target_id {
+                        let removed = terminal_id.clone();
+                        let sibling = std::mem::replace(
+                            first.as_mut(),
+                            LayoutNode::Leaf {
+                                terminal_id: String::new(),
+                            },
+                        );
+                        *self = sibling;
+                        return Some(removed);
+                    }
+                }
+                // Recurse into children
+                first
+                    .unsplit_leaf(target_id)
+                    .or_else(|| second.unsplit_leaf(target_id))
+            }
+        }
+    }
+
+    /// Returns the next leaf ID in depth-first order after `current_id`.
+    ///
+    /// Wraps around from the last leaf to the first. Returns `None` if
+    /// `current_id` is not found in the tree.
+    pub fn next_leaf_id(&self, current_id: &str) -> Option<&str> {
+        let ids = self.all_leaf_ids();
+        let pos = ids.iter().position(|&id| id == current_id)?;
+        let next_pos = (pos + 1) % ids.len();
+        Some(ids[next_pos])
+    }
 }
 
 /// Converts a float ratio (0.0..1.0) to integer fill portions for two children.
@@ -256,5 +345,241 @@ mod tests {
         let (first, second) = ratio_to_portions(1.0);
         assert!(first >= 1);
         assert!(second >= 1);
+    }
+
+    // --- split_leaf tests ---
+
+    #[test]
+    fn test_split_leaf_single() {
+        let mut node = LayoutNode::Leaf {
+            terminal_id: "t1".into(),
+        };
+        assert!(node.split_leaf("t1", "t2".into(), SplitDirection::Horizontal));
+
+        // Should now be a Split with two children
+        match &node {
+            LayoutNode::Split {
+                direction,
+                ratio,
+                first,
+                second,
+            } => {
+                assert_eq!(*direction, SplitDirection::Horizontal);
+                assert!((ratio - 0.5).abs() < f32::EPSILON);
+                match first.as_ref() {
+                    LayoutNode::Leaf { terminal_id } => assert_eq!(terminal_id, "t1"),
+                    _ => panic!("first child should be a Leaf"),
+                }
+                match second.as_ref() {
+                    LayoutNode::Leaf { terminal_id } => assert_eq!(terminal_id, "t2"),
+                    _ => panic!("second child should be a Leaf"),
+                }
+            }
+            _ => panic!("root should be a Split after split_leaf"),
+        }
+        assert_eq!(node.leaf_count(), 2);
+    }
+
+    #[test]
+    fn test_split_leaf_nested() {
+        // Start: Split(H) [t1, t2]
+        // Split t2 vertically with t3
+        // Result: Split(H) [t1, Split(V) [t2, t3]]
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Leaf {
+                terminal_id: "t2".into(),
+            }),
+        };
+
+        assert!(node.split_leaf("t2", "t3".into(), SplitDirection::Vertical));
+        assert_eq!(node.leaf_count(), 3);
+        assert_eq!(node.all_leaf_ids(), vec!["t1", "t2", "t3"]);
+
+        // Verify the nested structure
+        match &node {
+            LayoutNode::Split { second, .. } => match second.as_ref() {
+                LayoutNode::Split { direction, .. } => {
+                    assert_eq!(*direction, SplitDirection::Vertical);
+                }
+                _ => panic!("second child should be a Split after nested split"),
+            },
+            _ => panic!("root should still be a Split"),
+        }
+    }
+
+    #[test]
+    fn test_split_leaf_nonexistent() {
+        let mut node = LayoutNode::Leaf {
+            terminal_id: "t1".into(),
+        };
+        assert!(!node.split_leaf("nonexistent", "t2".into(), SplitDirection::Horizontal));
+
+        // Node should remain unchanged
+        match &node {
+            LayoutNode::Leaf { terminal_id } => assert_eq!(terminal_id, "t1"),
+            _ => panic!("node should remain a Leaf"),
+        }
+    }
+
+    // --- unsplit_leaf tests ---
+
+    #[test]
+    fn test_unsplit_leaf() {
+        // Start: Split(H) [t1, t2]
+        // Unsplit t1 -> should promote t2 to root
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Leaf {
+                terminal_id: "t2".into(),
+            }),
+        };
+
+        let removed = node.unsplit_leaf("t1");
+        assert_eq!(removed, Some("t1".into()));
+        match &node {
+            LayoutNode::Leaf { terminal_id } => assert_eq!(terminal_id, "t2"),
+            _ => panic!("root should be promoted to a Leaf"),
+        }
+    }
+
+    #[test]
+    fn test_unsplit_leaf_nested() {
+        // Structure:
+        //   Split(H)
+        //   +-- t1
+        //   +-- Split(V)
+        //       +-- t2
+        //       +-- t3
+        //
+        // Unsplit t2 -> sibling t3 promoted:
+        //   Split(H)
+        //   +-- t1
+        //   +-- t3
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Split {
+                direction: SplitDirection::Vertical,
+                ratio: 0.5,
+                first: Box::new(LayoutNode::Leaf {
+                    terminal_id: "t2".into(),
+                }),
+                second: Box::new(LayoutNode::Leaf {
+                    terminal_id: "t3".into(),
+                }),
+            }),
+        };
+
+        let removed = node.unsplit_leaf("t2");
+        assert_eq!(removed, Some("t2".into()));
+        assert_eq!(node.leaf_count(), 2);
+        assert_eq!(node.all_leaf_ids(), vec!["t1", "t3"]);
+    }
+
+    #[test]
+    fn test_unsplit_root_leaf() {
+        // Cannot unsplit a single root leaf
+        let mut node = LayoutNode::Leaf {
+            terminal_id: "t1".into(),
+        };
+        assert_eq!(node.unsplit_leaf("t1"), None);
+    }
+
+    #[test]
+    fn test_unsplit_nonexistent() {
+        let mut node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Leaf {
+                terminal_id: "t2".into(),
+            }),
+        };
+        assert_eq!(node.unsplit_leaf("nonexistent"), None);
+        // Tree should be unchanged
+        assert_eq!(node.leaf_count(), 2);
+    }
+
+    // --- next_leaf_id tests ---
+
+    #[test]
+    fn test_next_leaf_id() {
+        // Split(H) [t1, Split(V) [t2, t3]]
+        // Order: t1, t2, t3
+        let node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Split {
+                direction: SplitDirection::Vertical,
+                ratio: 0.5,
+                first: Box::new(LayoutNode::Leaf {
+                    terminal_id: "t2".into(),
+                }),
+                second: Box::new(LayoutNode::Leaf {
+                    terminal_id: "t3".into(),
+                }),
+            }),
+        };
+
+        assert_eq!(node.next_leaf_id("t1"), Some("t2"));
+        assert_eq!(node.next_leaf_id("t2"), Some("t3"));
+    }
+
+    #[test]
+    fn test_next_leaf_id_wraps() {
+        let node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Leaf {
+                terminal_id: "t2".into(),
+            }),
+        };
+
+        // Last leaf wraps to first
+        assert_eq!(node.next_leaf_id("t2"), Some("t1"));
+    }
+
+    #[test]
+    fn test_next_leaf_id_single() {
+        let node = LayoutNode::Leaf {
+            terminal_id: "t1".into(),
+        };
+        // Single leaf wraps to itself
+        assert_eq!(node.next_leaf_id("t1"), Some("t1"));
+    }
+
+    #[test]
+    fn test_next_leaf_id_nonexistent() {
+        let node = LayoutNode::Split {
+            direction: SplitDirection::Horizontal,
+            ratio: 0.5,
+            first: Box::new(LayoutNode::Leaf {
+                terminal_id: "t1".into(),
+            }),
+            second: Box::new(LayoutNode::Leaf {
+                terminal_id: "t2".into(),
+            }),
+        };
+        assert_eq!(node.next_leaf_id("nonexistent"), None);
     }
 }


### PR DESCRIPTION
## Summary
- Add `split_leaf()` method to split a leaf node into a binary split with a new terminal pane
- Add `unsplit_leaf()` method to remove a leaf and promote its sibling in the layout tree
- Add `next_leaf_id()` method for depth-first focus cycling through leaf nodes
- 11 new unit tests covering all mutation operations including edge cases

## Test plan
- [x] `cargo check -p godly-iced-shell` passes
- [x] `cargo test -p godly-iced-shell -- split_pane` — all 18 tests pass (8 existing + 11 new)
- [ ] CI full build and test suite