### PR TITLE
feat: add frontend mode dispatch to Tauri launcher

### DIFF
--- a/changelog/unreleased/phase5-wu3-launcher-dispatch.md
+++ b/changelog/unreleased/phase5-wu3-launcher-dispatch.md
@@ -1,0 +1,2 @@
+### Added
+- **Frontend mode dispatch** — The Tauri app now checks `GODLY_FRONTEND_MODE` and routes to the native Iced shell when mode is `Native`. Falls back to the web frontend if the native binary is not found.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,5 +5,63 @@
 )]
 
 fn main() {
-    godly_terminal_lib::run()
+    let mode = godly_protocol::frontend_mode();
+
+    match mode {
+        godly_protocol::FrontendMode::Native => {
+            // Try to launch the native Iced shell binary.
+            // If it's not found, fall back to the web frontend.
+            match launch_native() {
+                Ok(()) => {} // Native shell launched, this process can exit
+                Err(e) => {
+                    eprintln!("Failed to launch native frontend: {}. Falling back to web.", e);
+                    godly_terminal_lib::run();
+                }
+            }
+        }
+        _ => {
+            // Web or Shadow mode — use the Tauri frontend
+            godly_terminal_lib::run();
+        }
+    }
+}
+
+/// Find and launch the native Iced shell binary (godly-native.exe).
+/// Returns Ok(()) if the native binary was found and launched.
+fn launch_native() -> Result<(), String> {
+    let current_exe = std::env::current_exe()
+        .map_err(|e| format!("Failed to get current exe path: {}", e))?;
+    let exe_dir = current_exe
+        .parent()
+        .ok_or("No parent directory for current exe")?;
+
+    let native_name = if cfg!(windows) {
+        "godly-native.exe"
+    } else {
+        "godly-native"
+    };
+    let native_path = exe_dir.join(native_name);
+
+    if !native_path.exists() {
+        return Err(format!("Native binary not found at {:?}", native_path));
+    }
+
+    // Launch the native binary as a detached process.
+    // Pass through any relevant environment variables.
+    let mut cmd = std::process::Command::new(&native_path);
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // DETACHED_PROCESS (0x00000008) — don't inherit the console
+        cmd.creation_flags(0x00000008);
+    }
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn native binary: {}", e))?;
+
+    // The native binary is running independently — drop our handle.
+    drop(child);
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- The Tauri app's `main.rs` now reads `GODLY_FRONTEND_MODE` via `godly_protocol::frontend_mode()` before starting
- When mode is `Native`, it locates and spawns `godly-native.exe` (the Iced shell) as a detached process, then exits
- Falls back to the standard Tauri web frontend if the native binary is not found or fails to launch
- On Windows, uses `DETACHED_PROCESS` creation flag so the native binary runs independently

## Test plan
- [x] `cargo check -p godly-terminal` passes (with resource stubs)
- [x] `cargo check -p godly-iced-shell` passes
- [ ] CI full build validates cross-crate correctness
- [ ] Manual: set `GODLY_FRONTEND_MODE=native` with `godly-native.exe` present — launches Iced shell
- [ ] Manual: set `GODLY_FRONTEND_MODE=native` without `godly-native.exe` — falls back to web
- [ ] Manual: unset `GODLY_FRONTEND_MODE` (default) — launches web frontend as before