### PR TITLE
feat: add clipboard module for native shell (Phase 4 WU-2)

### DIFF
--- a/changelog/unreleased/phase4-wu2-clipboard.md
+++ b/changelog/unreleased/phase4-wu2-clipboard.md
@@ -1,0 +1,2 @@
+### Added
+- **Clipboard support** — system clipboard copy/paste via `arboard` in the native shell

--- a/src-tauri/native/app-adapter/Cargo.toml
+++ b/src-tauri/native/app-adapter/Cargo.toml
@@ -10,6 +10,7 @@ godly-protocol = { path = "../../protocol" }
 parking_lot.workspace = true
 log = "0.4"
 iced.workspace = true
+arboard = "3"
 
 [target.'cfg(windows)'.dependencies]
 winapi.workspace = true

--- a/src-tauri/native/app-adapter/src/clipboard.rs
+++ b/src-tauri/native/app-adapter/src/clipboard.rs
@@ -1,0 +1,66 @@
+use arboard::Clipboard;
+
+/// Copy text to the system clipboard.
+pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    let mut clipboard =
+        Clipboard::new().map_err(|e| format!("Failed to access clipboard: {}", e))?;
+    clipboard
+        .set_text(text)
+        .map_err(|e| format!("Failed to copy: {}", e))
+}
+
+/// Paste text from the system clipboard.
+pub fn paste_from_clipboard() -> Result<String, String> {
+    let mut clipboard =
+        Clipboard::new().map_err(|e| format!("Failed to access clipboard: {}", e))?;
+    clipboard
+        .get_text()
+        .map_err(|e| format!("Failed to paste: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Clipboard tests require a display server / desktop session.
+    // They are marked #[ignore] so they don't fail in headless CI,
+    // but can be run locally with:
+    //   cargo test -p godly-app-adapter -- --ignored --test-threads=1
+    // (single-threaded required: concurrent Clipboard::new() races on Win32)
+
+    #[test]
+    #[ignore]
+    fn round_trip_copy_paste() {
+        let text = "Hello from godly-app-adapter clipboard test!";
+        copy_to_clipboard(text).expect("copy should succeed");
+        let pasted = paste_from_clipboard().expect("paste should succeed");
+        assert_eq!(pasted, text);
+    }
+
+    #[test]
+    #[ignore]
+    fn empty_string_round_trip() {
+        let text = "";
+        copy_to_clipboard(text).expect("copy empty string should succeed");
+        let pasted = paste_from_clipboard().expect("paste should succeed");
+        assert_eq!(pasted, text);
+    }
+
+    #[test]
+    #[ignore]
+    fn unicode_round_trip() {
+        let text = "こんにちは 🌍 Ñoño café résumé";
+        copy_to_clipboard(text).expect("copy unicode should succeed");
+        let pasted = paste_from_clipboard().expect("paste should succeed");
+        assert_eq!(pasted, text);
+    }
+
+    #[test]
+    #[ignore]
+    fn multiline_round_trip() {
+        let text = "line 1\nline 2\nline 3";
+        copy_to_clipboard(text).expect("copy multiline should succeed");
+        let pasted = paste_from_clipboard().expect("paste should succeed");
+        assert_eq!(pasted, text);
+    }
+}

--- a/src-tauri/native/app-adapter/src/lib.rs
+++ b/src-tauri/native/app-adapter/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod clipboard;
 pub mod commands;
 pub mod daemon_client;
 pub mod event_loop;


### PR DESCRIPTION
## Summary
- Adds system clipboard copy/paste support to the `godly-app-adapter` crate via `arboard` crate
- Two public functions: `copy_to_clipboard` and `paste_from_clipboard`
- Includes 4 unit tests (round-trip, empty string, unicode, multiline) marked `#[ignore]` for CI compatibility

## Changes
- `src-tauri/native/app-adapter/Cargo.toml` — added `arboard = "3"` dependency
- `src-tauri/native/app-adapter/src/lib.rs` — added `pub mod clipboard;`
- `src-tauri/native/app-adapter/src/clipboard.rs` — new clipboard module with tests
- `changelog/unreleased/phase4-wu2-clipboard.md` — changelog fragment

## Test plan
- [x] `cargo check -p godly-app-adapter` passes
- [x] `cargo test -p godly-app-adapter` passes (61 existing + 4 ignored clipboard tests)
- [x] `cargo test -p godly-app-adapter -- --ignored --test-threads=1` passes all 4 clipboard tests locally