### PR TITLE
Make ai-suggest branch naming provider-agnostic

### DIFF
--- a/src-tauri/llm/src/lib.rs
+++ b/src-tauri/llm/src/lib.rs
@@ -1,5 +1,63 @@
 mod branch_name;
 mod gemini;
+mod openai_compatible;
 
 pub use branch_name::{is_quality_branch_name, sanitize_branch_name};
 pub use gemini::generate_branch_name_gemini;
+pub use openai_compatible::generate_branch_name_openai_compatible;
+
+use anyhow::Result;
+
+pub const PROVIDER_GEMINI: &str = "gemini";
+pub const PROVIDER_OPENAI_COMPATIBLE: &str = "openai-compatible";
+
+pub const DEFAULT_GEMINI_MODEL: &str = "gemini-2.0-flash-lite";
+pub const DEFAULT_OPENAI_COMPAT_MODEL: &str = "gpt-4o-mini";
+
+/// Normalize provider aliases into canonical provider IDs.
+pub fn normalize_provider(provider: &str) -> Option<&'static str> {
+    let normalized = provider.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        PROVIDER_GEMINI => Some(PROVIDER_GEMINI),
+        PROVIDER_OPENAI_COMPATIBLE | "openai_compatible" | "openai" => {
+            Some(PROVIDER_OPENAI_COMPATIBLE)
+        }
+        _ => None,
+    }
+}
+
+/// Return a sensible default model for a given provider.
+pub fn default_model_for_provider(provider: &str) -> &'static str {
+    match normalize_provider(provider) {
+        Some(PROVIDER_OPENAI_COMPATIBLE) => DEFAULT_OPENAI_COMPAT_MODEL,
+        _ => DEFAULT_GEMINI_MODEL,
+    }
+}
+
+/// Generate a branch name using the configured provider backend.
+pub async fn generate_branch_name(
+    provider: &str,
+    api_key: &str,
+    description: &str,
+    model: &str,
+    api_base_url: Option<&str>,
+) -> Result<String> {
+    match normalize_provider(provider) {
+        Some(PROVIDER_GEMINI) => generate_branch_name_gemini(api_key, description, model).await,
+        Some(PROVIDER_OPENAI_COMPATIBLE) => {
+            generate_branch_name_openai_compatible(
+                api_key,
+                description,
+                model,
+                api_base_url,
+            )
+            .await
+        }
+        _ => anyhow::bail!(
+            "Unsupported LLM provider '{}'. Supported providers: '{}', '{}'",
+            provider,
+            PROVIDER_GEMINI,
+            PROVIDER_OPENAI_COMPATIBLE
+        ),
+    }
+}

