### PR TITLE
perf: eliminate grid clone in terminal render path

### DIFF
--- a/changelog/unreleased/phase4-wu2-eliminate-grid-clone.md
+++ b/changelog/unreleased/phase4-wu2-eliminate-grid-clone.md
@@ -1,0 +1,2 @@
+### Changed
+- **Eliminate grid clone in render path** — Use borrowed references instead of cloning RichGridData per pane per frame, reducing memory pressure and CPU cost.

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1119,7 +1119,7 @@ impl GodlyApp {
         };
 
         let tc = TerminalCanvas {
-            grid: term.grid.clone(),
+            grid: term.grid.as_ref(),
             metrics: self.font_metrics,
             selection,
         };

--- a/src-tauri/native/terminal-surface/src/surface.rs
+++ b/src-tauri/native/terminal-surface/src/surface.rs
@@ -40,13 +40,12 @@ pub struct TerminalCanvasState;
 
 /// Terminal canvas program that renders a RichGridData snapshot.
 ///
-/// Grid data and font metrics are carried on the struct, enabling the parent
-/// to set per-terminal data before each render. Drawing uses Iced's Canvas
-/// widget via `Frame::fill_rectangle()` for backgrounds and
-/// `Frame::fill_text()` for cell content.
-pub struct TerminalCanvas {
-    /// Current grid data from the daemon.
-    pub grid: Option<RichGridData>,
+/// Grid data is borrowed for the duration of the render, avoiding a full clone
+/// of `RichGridData` per pane per frame. Font metrics and selection state are
+/// cheap `Copy` types carried by value.
+pub struct TerminalCanvas<'a> {
+    /// Borrowed grid data from the daemon (avoids cloning per frame).
+    pub grid: Option<&'a RichGridData>,
     /// Font metrics for cell sizing.
     pub metrics: FontMetrics,
     /// Optional selection range (start, end) in reading order.
@@ -54,7 +53,7 @@ pub struct TerminalCanvas {
     pub selection: Option<(GridPos, GridPos)>,
 }
 
-impl Default for TerminalCanvas {
+impl Default for TerminalCanvas<'_> {
     fn default() -> Self {
         Self {
             grid: None,
@@ -64,7 +63,7 @@ impl Default for TerminalCanvas {
     }
 }
 
-impl TerminalCanvas {
+impl<'a> TerminalCanvas<'a> {
     /// Create a new terminal canvas with the given font metrics.
     pub fn new(metrics: FontMetrics) -> Self {
         Self {
@@ -75,7 +74,7 @@ impl TerminalCanvas {
     }
 }
 
-impl<Message> canvas::Program<Message> for TerminalCanvas {
+impl<Message> canvas::Program<Message> for TerminalCanvas<'_> {
     type State = TerminalCanvasState;
 
     fn draw(


### PR DESCRIPTION
## Summary
- **Change `TerminalCanvas` to borrow `RichGridData` via lifetime parameter** (`Option<&'a RichGridData>`) instead of cloning it (`Option<RichGridData>`) per pane per frame
- With 4 split panes at 60 FPS, this eliminates ~240 deep clones/sec of grid data, reducing memory pressure and CPU cost in the native Iced shell render path
- Iced 0.14's `canvas::Program` trait does not require `'static` on the implementor, so the lifetime approach works cleanly without needing `Arc` fallback

## Test plan
- [x] `cargo check -p godly-terminal-surface` passes
- [x] `cargo check -p godly-iced-shell` passes
- [x] `cargo nextest run -p godly-iced-shell` — all 196 tests pass
- [ ] CI full workspace check