### PR TITLE
feat: update build scripts for native-first workflow

### DIFF
--- a/changelog/unreleased/phase5-wu2-build-workflow.md
+++ b/changelog/unreleased/phase5-wu2-build-workflow.md
@@ -1,0 +1,2 @@
+### Changed
+- **Native-first build workflow** — `pnpm dev:native` runs the native Iced shell, `pnpm dev:web` runs the legacy Tauri frontend. Build scripts now build both daemon and native shell together.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "production:install": "pwsh scripts/production-install.ps1",
     "staging:build": "pwsh scripts/staging-build.ps1",
     "staging:install": "pwsh scripts/staging-install.ps1",
+    "dev:native": "cd src-tauri && cargo build -p godly-daemon && cargo run -p godly-iced-shell",
+    "dev:web": "pnpm tauri dev",
     "build:native": "pwsh scripts/build-native.ps1",
     "build:native:release": "pwsh scripts/build-native.ps1 -Release"
   },

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -14,25 +14,37 @@ Write-Host "=== Building Godly Terminal (Native) ===" -ForegroundColor Cyan
 $profileArg = if ($Release) { "--release" } else { $null }
 $profileName = if ($Release) { "release" } else { "debug" }
 
-# Build the native binary
-$buildArgs = @("build", "-p", "godly-iced-shell")
-if ($profileArg) { $buildArgs += $profileArg }
-
-Write-Host "Running: cargo $($buildArgs -join ' ')" -ForegroundColor Gray
 Push-Location "$PSScriptRoot\..\src-tauri"
 try {
+    # Build the daemon first
+    $daemonArgs = @("build", "-p", "godly-daemon")
+    if ($profileArg) { $daemonArgs += $profileArg }
+
+    Write-Host "Running: cargo $($daemonArgs -join ' ')" -ForegroundColor Gray
+    & cargo @daemonArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Daemon build failed with exit code $LASTEXITCODE"
+    }
+
+    # Build the native shell
+    $buildArgs = @("build", "-p", "godly-iced-shell")
+    if ($profileArg) { $buildArgs += $profileArg }
+
+    Write-Host "Running: cargo $($buildArgs -join ' ')" -ForegroundColor Gray
     & cargo @buildArgs
     if ($LASTEXITCODE -ne 0) {
-        throw "Cargo build failed with exit code $LASTEXITCODE"
+        throw "Native shell build failed with exit code $LASTEXITCODE"
     }
 } finally {
     Pop-Location
 }
 
-$binaryPath = "$PSScriptRoot\..\src-tauri\target\$profileName\godly-native.exe"
-if (Test-Path $binaryPath) {
-    $size = (Get-Item $binaryPath).Length / 1MB
-    Write-Host "`nBuild complete: $binaryPath ($([math]::Round($size, 1)) MB)" -ForegroundColor Green
-} else {
-    Write-Host "`nBuild complete (binary at: src-tauri/target/$profileName/godly-native)" -ForegroundColor Green
+$targetDir = "$PSScriptRoot\..\src-tauri\target\$profileName"
+Write-Host "`nBuild complete:" -ForegroundColor Green
+foreach ($bin in @("godly-native.exe", "godly-daemon.exe")) {
+    $path = Join-Path $targetDir $bin
+    if (Test-Path $path) {
+        $size = (Get-Item $path).Length / 1MB
+        Write-Host "  $bin ($([math]::Round($size, 1)) MB)" -ForegroundColor Green
+    }
 }

--- a/scripts/production-build-native.ps1
+++ b/scripts/production-build-native.ps1
@@ -1,0 +1,31 @@
+# Build the native Godly Terminal for production distribution.
+# Produces: godly-native.exe + godly-daemon.exe (both release builds)
+param([switch]$SkipDaemon)
+
+$ErrorActionPreference = "Stop"
+Write-Host "=== Production Build: Godly Terminal (Native) ===" -ForegroundColor Cyan
+
+Push-Location "$PSScriptRoot\..\src-tauri"
+try {
+    if (-not $SkipDaemon) {
+        Write-Host "Building daemon (release)..." -ForegroundColor Gray
+        cargo build -p godly-daemon --release
+        if ($LASTEXITCODE -ne 0) { throw "Daemon build failed" }
+    }
+
+    Write-Host "Building native shell (release)..." -ForegroundColor Gray
+    cargo build -p godly-iced-shell --release
+    if ($LASTEXITCODE -ne 0) { throw "Native shell build failed" }
+} finally {
+    Pop-Location
+}
+
+$targetDir = "$PSScriptRoot\..\src-tauri\target\release"
+Write-Host "`nBuild complete:" -ForegroundColor Green
+foreach ($bin in @("godly-native.exe", "godly-daemon.exe")) {
+    $path = Join-Path $targetDir $bin
+    if (Test-Path $path) {
+        $size = (Get-Item $path).Length / 1MB
+        Write-Host "  $bin ($([math]::Round($size, 1)) MB)" -ForegroundColor Green
+    }
+}


### PR DESCRIPTION
## Summary
- Add `pnpm dev:native` script to run the native Iced shell (builds daemon first) and `pnpm dev:web` as explicit web fallback
- Update `scripts/build-native.ps1` to build both daemon and native shell together
- Add `scripts/production-build-native.ps1` for production release builds of both binaries

## Test plan
- [x] Verify `pnpm dev:native` script exists in package.json
- [x] Verify `scripts/build-native.ps1` PowerShell syntax is valid
- [x] Verify `scripts/production-build-native.ps1` PowerShell syntax is valid
- [x] Existing `build:native` and `build:native:release` scripts unchanged