--- a/src-tauri/llm/src/openai_compatible.rs
+++ b/src-tauri/llm/src/openai_compatible.rs
@@ -1,0 +1,231 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::branch_name::sanitize_branch_name;
+
+const OPENAI_COMPAT_API_BASE: &str = "https://api.openai.com/v1/chat/completions";
+
+const SYSTEM_PROMPT: &str = "\
+You are a git branch name generator. Given a description of a task, output ONLY a short, \
+kebab-case branch name. Rules:\n\
+- Use lowercase letters, numbers, and hyphens only\n\
+- Start with a conventional prefix: feat/, fix/, refactor/, docs/, chore/, test/\n\
+- Keep it under 50 characters total\n\
+- No explanations, just the branch name";
+
+/// Maximum number of retries for rate-limited (429) requests.
+const MAX_RETRIES: u32 = 3;
+
+#[derive(Serialize)]
+struct OpenAiRequest {
+    model: String,
+    messages: Vec<OpenAiMessage>,
+    temperature: f32,
+    max_tokens: u32,
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    choices: Option<Vec<OpenAiChoice>>,
+    error: Option<OpenAiError>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: Option<OpenAiResponseMessage>,
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponseMessage {
+    content: Option<OpenAiContent>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OpenAiContent {
+    Text(String),
+    Parts(Vec<OpenAiContentPart>),
+}
+
+#[derive(Deserialize)]
+struct OpenAiContentPart {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OpenAiError {
+    Structured { message: String },
+    Plain(String),
+}
+
+impl OpenAiError {
+    fn message(&self) -> &str {
+        match self {
+            OpenAiError::Structured { message } => message,
+            OpenAiError::Plain(s) => s,
+        }
+    }
+}
+
+fn extract_text(body: &OpenAiResponse) -> Option<String> {
+    body.choices
+        .as_ref()
+        .and_then(|choices| choices.first())
+        .and_then(|choice| {
+            choice
+                .message
+                .as_ref()
+                .and_then(|message| message.content.as_ref())
+                .and_then(|content| match content {
+                    OpenAiContent::Text(text) => Some(text.clone()),
+                    OpenAiContent::Parts(parts) => parts.iter().find_map(|part| {
+                        if matches!(part.kind.as_deref(), Some("text") | None) {
+                            part.text.clone()
+                        } else {
+                            None
+                        }
+                    }),
+                })
+                .or_else(|| choice.text.clone())
+        })
+}
+
+/// Generate a branch name via an OpenAI-compatible chat-completions endpoint.
+///
+/// `api_base_url` defaults to OpenAI's `/v1/chat/completions` URL, but can point
+/// to any compatible provider endpoint.
+pub async fn generate_branch_name_openai_compatible(
+    api_key: &str,
+    description: &str,
+    model: &str,
+    api_base_url: Option<&str>,
+) -> Result<String> {
+    let client = reqwest::Client::new();
+    let endpoint = api_base_url
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .unwrap_or(OPENAI_COMPAT_API_BASE);
+
+    let request = OpenAiRequest {
+        model: model.trim().to_string(),
+        messages: vec![
+            OpenAiMessage {
+                role: "system".to_string(),
+                content: SYSTEM_PROMPT.to_string(),
+            },
+            OpenAiMessage {
+                role: "user".to_string(),
+                content: description.to_string(),
+            },
+        ],
+        temperature: 0.3,
+        max_tokens: 200,
+    };
+
+    let mut last_error = None;
+    for attempt in 0..=MAX_RETRIES {
+        if attempt > 0 {
+            let delay = std::time::Duration::from_millis(500 * 2u64.pow(attempt - 1));
+            tokio::time::sleep(delay).await;
+        }
+
+        let response = client
+            .post(endpoint)
+            .bearer_auth(api_key)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to call OpenAI-compatible API")?;
+
+        let status = response.status();
+        if status.as_u16() == 429 {
+            last_error = Some(format!("Rate limited (429) on attempt {}", attempt + 1));
+            continue;
+        }
+
+        if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
+            if let Ok(body) = serde_json::from_str::<OpenAiResponse>(&body_text) {
+                if let Some(error) = body.error {
+                    anyhow::bail!(
+                        "OpenAI-compatible API error ({}): {}",
+                        status,
+                        error.message()
+                    );
+                }
+            }
+            anyhow::bail!(
+                "OpenAI-compatible API returned HTTP {}: {}",
+                status,
+                body_text
+            );
+        }
+
+        let body: OpenAiResponse = response
+            .json()
+            .await
+            .context("Failed to parse OpenAI-compatible response")?;
+
+        let raw_text =
+            extract_text(&body).ok_or_else(|| anyhow::anyhow!("No text in LLM response"))?;
+        return Ok(sanitize_branch_name(&raw_text));
+    }
+
+    anyhow::bail!(
+        "OpenAI-compatible API rate limited after {} retries. {}",
+        MAX_RETRIES,
+        last_error.unwrap_or_default()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_text_from_message_string() {
+        let json = r#"{
+            "choices": [{
+                "message": { "role": "assistant", "content": "feat/add-oauth-auth" }
+            }]
+        }"#;
+        let body: OpenAiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_text(&body), Some("feat/add-oauth-auth".to_string()));
+    }
+
+    #[test]
+    fn extract_text_from_message_parts() {
+        let json = r#"{
+            "choices": [{
+                "message": {
+                    "content": [
+                        { "type": "text", "text": "fix/empty-file-crash" }
+                    ]
+                }
+            }]
+        }"#;
+        let body: OpenAiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_text(&body), Some("fix/empty-file-crash".to_string()));
+    }
+
+    #[test]
+    fn extract_text_from_legacy_choice_text() {
+        let json = r#"{
+            "choices": [{
+                "text": "docs/update-readme"
+            }]
+        }"#;
+        let body: OpenAiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_text(&body), Some("docs/update-readme".to_string()));
+    }
+}

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tauri::State;
 
 use crate::llm_state::LlmState;
