### PR TITLE
feat: switch default frontend mode from Web to Native

### DIFF
--- a/changelog/unreleased/phase5-wu1-native-default.md
+++ b/changelog/unreleased/phase5-wu1-native-default.md
@@ -1,0 +1,2 @@
+### Changed
+- **Native frontend is now the default** — `FrontendMode` defaults to `Native` instead of `Web`. Set `GODLY_FRONTEND_MODE=web` to use the legacy Tauri frontend.

--- a/src-tauri/protocol/src/types.rs
+++ b/src-tauri/protocol/src/types.rs
@@ -2,11 +2,11 @@ use serde::{Deserialize, Serialize};
 
 /// Which frontend is driving the terminal.
 ///
-/// - `Web` — Tauri + TypeScript + Canvas2D (current default)
-/// - `Native` — Iced + wgpu (the migration target)
+/// - `Web` — Tauri + TypeScript + Canvas2D (legacy fallback)
+/// - `Native` — Iced + wgpu (default)
 /// - `Shadow` — headless mode for testing (no rendering)
 ///
-/// Read from `GODLY_FRONTEND_MODE` env var at startup. Defaults to `Web`.
+/// Read from `GODLY_FRONTEND_MODE` env var at startup. Defaults to `Native`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FrontendMode {
@@ -17,17 +17,18 @@ pub enum FrontendMode {
 
 impl Default for FrontendMode {
     fn default() -> Self {
-        Self::Web
+        Self::Native
     }
 }
 
 /// Read the frontend mode from the `GODLY_FRONTEND_MODE` env var.
-/// Returns `FrontendMode::Web` if unset or unrecognized.
+/// Returns `FrontendMode::Native` if unset or unrecognized.
 pub fn frontend_mode() -> FrontendMode {
     match std::env::var("GODLY_FRONTEND_MODE").as_deref() {
+        Ok("web") => FrontendMode::Web,
         Ok("native") => FrontendMode::Native,
         Ok("shadow") => FrontendMode::Shadow,
-        _ => FrontendMode::Web,
+        _ => FrontendMode::Native,
     }
 }
 
@@ -243,8 +244,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_frontend_mode_default_is_web() {
-        assert_eq!(FrontendMode::default(), FrontendMode::Web);
+    fn test_frontend_mode_default_is_native() {
+        assert_eq!(FrontendMode::default(), FrontendMode::Native);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Flip `FrontendMode::default()` from `Web` to `Native`** — the Iced + wgpu frontend is now the default
- **Update `frontend_mode()` fallback** — unrecognized/unset `GODLY_FRONTEND_MODE` env var now resolves to `Native`
- **Add explicit `web` match arm** — users can set `GODLY_FRONTEND_MODE=web` to use the legacy Tauri + Canvas2D frontend
- **Update doc comment and test** to reflect the new default

## Test plan
- [x] `cargo check -p godly-protocol` passes
- [x] All 26 `types` module tests pass (`cargo nextest run -p godly-protocol -E 'test(types)'`)
- [x] Renamed test `test_frontend_mode_default_is_native` asserts `FrontendMode::default() == Native`

> **Note:** One pre-existing test failure in `layout_tree::tests::old_json_without_grid_still_deserializes` is unrelated to this change (serde format mismatch in layout tree backward-compat test).