-use godly_llm::{generate_branch_name_gemini, is_quality_branch_name};
+use godly_llm::{generate_branch_name, is_quality_branch_name, normalize_provider};
 
 #[tauri::command]
 pub async fn llm_has_api_key(llm: State<'_, Arc<LlmState>>) -> Result<bool, String> {
@@ -23,11 +23,46 @@ pub async fn llm_set_api_key(
 }
 
 #[tauri::command]
+pub async fn llm_set_provider(
+    llm: State<'_, Arc<LlmState>>,
+    provider: String,
+) -> Result<(), String> {
+    let provider = normalize_provider(&provider).ok_or_else(|| {
+        format!(
+            "Unsupported provider '{}'. Supported providers: 'gemini', 'openai-compatible'",
+            provider
+        )
+    })?;
+
+    let previous_provider = llm.get_provider();
+    let previous_default_model = godly_llm::default_model_for_provider(&previous_provider);
+    let current_model = llm.get_model();
+
+    llm.set_provider(provider.to_string());
+
+    // Keep model sensible when switching providers.
+    if current_model.trim().is_empty() || current_model == previous_default_model {
+        llm.set_model(godly_llm::default_model_for_provider(provider).to_string());
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn llm_get_provider(llm: State<'_, Arc<LlmState>>) -> Result<String, String> {
+    Ok(llm.get_provider())
+}
+
+#[tauri::command]
 pub async fn llm_set_model(
     llm: State<'_, Arc<LlmState>>,
     model: String,
 ) -> Result<(), String> {
-    llm.set_model(model);
+    let model = model.trim();
+    if model.is_empty() {
+        return Err("Model cannot be empty".to_string());
+    }
+    llm.set_model(model.to_string());
     Ok(())
 }
 
@@ -37,17 +72,44 @@ pub async fn llm_get_model(llm: State<'_, Arc<LlmState>>) -> Result<String, Stri
 }
 
 #[tauri::command]
+pub async fn llm_set_api_base_url(
+    llm: State<'_, Arc<LlmState>>,
+    api_base_url: Option<String>,
+) -> Result<(), String> {
+    let api_base_url = api_base_url
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty());
+    llm.set_api_base_url(api_base_url);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn llm_get_api_base_url(
+    llm: State<'_, Arc<LlmState>>,
+) -> Result<Option<String>, String> {
+    Ok(llm.get_api_base_url())
+}
+
+#[tauri::command]
 pub async fn llm_generate_branch_name(
     llm: State<'_, Arc<LlmState>>,
     description: String,
 ) -> Result<String, String> {
     let api_key = llm.get_api_key().ok_or_else(|| {
-        "No API key configured. Add your Google Gemini API key in Settings > Branch Name AI."
+        "No API key configured. Add your provider API key in Settings > Branch Name AI."
             .to_string()
     })?;
+    let provider = llm.get_provider();
     let model = llm.get_model();
+    let api_base_url = llm.get_api_base_url();
 
-    let name = generate_branch_name_gemini(&api_key, &description, &model)
+    let name = generate_branch_name(
+        &provider,
+        &api_key,
+        &description,
+        &model,
+        api_base_url.as_deref(),
+    )
         .await
         .map_err(|e| format!("Branch name generation failed: {}", e))?;
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -363,8 +363,18 @@ pub async fn quick_claude(
     // Auto-generate branch name from prompt if not provided
     let branch_name = if use_worktree && branch_name.is_none() {
         if let Some(api_key) = llm.get_api_key() {
+            let provider = llm.get_provider();
             let model = llm.get_model();
-            match godly_llm::generate_branch_name_gemini(&api_key, &prompt, &model).await {
+            let api_base_url = llm.get_api_base_url();
+            match godly_llm::generate_branch_name(
+                &provider,
+                &api_key,
+                &prompt,
+                &model,
+                api_base_url.as_deref(),
+            )
+            .await
+            {
                 Ok(name) if godly_llm::is_quality_branch_name(&name) => Some(name),
                 _ => None,
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -313,8 +313,12 @@ pub fn run() {
             // --- LLM ---
             commands::llm_has_api_key,
             commands::llm_set_api_key,
+            commands::llm_set_provider,
+            commands::llm_get_provider,
             commands::llm_set_model,
             commands::llm_get_model,
+            commands::llm_set_api_base_url,
+            commands::llm_get_api_base_url,
             commands::llm_generate_branch_name,
             // --- Whisper ---
             commands::whisper_is_available,

--- a/src-tauri/src/llm_state.rs
+++ b/src-tauri/src/llm_state.rs
@@ -1,20 +1,28 @@
 use parking_lot::RwLock;
 
-/// Default Gemini model for branch name generation.
-const DEFAULT_MODEL: &str = "gemini-2.0-flash-lite";
+/// Default provider for branch name generation.
+const DEFAULT_PROVIDER: &str = godly_llm::PROVIDER_GEMINI;
+/// Default model for branch name generation.
+const DEFAULT_MODEL: &str = godly_llm::DEFAULT_GEMINI_MODEL;
 
 pub struct LlmState {
-    /// Google Gemini API key for branch name generation.
+    /// LLM provider API key for branch name generation.
     pub api_key: RwLock<Option<String>>,
-    /// Selected Gemini model ID.
+    /// Selected provider ID.
+    pub provider: RwLock<String>,
+    /// Selected model ID.
     pub model: RwLock<String>,
+    /// Optional custom API base URL (used by compatible providers).
+    pub api_base_url: RwLock<Option<String>>,
 }
 
 impl LlmState {
     pub fn new() -> Self {
         Self {
             api_key: RwLock::new(None),
+            provider: RwLock::new(DEFAULT_PROVIDER.to_string()),
             model: RwLock::new(DEFAULT_MODEL.to_string()),
+            api_base_url: RwLock::new(None),
         }
     }
 
@@ -30,11 +38,27 @@ impl LlmState {
         self.api_key.read().is_some()
     }
 
+    pub fn set_provider(&self, provider: String) {
+        *self.provider.write() = provider;
+    }
+
+    pub fn get_provider(&self) -> String {
+        self.provider.read().clone()
+    }
+
     pub fn set_model(&self, model: String) {
         *self.model.write() = model;
     }
 
     pub fn get_model(&self) -> String {
         self.model.read().clone()
+    }
+
+    pub fn set_api_base_url(&self, api_base_url: Option<String>) {
+        *self.api_base_url.write() = api_base_url;
+    }
+
+    pub fn get_api_base_url(&self) -> Option<String> {
+        self.api_base_url.read().clone()
     }
 }

--- a/src-tauri/src/mcp_server/handler.rs
+++ b/src-tauri/src/mcp_server/handler.rs
@@ -512,11 +512,19 @@ pub fn handle_mcp_request(
             // Auto-generate branch name from prompt if not provided
             let branch_name = if use_worktree && branch_name.is_none() {
                 if let Some(api_key) = llm_state.get_api_key() {
+                    let provider = llm_state.get_provider();
                     let model = llm_state.get_model();
+                    let api_base_url = llm_state.get_api_base_url();
                     tokio::runtime::Runtime::new()
                         .ok()
                         .and_then(|rt| {
-                            rt.block_on(godly_llm::generate_branch_name_gemini(&api_key, prompt, &model))
+                            rt.block_on(godly_llm::generate_branch_name(
+                                &provider,
+                                &api_key,
+                                prompt,
+                                &model,
+                                api_base_url.as_deref(),
+                            ))
                                 .ok()
                         })
                         .filter(|name| godly_llm::is_quality_branch_name(name))

--- a/src/plugins/smollm2/index.ts
+++ b/src/plugins/smollm2/index.ts
@@ -1,58 +1,170 @@
 import type { GodlyPlugin, PluginContext } from '../types';
 import {
+  llmGenerateBranchName,
   llmHasApiKey,
+  llmSetApiBaseUrl,
   llmSetApiKey,
   llmSetModel,
-  llmGenerateBranchName,
+  llmSetProvider,
+  type BranchAiProvider,
 } from './llm-service';
+
+const PROVIDER_SETTINGS_KEY = 'llmProvider';
+const GEMINI_API_KEY_SETTINGS_KEY = 'geminiApiKey';
+const GEMINI_MODEL_SETTINGS_KEY = 'geminiModel';
+
+function normalizeProvider(provider: string | null | undefined): BranchAiProvider {
+  return provider === 'openai-compatible' ? 'openai-compatible' : 'gemini';
+}
+
+function defaultModelForProvider(provider: BranchAiProvider): string {
+  return provider === 'openai-compatible' ? 'gpt-4o-mini' : 'gemini-2.0-flash-lite';
+}
+
+function keyStorageKey(provider: BranchAiProvider): string {
+  return `llmApiKey.${provider}`;
+}
+
+function modelStorageKey(provider: BranchAiProvider): string {
+  return `llmModel.${provider}`;
+}
+
+function apiBaseUrlStorageKey(provider: BranchAiProvider): string {
+  return `llmApiBaseUrl.${provider}`;
+}
+
+function providerLabel(provider: BranchAiProvider): string {
+  return provider === 'openai-compatible' ? 'OpenAI-Compatible' : 'Google Gemini';
+}
 
 export class SmolLM2Plugin implements GodlyPlugin {
   id = 'smollm2';
   name = 'Branch Name AI';
-  description = 'Generate branch names from task descriptions using Google Gemini Flash (free tier).';
+  description = 'Generate branch names from task descriptions with a configurable LLM provider.';
   version = '2.0.0';
 
   private ctx!: PluginContext;
   private hasKey = false;
-  private selectedModel = 'gemini-2.0-flash-lite';
+  private selectedProvider: BranchAiProvider = 'gemini';
+  private selectedModel = defaultModelForProvider('gemini');
+  private apiBaseUrl = '';
 
+  private getSavedApiKey(provider: BranchAiProvider): string | null {
+    if (provider === 'gemini') {
+      return this.ctx.getSetting<string | null>(
+        keyStorageKey(provider),
+        this.ctx.getSetting<string | null>(GEMINI_API_KEY_SETTINGS_KEY, null),
+      );
+    }
+    return this.ctx.getSetting<string | null>(keyStorageKey(provider), null);
+  }
+
+  private setSavedApiKey(provider: BranchAiProvider, key: string | null): void {
+    this.ctx.setSetting(keyStorageKey(provider), key);
+    if (provider === 'gemini') {
+      this.ctx.setSetting(GEMINI_API_KEY_SETTINGS_KEY, key);
+    }
+  }
+
+  private getSavedModel(provider: BranchAiProvider): string | null {
+    if (provider === 'gemini') {
+      return this.ctx.getSetting<string | null>(
+        modelStorageKey(provider),
+        this.ctx.getSetting<string | null>(GEMINI_MODEL_SETTINGS_KEY, null),
+      );
+    }
+    return this.ctx.getSetting<string | null>(modelStorageKey(provider), null);
+  }
+
+  private setSavedModel(provider: BranchAiProvider, model: string): void {
+    this.ctx.setSetting(modelStorageKey(provider), model);
+    if (provider === 'gemini') {
+      this.ctx.setSetting(GEMINI_MODEL_SETTINGS_KEY, model);
+    }
+  }
+
+  private getSavedApiBaseUrl(provider: BranchAiProvider): string | null {
+    return this.ctx.getSetting<string | null>(apiBaseUrlStorageKey(provider), null);
+  }
+
+  private setSavedApiBaseUrl(provider: BranchAiProvider, apiBaseUrl: string | null): void {
+    this.ctx.setSetting(apiBaseUrlStorageKey(provider), apiBaseUrl);
+  }
+
+  private getProviderMeta(provider: BranchAiProvider): {
+    keyTitle: string;
+    keyHint: string;
+    modelPlaceholder: string;
+    modelLabel: string;
+    showBaseUrl: boolean;
+    baseUrlPlaceholder: string;
+    baseUrlHint: string;
+  } {
+    if (provider === 'openai-compatible') {
+      return {
+        keyTitle: 'Provider API Key',
+        keyHint: 'Works with OpenAI and any OpenAI-compatible provider.',
+        modelLabel: 'Model',
+        modelPlaceholder: 'e.g. gpt-4o-mini',
+        showBaseUrl: true,
+        baseUrlPlaceholder: 'https://api.openai.com/v1/chat/completions',
+        baseUrlHint: 'Use a custom endpoint for OpenRouter, Groq, local gateways, etc.',
+      };
+    }
+    return {
+      keyTitle: 'Google Gemini API Key',
+      keyHint: 'Free tier: 250 req/day. Get a key from Google AI Studio.',
+      modelLabel: 'Model',
+      modelPlaceholder: 'e.g. gemini-2.0-flash-lite',
+      showBaseUrl: false,
+      baseUrlPlaceholder: '',
+      baseUrlHint: '',
+    };
+  }
 
   async init(ctx: PluginContext): Promise<void> {
     this.ctx = ctx;
     try {
       this.hasKey = await llmHasApiKey();
     } catch {
-      // Assume no key
+      // Assume not configured
     }
   }
 
   async enable(): Promise<void> {
-    // Restore saved API key into backend state
-    const savedKey = this.ctx.getSetting<string | null>('geminiApiKey', null);
-    if (savedKey) {
-      try {
-        await llmSetApiKey(savedKey);
-        this.hasKey = true;
-      } catch (e) {
-        console.warn('[BranchNameAI] Failed to restore API key:', e);
-      }
-    }
-    // Restore saved model
-    const savedModel = this.ctx.getSetting<string | null>('geminiModel', null);
-    if (savedModel) {
-      this.selectedModel = savedModel;
-      try {
-        await llmSetModel(savedModel);
-      } catch (e) {
-        console.warn('[BranchNameAI] Failed to restore model:', e);
-      }
+    const provider = normalizeProvider(
+      this.ctx.getSetting<string | null>(PROVIDER_SETTINGS_KEY, this.selectedProvider),
+    );
+    this.selectedProvider = provider;
+    this.ctx.setSetting(PROVIDER_SETTINGS_KEY, provider);
+
+    const savedKey = this.getSavedApiKey(provider);
+    const savedModel = this.getSavedModel(provider) ?? defaultModelForProvider(provider);
+    const savedBaseUrl = this.getSavedApiBaseUrl(provider) ?? '';
+
+    this.selectedModel = savedModel;
+    this.apiBaseUrl = savedBaseUrl;
+    this.hasKey = Boolean(savedKey);
+
+    // Persist migrated/default model so provider switches keep stable defaults.
+    this.setSavedModel(provider, savedModel);
+
+    try {
+      await llmSetProvider(provider);
+      await llmSetApiKey(savedKey);
+      await llmSetModel(savedModel);
+      await llmSetApiBaseUrl(provider === 'openai-compatible' ? (savedBaseUrl || null) : null);
+      this.hasKey = await llmHasApiKey();
+    } catch (e) {
+      console.warn('[BranchNameAI] Failed to restore provider settings:', e);
     }
   }
 
   async disable(): Promise<void> {
-    // Clear API key from backend memory (stays in settings for next enable)
+    // Clear sensitive values from backend memory (settings stay persisted).
     try {
       await llmSetApiKey(null);
+      await llmSetApiBaseUrl(null);
       this.hasKey = false;
     } catch {
       // ignore
@@ -65,17 +177,47 @@ export class SmolLM2Plugin implements GodlyPlugin {
     const container = document.createElement('div');
     container.className = 'smollm2-settings';
 
+    // -- Provider section --
+    const providerSection = document.createElement('div');
+    providerSection.className = 'settings-section';
+    const providerTitle = document.createElement('div');
+    providerTitle.className = 'settings-section-title';
+    providerTitle.textContent = 'Provider';
+    providerSection.appendChild(providerTitle);
+
+    const providerRow = document.createElement('div');
+    providerRow.className = 'shortcut-row';
+    providerRow.style.gap = '8px';
+
+    const providerInput = document.createElement('select');
+    providerInput.className = 'dialog-input';
+    providerInput.style.cssText = 'flex: 1; font-size: 12px;';
+
+    const geminiOption = document.createElement('option');
+    geminiOption.value = 'gemini';
+    geminiOption.textContent = 'Google Gemini';
+    providerInput.appendChild(geminiOption);
+
+    const openaiOption = document.createElement('option');
+    openaiOption.value = 'openai-compatible';
+    openaiOption.textContent = 'OpenAI-Compatible';
+    providerInput.appendChild(openaiOption);
+
+    providerInput.value = this.selectedProvider;
+    providerRow.appendChild(providerInput);
+    providerSection.appendChild(providerRow);
+    container.appendChild(providerSection);
+
     // -- API Key section --
     const keySection = document.createElement('div');
     keySection.className = 'settings-section';
     const keyTitle = document.createElement('div');
     keyTitle.className = 'settings-section-title';
-    keyTitle.textContent = 'Google Gemini API Key';
     keySection.appendChild(keyTitle);
 
     const keyHint = document.createElement('div');
-    keyHint.style.cssText = 'padding: 0 12px; font-size: 10px; color: var(--text-secondary); margin-bottom: 8px;';
-    keyHint.textContent = 'Free tier: 250 req/day. Get a key from Google AI Studio.';
+    keyHint.style.cssText =
+      'padding: 0 12px; font-size: 10px; color: var(--text-secondary); margin-bottom: 8px;';
     keySection.appendChild(keyHint);
 
     const keyRow = document.createElement('div');
@@ -85,53 +227,23 @@ export class SmolLM2Plugin implements GodlyPlugin {
     const keyInput = document.createElement('input');
     keyInput.type = 'password';
     keyInput.className = 'dialog-input';
-    keyInput.placeholder = 'AIza...';
     keyInput.style.cssText = 'flex: 1; font-size: 12px; font-family: monospace;';
-
-    // Show saved key if exists
-    const savedKey = this.ctx.getSetting<string | null>('geminiApiKey', null);
-    if (savedKey) {
-      keyInput.value = savedKey;
-    }
 
     const statusDot = document.createElement('span');
     statusDot.style.cssText = 'font-size: 11px; white-space: nowrap;';
-    const updateStatus = () => {
-      if (this.hasKey) {
-        statusDot.textContent = 'Active';
-        statusDot.style.color = 'var(--accent)';
-      } else {
-        statusDot.textContent = 'Not set';
-        statusDot.style.color = 'var(--text-secondary)';
-      }
-    };
-    updateStatus();
 
     const saveBtn = document.createElement('button');
     saveBtn.className = 'dialog-btn dialog-btn-primary';
     saveBtn.textContent = 'Save';
     saveBtn.style.fontSize = '11px';
-    saveBtn.onclick = async () => {
-      const key = keyInput.value.trim();
-      saveBtn.disabled = true;
-      saveBtn.textContent = 'Saving...';
-      try {
-        if (key) {
-          await llmSetApiKey(key);
-          this.ctx.setSetting('geminiApiKey', key);
-          this.hasKey = true;
-        } else {
-          await llmSetApiKey(null);
-          this.ctx.setSetting('geminiApiKey', null);
-          this.hasKey = false;
-        }
-        updateStatus();
-      } catch (e) {
-        statusDot.textContent = `Error: ${e}`;
-        statusDot.style.color = 'var(--error)';
-      } finally {
-        saveBtn.disabled = false;
-        saveBtn.textContent = 'Save';
+
+    const updateStatus = () => {
+      if (this.hasKey) {
+        statusDot.textContent = `Active (${providerLabel(this.selectedProvider)})`;
+        statusDot.style.color = 'var(--accent)';
+      } else {
+        statusDot.textContent = 'Not set';
+        statusDot.style.color = 'var(--text-secondary)';
       }
     };
 
@@ -141,12 +253,11 @@ export class SmolLM2Plugin implements GodlyPlugin {
     keySection.appendChild(keyRow);
     container.appendChild(keySection);
 
-    // -- Model selector section --
+    // -- Model section --
     const modelSection = document.createElement('div');
     modelSection.className = 'settings-section';
     const modelTitle = document.createElement('div');
     modelTitle.className = 'settings-section-title';
-    modelTitle.textContent = 'Gemini Model';
     modelSection.appendChild(modelTitle);
 
     const modelRow = document.createElement('div');
@@ -157,13 +268,121 @@ export class SmolLM2Plugin implements GodlyPlugin {
     modelInput.type = 'text';
     modelInput.className = 'dialog-input';
     modelInput.style.cssText = 'flex: 1; font-size: 12px;';
-    modelInput.placeholder = 'e.g. gemini-2.0-flash-lite';
-    modelInput.value = this.selectedModel;
+    modelRow.appendChild(modelInput);
+    modelSection.appendChild(modelRow);
+    container.appendChild(modelSection);
+
+    // -- API Base URL section (openai-compatible only) --
+    const baseUrlSection = document.createElement('div');
+    baseUrlSection.className = 'settings-section';
+    const baseUrlTitle = document.createElement('div');
+    baseUrlTitle.className = 'settings-section-title';
+    baseUrlTitle.textContent = 'API Base URL';
+    baseUrlSection.appendChild(baseUrlTitle);
+
+    const baseUrlHint = document.createElement('div');
+    baseUrlHint.style.cssText =
+      'padding: 0 12px; font-size: 10px; color: var(--text-secondary); margin-bottom: 8px;';
+    baseUrlSection.appendChild(baseUrlHint);
+
+    const baseUrlRow = document.createElement('div');
+    baseUrlRow.className = 'shortcut-row';
+    baseUrlRow.style.gap = '8px';
+
+    const baseUrlInput = document.createElement('input');
+    baseUrlInput.type = 'text';
+    baseUrlInput.className = 'dialog-input';
+    baseUrlInput.style.cssText = 'flex: 1; font-size: 12px; font-family: monospace;';
+    baseUrlRow.appendChild(baseUrlInput);
+    baseUrlSection.appendChild(baseUrlRow);
+    container.appendChild(baseUrlSection);
+
+    const syncUiFromProvider = (provider: BranchAiProvider) => {
+      const meta = this.getProviderMeta(provider);
+      keyTitle.textContent = meta.keyTitle;
+      keyHint.textContent = meta.keyHint;
+      modelTitle.textContent = meta.modelLabel;
+      modelInput.placeholder = meta.modelPlaceholder;
+      baseUrlHint.textContent = meta.baseUrlHint;
+      baseUrlInput.placeholder = meta.baseUrlPlaceholder;
+      baseUrlSection.style.display = meta.showBaseUrl ? '' : 'none';
+    };
+
+    const loadProviderStateIntoFields = (provider: BranchAiProvider) => {
+      const savedKey = this.getSavedApiKey(provider) ?? '';
+      const savedModel = this.getSavedModel(provider) ?? defaultModelForProvider(provider);
+      const savedBaseUrl = this.getSavedApiBaseUrl(provider) ?? '';
+
+      this.selectedModel = savedModel;
+      this.apiBaseUrl = savedBaseUrl;
+      this.hasKey = Boolean(savedKey);
+
+      keyInput.value = savedKey;
+      modelInput.value = savedModel;
+      baseUrlInput.value = savedBaseUrl;
+      updateStatus();
+    };
+
+    const applyProviderToBackend = async (provider: BranchAiProvider): Promise<void> => {
+      const key = keyInput.value.trim();
+      const model = modelInput.value.trim() || defaultModelForProvider(provider);
+      const apiBaseUrl = baseUrlInput.value.trim();
+
+      await llmSetProvider(provider);
+      await llmSetApiKey(key || null);
+      await llmSetModel(model);
+      await llmSetApiBaseUrl(provider === 'openai-compatible' ? (apiBaseUrl || null) : null);
+    };
+
+    providerInput.onchange = async () => {
+      const provider = normalizeProvider(providerInput.value);
+      providerInput.disabled = true;
+
+      this.selectedProvider = provider;
+      this.ctx.setSetting(PROVIDER_SETTINGS_KEY, provider);
+      syncUiFromProvider(provider);
+      loadProviderStateIntoFields(provider);
+
+      // Ensure a default model exists in settings for this provider.
+      if (!this.getSavedModel(provider)) {
+        this.setSavedModel(provider, this.selectedModel);
+      }
+
+      try {
+        await applyProviderToBackend(provider);
+        this.hasKey = await llmHasApiKey();
+        updateStatus();
+      } catch (e) {
+        statusDot.textContent = `Error: ${e}`;
+        statusDot.style.color = 'var(--error)';
+      } finally {
+        providerInput.disabled = false;
+      }
+    };
+
+    saveBtn.onclick = async () => {
+      const key = keyInput.value.trim();
+      saveBtn.disabled = true;
+      saveBtn.textContent = 'Saving...';
+      try {
+        await llmSetApiKey(key || null);
+        this.setSavedApiKey(this.selectedProvider, key || null);
+        this.hasKey = Boolean(key);
+        updateStatus();
+      } catch (e) {
+        statusDot.textContent = `Error: ${e}`;
+        statusDot.style.color = 'var(--error)';
+      } finally {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+      }
+    };
+
     modelInput.onchange = async () => {
       const model = modelInput.value.trim();
       if (!model) return;
       this.selectedModel = model;
-      this.ctx.setSetting('geminiModel', model);
+      this.setSavedModel(this.selectedProvider, model);
       try {
         await llmSetModel(model);
       } catch (e) {
@@ -171,9 +390,20 @@ export class SmolLM2Plugin implements GodlyPlugin {
       }
     };
 
-    modelRow.appendChild(modelInput);
-    modelSection.appendChild(modelRow);
-    container.appendChild(modelSection);
+    baseUrlInput.onchange = async () => {
+      if (this.selectedProvider !== 'openai-compatible') return;
+      const apiBaseUrl = baseUrlInput.value.trim();
+      this.apiBaseUrl = apiBaseUrl;
+      this.setSavedApiBaseUrl(this.selectedProvider, apiBaseUrl || null);
+      try {
+        await llmSetApiBaseUrl(apiBaseUrl || null);
+      } catch (e) {
+        console.warn('[BranchNameAI] Failed to set API base URL:', e);
+      }
+    };
+
+    syncUiFromProvider(this.selectedProvider);
+    loadProviderStateIntoFields(this.selectedProvider);
 
     // -- Test Generation section --
     const testSection = document.createElement('div');

--- a/src/plugins/smollm2/llm-service.test.ts
+++ b/src/plugins/smollm2/llm-service.test.ts
@@ -8,9 +8,13 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 import {
+  llmGetApiBaseUrl,
+  llmGetProvider,
   llmHasApiKey,
-  llmSetApiKey,
   llmGenerateBranchName,
+  llmSetApiBaseUrl,
+  llmSetApiKey,
+  llmSetProvider,
 } from './llm-service';
 
 describe('llm-service', () => {
@@ -37,6 +41,19 @@ describe('llm-service', () => {
     expect(mockInvoke).toHaveBeenCalledWith('llm_set_api_key', { key: null });
   });
 
+  it('llmSetProvider invokes with provider', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    await llmSetProvider('openai-compatible');
+    expect(mockInvoke).toHaveBeenCalledWith('llm_set_provider', { provider: 'openai-compatible' });
+  });
+
+  it('llmGetProvider invokes correct command', async () => {
+    mockInvoke.mockResolvedValue('gemini');
+    const provider = await llmGetProvider();
+    expect(mockInvoke).toHaveBeenCalledWith('llm_get_provider');
+    expect(provider).toBe('gemini');
+  });
+
   it('llmGenerateBranchName passes description', async () => {
     mockInvoke.mockResolvedValue('feat/add-login');
     const result = await llmGenerateBranchName('Add login page');
@@ -44,5 +61,20 @@ describe('llm-service', () => {
       description: 'Add login page',
     });
     expect(result).toBe('feat/add-login');
+  });
+
+  it('llmSetApiBaseUrl invokes with URL', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    await llmSetApiBaseUrl('https://example.com/v1/chat/completions');
+    expect(mockInvoke).toHaveBeenCalledWith('llm_set_api_base_url', {
+      apiBaseUrl: 'https://example.com/v1/chat/completions',
+    });
+  });
+
+  it('llmGetApiBaseUrl invokes correct command', async () => {
+    mockInvoke.mockResolvedValue('https://example.com/v1/chat/completions');
+    const result = await llmGetApiBaseUrl();
+    expect(mockInvoke).toHaveBeenCalledWith('llm_get_api_base_url');
+    expect(result).toBe('https://example.com/v1/chat/completions');
   });
 });

--- a/src/plugins/smollm2/llm-service.ts
+++ b/src/plugins/smollm2/llm-service.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+export type BranchAiProvider = 'gemini' | 'openai-compatible';
+
 export async function llmHasApiKey(): Promise<boolean> {
   return invoke<boolean>('llm_has_api_key');
 }
@@ -8,12 +10,28 @@ export async function llmSetApiKey(key: string | null): Promise<void> {
   return invoke<void>('llm_set_api_key', { key });
 }
 
+export async function llmSetProvider(provider: BranchAiProvider): Promise<void> {
+  return invoke<void>('llm_set_provider', { provider });
+}
+
+export async function llmGetProvider(): Promise<BranchAiProvider> {
+  return invoke<BranchAiProvider>('llm_get_provider');
+}
+
 export async function llmSetModel(model: string): Promise<void> {
   return invoke<void>('llm_set_model', { model });
 }
 
 export async function llmGetModel(): Promise<string> {
   return invoke<string>('llm_get_model');
+}
+
+export async function llmSetApiBaseUrl(apiBaseUrl: string | null): Promise<void> {
+  return invoke<void>('llm_set_api_base_url', { apiBaseUrl });
+}
+
+export async function llmGetApiBaseUrl(): Promise<string | null> {
+  return invoke<string | null>('llm_get_api_base_url');
 }
 
 export async function llmGenerateBranchName(description: string): Promise<string> {


### PR DESCRIPTION
## Summary
- make AI branch-name generation provider-agnostic instead of Gemini-only
- add backend support for an `openai-compatible` provider alongside existing Gemini support
- thread provider settings (`provider`, `apiBaseUrl`) through Tauri state/commands, quick-claude flow, and MCP quick-claude handler
- update smollm2 plugin settings and service APIs to select provider and base URL, with backward-compatible defaults
- add/extend unit tests for provider settings and OpenAI-compatible response parsing

## Testing
- `cargo test -p godly-llm`
- `pnpm test -- src/plugins/smollm2/llm-service.test.ts`

## Notes
- `cargo check -p godly-terminal --lib` still fails in this environment due existing Tauri build-script release-resource path resolution.
