### PR TITLE
feat: add workspace-scoped GitHub auth token policies

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -4,6 +4,7 @@ use tauri::{Emitter, State};
 use uuid::Uuid;
 
 use crate::daemon_client::DaemonClient;
+use crate::github_auth;
 use crate::llm_state::LlmState;
 use crate::persistence::AutoSaveManager;
 use crate::state::{AppState, SessionMetadata, ShellType, Terminal};
@@ -48,9 +49,17 @@ pub fn create_terminal(
             match crate::worktree::get_repo_root(&ws.folder_path, wsl.as_ref()) {
                 Ok(repo_root) => {
                     let custom_name = worktree_name.as_deref();
-                    match crate::worktree::create_worktree(&repo_root, &terminal_id, custom_name, wsl.as_ref()) {
+                    match crate::worktree::create_worktree(
+                        &repo_root,
+                        &terminal_id,
+                        custom_name,
+                        wsl.as_ref(),
+                    ) {
                         Ok(wt_result) => {
-                            eprintln!("[terminal] Created worktree at: {} (branch: {})", wt_result.path, wt_result.branch);
+                            eprintln!(
+                                "[terminal] Created worktree at: {} (branch: {})",
+                                wt_result.path, wt_result.branch
+                            );
                             worktree_path_result = Some(wt_result.path.clone());
                             worktree_branch = Some(wt_result.branch);
                             Some(wt_result.path)
@@ -102,6 +111,16 @@ pub fn create_terminal(
                 );
             }
         }
+    }
+
+    if let Some(ref ws) = workspace {
+        let policy = state.get_workspace_github_auth_policy(&workspace_id);
+        github_auth::inject_workspace_github_token_env(
+            &mut env_vars,
+            ws,
+            working_dir.as_deref(),
+            &policy,
+        );
     }
 
     // Create session via daemon
@@ -157,7 +176,10 @@ pub fn create_terminal(
 
     auto_save.mark_dirty();
 
-    Ok(CreateTerminalResult { id: terminal_id, worktree_branch })
+    Ok(CreateTerminalResult {
+        id: terminal_id,
+        worktree_branch,
+    })
 }
 
 #[tauri::command]
@@ -201,9 +223,7 @@ pub fn write_to_terminal(
     // Convert \n → \r for PTY: terminals expect CR (Enter), not LF.
     // Frontend already sends \r for Enter, so this is a no-op for keyboard input
     // but fixes programmatic writes (MCP, paste) that use \n.
-    let converted = data
-        .replace("\r\n", "\r")
-        .replace('\n', "\r");
+    let converted = data.replace("\r\n", "\r").replace('\n', "\r");
     let request = Request::Write {
         session_id: terminal_id,
         data: converted.into_bytes(),
@@ -250,9 +270,7 @@ pub fn rename_terminal(
 
 /// List live sessions from the daemon (for reconnection on app restart)
 #[tauri::command]
-pub fn reconnect_sessions(
-    daemon: State<Arc<DaemonClient>>,
-) -> Result<Vec<SessionInfo>, String> {
+pub fn reconnect_sessions(daemon: State<Arc<DaemonClient>>) -> Result<Vec<SessionInfo>, String> {
     let request = Request::ListSessions;
     let response = daemon.send_request(&request)?;
     match response {
@@ -426,7 +444,11 @@ pub async fn quick_claude(
     env_vars.insert("GODLY_WORKSPACE_ID".to_string(), workspace_id.clone());
     if let Ok(current_exe) = std::env::current_exe() {
         if let Some(exe_dir) = current_exe.parent() {
-            let mcp_name = if cfg!(windows) { "godly-mcp.exe" } else { "godly-mcp" };
+            let mcp_name = if cfg!(windows) {
+                "godly-mcp.exe"
+            } else {
+                "godly-mcp"
+            };
             let mcp_path = exe_dir.join(mcp_name);
             if mcp_path.exists() {
                 env_vars.insert(
@@ -436,6 +458,14 @@ pub async fn quick_claude(
             }
         }
     }
+
+    let github_policy = state.get_workspace_github_auth_policy(&workspace_id);
+    github_auth::inject_workspace_github_token_env(
+        &mut env_vars,
+        &workspace,
+        working_dir.as_deref(),
+        &github_policy,
+    );
 
     // Create session via daemon
     let request = Request::CreateSession {
@@ -498,9 +528,21 @@ pub async fn quick_claude(
     let use_codex = ai_tool.as_deref() == Some("codex");
     std::thread::spawn(move || {
         if use_codex {
-            quick_codex_background(daemon_bg, app_handle_bg, terminal_id_bg, prompt, terminal_name);
+            quick_codex_background(
+                daemon_bg,
+                app_handle_bg,
+                terminal_id_bg,
+                prompt,
+                terminal_name,
+            );
         } else {
-            quick_claude_background(daemon_bg, app_handle_bg, terminal_id_bg, prompt, terminal_name);
+            quick_claude_background(
+                daemon_bg,
+                app_handle_bg,
+                terminal_id_bg,
+                prompt,
+                terminal_name,
+            );
         }
     });
 
@@ -522,13 +564,17 @@ pub(crate) fn quick_claude_background(
     // Step 1: Wait for shell to be ready (idle for 500ms, timeout 5s)
     let shell_ready = poll_idle(&daemon, &terminal_id, 500, 5_000);
     if !shell_ready {
-        eprintln!("[quick_claude] Shell did not become idle in time, writing claude command anyway");
+        eprintln!(
+            "[quick_claude] Shell did not become idle in time, writing claude command anyway"
+        );
     }
 
     // Step 2: Write claude command
     let claude_cmd = Request::Write {
         session_id: terminal_id.clone(),
-        data: "claude --dangerously-skip-permissions\r".as_bytes().to_vec(),
+        data: "claude --dangerously-skip-permissions\r"
+            .as_bytes()
+            .to_vec(),
     };
     if let Err(e) = daemon.send_fire_and_forget(&claude_cmd) {
         eprintln!("[quick_claude] Failed to write claude command: {}", e);
@@ -548,7 +594,9 @@ pub(crate) fn quick_claude_background(
     // If a trust prompt appears at any point, auto-accept it and keep polling.
     let claude_ready = poll_idle_or_trust(&daemon, &terminal_id, 400, 25_000);
     if !claude_ready {
-        eprintln!("[quick_claude] Claude did not become idle within timeout, writing prompt anyway");
+        eprintln!(
+            "[quick_claude] Claude did not become idle within timeout, writing prompt anyway"
+        );
     }
 
     // Step 4: Small delay to ensure Claude is fully accepting input
@@ -608,7 +656,11 @@ pub(crate) fn quick_claude_background(
             data: b"\r".to_vec(),
         };
         if let Err(e) = daemon.send_fire_and_forget(&submit_req) {
-            eprintln!("[quick_claude] Failed to send submit key (attempt {}): {}", attempt + 1, e);
+            eprintln!(
+                "[quick_claude] Failed to send submit key (attempt {}): {}",
+                attempt + 1,
+                e
+            );
             return;
         }
 
@@ -706,9 +758,13 @@ fn quick_codex_background(
 }
 
 /// Poll until the terminal has been idle for `idle_ms` milliseconds, or timeout.
-pub(crate) fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, timeout_ms: u64) -> bool {
-    let deadline =
-        std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+pub(crate) fn poll_idle(
+    daemon: &DaemonClient,
+    session_id: &str,
+    idle_ms: u64,
+    timeout_ms: u64,
+) -> bool {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
     let poll_interval = (idle_ms / 4).min(500).max(50);
 
     loop {
@@ -716,7 +772,9 @@ pub(crate) fn poll_idle(daemon: &DaemonClient, session_id: &str, idle_ms: u64, t
             session_id: session_id.to_string(),
         };
         match daemon.send_request(&req) {
-            Ok(Response::LastOutputTime { epoch_ms, running, .. }) => {
+            Ok(Response::LastOutputTime {
+                epoch_ms, running, ..
+            }) => {
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -765,7 +823,9 @@ fn poll_idle_or_trust(
             session_id: session_id.to_string(),
         };
         let is_idle = match daemon.send_request(&req) {
-            Ok(Response::LastOutputTime { epoch_ms, running, .. }) => {
+            Ok(Response::LastOutputTime {
+                epoch_ms, running, ..
+            }) => {
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -851,7 +911,10 @@ fn has_trust_prompt(daemon: &DaemonClient, session_id: &str) -> bool {
         let screen_text = grid.rows.join(" ");
         for needle in NEEDLES {
             if screen_text.contains(needle) {
-                eprintln!("[quick_claude] Trust prompt found via grid search: {:?}", needle);
+                eprintln!(
+                    "[quick_claude] Trust prompt found via grid search: {:?}",
+                    needle
+                );
                 return true;
             }
         }
@@ -870,8 +933,7 @@ fn poll_text_in_output(
     text: &str,
     timeout_ms: u64,
 ) -> bool {
-    let deadline =
-        std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
 
     loop {
         let req = Request::SearchBuffer {
@@ -920,25 +982,15 @@ fn prompt_disappeared_from_grid(
 /// Pause output streaming for a session (session stays alive, VT parser
 /// keeps running, but no Output/GridDiff events are sent to the client).
 #[tauri::command]
-pub fn pause_session(
-    session_id: String,
-    daemon: State<Arc<DaemonClient>>,
-) -> Result<(), String> {
-    let request = Request::PauseSession {
-        session_id,
-    };
+pub fn pause_session(session_id: String, daemon: State<Arc<DaemonClient>>) -> Result<(), String> {
+    let request = Request::PauseSession { session_id };
     daemon.send_fire_and_forget(&request)
 }
 
 /// Resume output streaming for a previously paused session.
 #[tauri::command]
-pub fn resume_session(
-    session_id: String,
-    daemon: State<Arc<DaemonClient>>,
-) -> Result<(), String> {
-    let request = Request::ResumeSession {
-        session_id,
-    };
+pub fn resume_session(session_id: String, daemon: State<Arc<DaemonClient>>) -> Result<(), String> {
+    let request = Request::ResumeSession { session_id };
     daemon.send_fire_and_forget(&request)
 }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,13 +1,15 @@
-use std::sync::Arc;
 use godly_protocol::{LayoutNode, SplitDirection};
+use std::sync::Arc;
 use tauri::State;
 use uuid::Uuid;
 
-use std::collections::HashSet;
 use crate::daemon_client::DaemonClient;
 use crate::persistence::AutoSaveManager;
 #[allow(deprecated)]
-use crate::state::{AiToolMode, AppState, ShellType, SplitView, Workspace};
+use crate::state::{
+    AiToolMode, AppState, ShellType, SplitView, Workspace, WorkspaceGitHubAuthPolicy,
+};
+use std::collections::HashSet;
 
 #[tauri::command]
 pub fn create_workspace(
@@ -63,6 +65,56 @@ pub fn delete_workspace(
 #[tauri::command]
 pub fn get_workspaces(state: State<Arc<AppState>>) -> Vec<Workspace> {
     state.get_all_workspaces()
+}
+
+fn is_valid_env_var_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+#[tauri::command]
+pub fn set_workspace_github_auth_policy(
+    workspace_id: String,
+    policy: WorkspaceGitHubAuthPolicy,
+    state: State<Arc<AppState>>,
+    auto_save: State<Arc<AutoSaveManager>>,
+) -> Result<(), String> {
+    if state.get_workspace(&workspace_id).is_none() {
+        return Err("Workspace not found".to_string());
+    }
+
+    if policy.rules.len() > 64 {
+        return Err("GitHub auth policy supports at most 64 rules".to_string());
+    }
+
+    for rule in &policy.rules {
+        if rule.pattern.trim().is_empty() {
+            return Err("GitHub auth rule pattern must not be empty".to_string());
+        }
+        if !is_valid_env_var_name(&rule.token_env_var) {
+            return Err(format!(
+                "Invalid token_env_var '{}': use only letters, numbers, and underscores",
+                rule.token_env_var
+            ));
+        }
+    }
+
+    state.set_workspace_github_auth_policy(&workspace_id, policy);
+    auto_save.mark_dirty();
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_workspace_github_auth_policy(
+    workspace_id: String,
+    state: State<Arc<AppState>>,
+) -> Result<WorkspaceGitHubAuthPolicy, String> {
+    if state.get_workspace(&workspace_id).is_none() {
+        return Err("Workspace not found".to_string());
+    }
+    Ok(state.get_workspace_github_auth_policy(&workspace_id))
 }
 
 #[tauri::command]
@@ -151,7 +203,10 @@ pub fn split_terminal(
         }
     });
     if !tree.split_at(&target_terminal_id, &new_terminal_id, direction, ratio) {
-        return Err(format!("Terminal {} not found in layout tree", target_terminal_id));
+        return Err(format!(
+            "Terminal {} not found in layout tree",
+            target_terminal_id
+        ));
     }
     drop(trees);
     auto_save.mark_dirty();
@@ -168,7 +223,10 @@ pub fn unsplit_terminal(
     let mut trees = state.layout_trees.write();
     if let Some(tree) = trees.get_mut(&workspace_id) {
         // Check if this terminal is the root (only leaf)
-        if let LayoutNode::Leaf { terminal_id: ref id } = tree {
+        if let LayoutNode::Leaf {
+            terminal_id: ref id,
+        } = tree
+        {
             if id == &terminal_id {
                 // Last terminal — remove the tree entirely
                 trees.remove(&workspace_id);
@@ -197,10 +255,7 @@ pub fn unsplit_terminal(
 }
 
 #[tauri::command]
-pub fn get_layout_tree(
-    workspace_id: String,
-    state: State<Arc<AppState>>,
-) -> Option<LayoutNode> {
+pub fn get_layout_tree(workspace_id: String, state: State<Arc<AppState>>) -> Option<LayoutNode> {
     state.get_layout_tree(&workspace_id)
 }
 
@@ -258,4 +313,3 @@ pub fn prune_stale_terminal_ids(
     auto_save.mark_dirty();
     Ok(())
 }
-

--- a/src-tauri/src/github_auth.rs
+++ b/src-tauri/src/github_auth.rs
@@ -1,0 +1,443 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::{Command, Output};
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use winapi::um::winbase::CREATE_NO_WINDOW;
+
+use crate::state::{GitHubTokenRule, Workspace, WorkspaceGitHubAuthPolicy};
+use crate::worktree::{self, WslConfig};
+
+const ENV_GH_TOKEN: &str = "GH_TOKEN";
+const ENV_GITHUB_TOKEN: &str = "GITHUB_TOKEN";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct MatchContext {
+    repo_full: Option<String>,
+    repo_slug: Option<String>,
+    paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepoIdentity {
+    host: String,
+    owner: String,
+    repo: String,
+}
+
+impl RepoIdentity {
+    fn slug(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+
+    fn full(&self) -> String {
+        format!("{}/{}", self.host, self.slug())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct RuleScore {
+    tier: u8,
+    specificity: usize,
+    pattern_len: usize,
+}
+
+pub fn inject_workspace_github_token_env(
+    env_vars: &mut HashMap<String, String>,
+    workspace: &Workspace,
+    working_dir: Option<&str>,
+    policy: &WorkspaceGitHubAuthPolicy,
+) {
+    if policy.rules.is_empty() && !policy.fallback_to_gh_auth {
+        return;
+    }
+
+    let match_ctx = build_match_context(workspace, working_dir);
+
+    if let Some(rule) = select_best_rule(&policy.rules, &match_ctx) {
+        if let Some(token) = load_token_from_env_var(&rule.token_env_var) {
+            set_github_token_env(env_vars, &token);
+            eprintln!(
+                "[github_auth] Applied GitHub token rule '{}' for workspace {}",
+                rule.pattern, workspace.id
+            );
+            return;
+        }
+
+        eprintln!(
+            "[github_auth] Rule '{}' matched but env var '{}' is missing/empty; continuing to fallback",
+            rule.pattern, rule.token_env_var
+        );
+    }
+
+    if policy.fallback_to_gh_auth {
+        if let Some(token) = resolve_gh_auth_token(workspace, working_dir) {
+            set_github_token_env(env_vars, &token);
+            eprintln!(
+                "[github_auth] Applied GitHub token from `gh auth token` for workspace {}",
+                workspace.id
+            );
+        }
+    }
+}
+
+fn set_github_token_env(env_vars: &mut HashMap<String, String>, token: &str) {
+    env_vars.insert(ENV_GH_TOKEN.to_string(), token.to_string());
+    env_vars.insert(ENV_GITHUB_TOKEN.to_string(), token.to_string());
+}
+
+fn load_token_from_env_var(env_var: &str) -> Option<String> {
+    let value = std::env::var(env_var).ok()?;
+    let token = value.trim().to_string();
+    if token.is_empty() {
+        return None;
+    }
+    Some(token)
+}
+
+fn resolve_gh_auth_token(workspace: &Workspace, working_dir: Option<&str>) -> Option<String> {
+    let workspace_wsl = WslConfig::from_path(&workspace.folder_path);
+
+    // Prefer running `gh` inside WSL for WSL workspaces.
+    if let Some(wsl) = workspace_wsl.as_ref() {
+        if let Some(token) = run_gh_auth_token_wsl(wsl) {
+            return Some(token);
+        }
+    }
+
+    // Try native `gh`, using cwd only if it's a valid local path.
+    let preferred_cwd = working_dir.or(Some(workspace.folder_path.as_str()));
+    if let Some(token) = run_gh_auth_token_native(preferred_cwd) {
+        return Some(token);
+    }
+
+    // Last attempt with no cwd.
+    run_gh_auth_token_native(None)
+}
+
+fn run_gh_auth_token_native(cwd: Option<&str>) -> Option<String> {
+    let mut cmd = new_command("gh");
+    cmd.args(["auth", "token"]);
+    if let Some(dir) = cwd {
+        let dir_path = Path::new(dir);
+        if dir_path.is_dir() {
+            cmd.current_dir(dir_path);
+        }
+    }
+    parse_token_output(cmd.output().ok()?)
+}
+
+fn run_gh_auth_token_wsl(wsl: &WslConfig) -> Option<String> {
+    let mut cmd = new_command("wsl.exe");
+    if let Some(distro) = &wsl.distribution {
+        cmd.args(["-d", distro]);
+    }
+    cmd.args(["--", "gh", "auth", "token"]);
+    parse_token_output(cmd.output().ok()?)
+}
+
+fn parse_token_output(output: Output) -> Option<String> {
+    if !output.status.success() {
+        return None;
+    }
+
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if token.is_empty() {
+        return None;
+    }
+    Some(token)
+}
+
+fn build_match_context(workspace: &Workspace, working_dir: Option<&str>) -> MatchContext {
+    let repo_identity = resolve_repo_identity(workspace, working_dir);
+
+    let mut paths = Vec::new();
+    if let Some(wd) = working_dir {
+        paths.push(normalize_for_match(wd));
+    }
+    let workspace_path = normalize_for_match(&workspace.folder_path);
+    if !paths.iter().any(|p| p == &workspace_path) {
+        paths.push(workspace_path);
+    }
+
+    MatchContext {
+        repo_full: repo_identity.as_ref().map(RepoIdentity::full),
+        repo_slug: repo_identity.as_ref().map(RepoIdentity::slug),
+        paths,
+    }
+}
+
+fn resolve_repo_identity(workspace: &Workspace, working_dir: Option<&str>) -> Option<RepoIdentity> {
+    let wsl = WslConfig::from_path(&workspace.folder_path);
+
+    if let Some(wd) = working_dir {
+        if let Some(identity) = get_repo_identity_from_path(wd, wsl.as_ref()) {
+            return Some(identity);
+        }
+    }
+
+    get_repo_identity_from_path(&workspace.folder_path, wsl.as_ref())
+}
+
+fn get_repo_identity_from_path(path: &str, wsl: Option<&WslConfig>) -> Option<RepoIdentity> {
+    let origin = worktree::get_origin_url(path, wsl).ok().flatten()?;
+    parse_repo_identity(&origin)
+}
+
+fn parse_repo_identity(origin: &str) -> Option<RepoIdentity> {
+    let trimmed = origin.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let (host, path) = if let Some((_, rest)) = trimmed.split_once("://") {
+        let (host_part, path_part) = rest.split_once('/')?;
+        let host = host_part.rsplit('@').next()?.split(':').next()?.to_lowercase();
+        (host, path_part.to_string())
+    } else if let Some((left, right)) = trimmed.split_once(':') {
+        // SCP-like syntax, e.g. git@github.com:owner/repo.git
+        if !left.contains('@') && !left.contains('.') {
+            return None;
+        }
+        let host = left.rsplit('@').next()?.to_lowercase();
+        (host, right.to_string())
+    } else {
+        return None;
+    };
+
+    let path = path.trim_start_matches('/').trim_end_matches('/');
+    let mut segments = path.split('/').filter(|segment| !segment.is_empty());
+    let owner = segments.next()?.to_lowercase();
+    let repo_raw = segments.next()?.to_lowercase();
+    let repo = repo_raw.strip_suffix(".git").unwrap_or(&repo_raw).to_string();
+    if repo.is_empty() {
+        return None;
+    }
+
+    Some(RepoIdentity { host, owner, repo })
+}
+
+fn select_best_rule<'a>(
+    rules: &'a [GitHubTokenRule],
+    match_ctx: &MatchContext,
+) -> Option<&'a GitHubTokenRule> {
+    let mut best: Option<(usize, RuleScore)> = None;
+
+    for (index, rule) in rules.iter().enumerate() {
+        let score = match rule_score(rule, match_ctx) {
+            Some(score) => score,
+            None => continue,
+        };
+
+        match best {
+            None => best = Some((index, score)),
+            Some((best_index, best_score)) => {
+                if score > best_score || (score == best_score && index < best_index) {
+                    best = Some((index, score));
+                }
+            }
+        }
+    }
+
+    best.map(|(index, _)| &rules[index])
+}
+
+fn rule_score(rule: &GitHubTokenRule, match_ctx: &MatchContext) -> Option<RuleScore> {
+    let pattern = normalize_for_match(&rule.pattern);
+    if pattern.is_empty() {
+        return None;
+    }
+
+    let has_wildcard = pattern.contains('*') || pattern.contains('?');
+    let specificity = pattern_specificity(&pattern);
+    let pattern_len = pattern.len();
+
+    if let Some(repo_slug) = match_ctx.repo_slug.as_deref() {
+        let repo_full_match = match_ctx
+            .repo_full
+            .as_deref()
+            .map(|repo_full| glob_matches(&pattern, repo_full))
+            .unwrap_or(false);
+        let repo_slug_match = glob_matches(&pattern, repo_slug);
+
+        if repo_full_match || repo_slug_match {
+            let is_exact_repo = !has_wildcard
+                && (match_ctx.repo_full.as_deref() == Some(pattern.as_str())
+                    || Some(repo_slug) == Some(pattern.as_str()));
+            return Some(RuleScore {
+                tier: if is_exact_repo { 3 } else { 2 },
+                specificity,
+                pattern_len,
+            });
+        }
+    }
+
+    if match_ctx
+        .paths
+        .iter()
+        .any(|path| glob_matches(&pattern, path))
+    {
+        return Some(RuleScore {
+            tier: 1,
+            specificity,
+            pattern_len,
+        });
+    }
+
+    None
+}
+
+fn pattern_specificity(pattern: &str) -> usize {
+    pattern
+        .chars()
+        .filter(|c| *c != '*' && *c != '?')
+        .count()
+}
+
+fn normalize_for_match(input: &str) -> String {
+    input
+        .trim()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_lowercase()
+}
+
+fn glob_matches(pattern: &str, text: &str) -> bool {
+    let pattern_bytes = pattern.as_bytes();
+    let text_bytes = text.as_bytes();
+
+    let mut pattern_index = 0usize;
+    let mut text_index = 0usize;
+    let mut star_index: Option<usize> = None;
+    let mut text_checkpoint = 0usize;
+
+    while text_index < text_bytes.len() {
+        if pattern_index < pattern_bytes.len()
+            && (pattern_bytes[pattern_index] == b'?'
+                || pattern_bytes[pattern_index] == text_bytes[text_index])
+        {
+            pattern_index += 1;
+            text_index += 1;
+            continue;
+        }
+
+        if pattern_index < pattern_bytes.len() && pattern_bytes[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            pattern_index += 1;
+            text_checkpoint = text_index;
+            continue;
+        }
+
+        if let Some(star) = star_index {
+            pattern_index = star + 1;
+            text_checkpoint += 1;
+            text_index = text_checkpoint;
+            continue;
+        }
+
+        return false;
+    }
+
+    while pattern_index < pattern_bytes.len() && pattern_bytes[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+
+    pattern_index == pattern_bytes.len()
+}
+
+fn new_command(program: &str) -> Command {
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_matches_basic_patterns() {
+        assert!(glob_matches("typesense/*", "typesense/typesense"));
+        assert!(glob_matches("*", "typesense/typesense"));
+        assert!(glob_matches(
+            "github.com/typesense/*",
+            "github.com/typesense/typesense"
+        ));
+        assert!(!glob_matches("typesense/*", "other-org/repo"));
+    }
+
+    #[test]
+    fn parse_repo_identity_from_https_origin() {
+        let identity = parse_repo_identity("https://github.com/typesense/typesense.git").unwrap();
+        assert_eq!(identity.host, "github.com");
+        assert_eq!(identity.owner, "typesense");
+        assert_eq!(identity.repo, "typesense");
+        assert_eq!(identity.slug(), "typesense/typesense");
+    }
+
+    #[test]
+    fn parse_repo_identity_from_ssh_origin() {
+        let identity = parse_repo_identity("git@github.com:typesense/typesense.git").unwrap();
+        assert_eq!(identity.full(), "github.com/typesense/typesense");
+    }
+
+    #[test]
+    fn exact_repo_rule_beats_wildcard() {
+        let ctx = MatchContext {
+            repo_full: Some("github.com/typesense/typesense".to_string()),
+            repo_slug: Some("typesense/typesense".to_string()),
+            paths: vec![],
+        };
+        let rules = vec![
+            GitHubTokenRule {
+                pattern: "*".to_string(),
+                token_env_var: "GH_TOKEN_FULL".to_string(),
+            },
+            GitHubTokenRule {
+                pattern: "typesense/typesense".to_string(),
+                token_env_var: "GH_TOKEN_SCOPED".to_string(),
+            },
+        ];
+        let selected = select_best_rule(&rules, &ctx).unwrap();
+        assert_eq!(selected.token_env_var, "GH_TOKEN_SCOPED");
+    }
+
+    #[test]
+    fn specific_wildcard_beats_generic_wildcard() {
+        let ctx = MatchContext {
+            repo_full: Some("github.com/typesense/server".to_string()),
+            repo_slug: Some("typesense/server".to_string()),
+            paths: vec![],
+        };
+        let rules = vec![
+            GitHubTokenRule {
+                pattern: "*".to_string(),
+                token_env_var: "GH_TOKEN_FULL".to_string(),
+            },
+            GitHubTokenRule {
+                pattern: "typesense/*".to_string(),
+                token_env_var: "GH_TOKEN_TYPESENSE".to_string(),
+            },
+        ];
+        let selected = select_best_rule(&rules, &ctx).unwrap();
+        assert_eq!(selected.token_env_var, "GH_TOKEN_TYPESENSE");
+    }
+
+    #[test]
+    fn path_rule_matches_when_repo_is_unknown() {
+        let ctx = MatchContext {
+            repo_full: None,
+            repo_slug: None,
+            paths: vec!["c:/code/typesense/repo".to_string()],
+        };
+        let rules = vec![GitHubTokenRule {
+            pattern: "c:/code/typesense/*".to_string(),
+            token_env_var: "GH_TOKEN_TYPESENSE".to_string(),
+        }];
+        let selected = select_best_rule(&rules, &ctx).unwrap();
+        assert_eq!(selected.token_env_var, "GH_TOKEN_TYPESENSE");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod custom_protocols;
 mod daemon_client;
+mod github_auth;
 mod gpu_renderer;
 mod llm_state;
 mod mcp_server;
@@ -14,9 +15,9 @@ mod whisper_state;
 mod window_lifecycle;
 mod worktree;
 
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
-use parking_lot::Mutex;
 use tauri::Manager;
 
 use crate::daemon_client::bridge::{DiffStreamRegistry, OutputStreamRegistry};
@@ -248,6 +249,8 @@ pub fn run() {
             commands::create_workspace,
             commands::delete_workspace,
             commands::get_workspaces,
+            commands::set_workspace_github_auth_policy,
+            commands::get_workspace_github_auth_policy,
             commands::move_tab_to_workspace,
             commands::reorder_tabs,
             // --- Split/Layout ---
@@ -370,7 +373,12 @@ pub fn run() {
             let emitter = daemon_client.event_emitter();
 
             // Start process monitor (queries daemon for PIDs, resolves process names locally)
-            process_monitor.start(app_handle.clone(), emitter, state_clone.clone(), daemon_client.clone());
+            process_monitor.start(
+                app_handle.clone(),
+                emitter,
+                state_clone.clone(),
+                daemon_client.clone(),
+            );
 
             // Start auto-save manager
             auto_save.start(app_handle.clone(), state_clone.clone());

--- a/src-tauri/src/persistence/layout.rs
+++ b/src-tauri/src/persistence/layout.rs
@@ -1,13 +1,14 @@
-use std::sync::Arc;
 use godly_protocol::{LayoutNode, SplitDirection};
+use std::sync::Arc;
 use tauri::{AppHandle, State};
 use tauri_plugin_store::StoreExt;
 
 #[allow(deprecated)]
-use crate::state::{AppState, Layout, TerminalInfo};
+use crate::state::{AppState, Layout, TerminalInfo, WorkspaceGitHubAuthPolicy};
 
 const STORE_PATH: &str = "layout.json";
 const LAYOUT_KEY: &str = "layout";
+const GITHUB_AUTH_POLICIES_KEY: &str = "workspace_github_auth_policies";
 
 fn log_info(msg: &str) {
     eprintln!("[persistence] {}", msg);
@@ -24,9 +25,7 @@ fn build_terminal_infos(state: &AppState) -> Vec<TerminalInfo> {
         .values()
         .map(|t| {
             let meta = session_meta.get(&t.id);
-            let shell_type = meta
-                .map(|m| m.shell_type.clone())
-                .unwrap_or_default();
+            let shell_type = meta.map(|m| m.shell_type.clone()).unwrap_or_default();
             let cwd = meta.and_then(|m| m.cwd.clone());
 
             let worktree_path = meta.and_then(|m| m.worktree_path.clone());
@@ -50,13 +49,11 @@ fn build_terminal_infos(state: &AppState) -> Vec<TerminalInfo> {
 pub fn save_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result<(), String> {
     log_info("Saving layout...");
 
-    let store = app_handle
-        .store(STORE_PATH)
-        .map_err(|e| {
-            let msg = format!("Failed to open store: {}", e);
-            log_error(&msg);
-            msg
-        })?;
+    let store = app_handle.store(STORE_PATH).map_err(|e| {
+        let msg = format!("Failed to open store: {}", e);
+        log_error(&msg);
+        msg
+    })?;
 
     let workspaces = state.get_all_workspaces();
     let terminals = build_terminal_infos(&state);
@@ -74,14 +71,22 @@ pub fn save_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
         window_state,
     };
 
-    let json_value = serde_json::to_value(&layout)
-        .map_err(|e| {
-            let msg = format!("Failed to serialize layout: {}", e);
+    let json_value = serde_json::to_value(&layout).map_err(|e| {
+        let msg = format!("Failed to serialize layout: {}", e);
+        log_error(&msg);
+        msg
+    })?;
+
+    store.set(LAYOUT_KEY, json_value);
+
+    let github_policies_value =
+        serde_json::to_value(state.get_all_workspace_github_auth_policies()).map_err(|e| {
+            let msg = format!("Failed to serialize GitHub auth policies: {}", e);
             log_error(&msg);
             msg
         })?;
+    store.set(GITHUB_AUTH_POLICIES_KEY, github_policies_value);
 
-    store.set(LAYOUT_KEY, json_value);
     store.save().map_err(|e| {
         let msg = format!("Failed to save store: {}", e);
         log_error(&msg);
@@ -102,22 +107,19 @@ pub fn save_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
 pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result<Layout, String> {
     log_info("Loading layout...");
 
-    let store = app_handle
-        .store(STORE_PATH)
-        .map_err(|e| {
-            let msg = format!("Failed to open store: {}", e);
-            log_error(&msg);
-            msg
-        })?;
+    let store = app_handle.store(STORE_PATH).map_err(|e| {
+        let msg = format!("Failed to open store: {}", e);
+        log_error(&msg);
+        msg
+    })?;
 
     match store.get(LAYOUT_KEY) {
         Some(value) => {
-            let layout: Layout = serde_json::from_value(value.clone())
-                .map_err(|e| {
-                    let msg = format!("Failed to parse layout: {}", e);
-                    log_error(&msg);
-                    msg
-                })?;
+            let layout: Layout = serde_json::from_value(value.clone()).map_err(|e| {
+                let msg = format!("Failed to parse layout: {}", e);
+                log_error(&msg);
+                msg
+            })?;
 
             log_info(&format!(
                 "Layout loaded: {} workspaces, {} terminals",
@@ -127,7 +129,10 @@ pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
 
             // Restore workspaces to backend state so create_terminal can find them
             for ws in &layout.workspaces {
-                log_info(&format!("Restoring workspace to backend state: {} ({})", ws.name, ws.id));
+                log_info(&format!(
+                    "Restoring workspace to backend state: {} ({})",
+                    ws.name, ws.id
+                ));
                 state.add_workspace(crate::state::Workspace {
                     id: ws.id.clone(),
                     name: ws.name.clone(),
@@ -158,7 +163,10 @@ pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
                 for (ws_id, tree) in &layout.layout_trees {
                     state.set_layout_tree(ws_id, tree.clone());
                 }
-                log_info(&format!("Restored {} layout trees", layout.layout_trees.len()));
+                log_info(&format!(
+                    "Restored {} layout trees",
+                    layout.layout_trees.len()
+                ));
             } else if !layout.split_views.is_empty() {
                 // Migrate old split_views to layout trees
                 for (ws_id, sv) in &layout.split_views {
@@ -183,6 +191,33 @@ pub fn load_layout(app_handle: AppHandle, state: State<Arc<AppState>>) -> Result
                     "Migrated {} split_views to layout trees",
                     layout.split_views.len()
                 ));
+            }
+
+            match store.get(GITHUB_AUTH_POLICIES_KEY) {
+                Some(policies_value) => {
+                    match serde_json::from_value::<
+                        std::collections::HashMap<String, WorkspaceGitHubAuthPolicy>,
+                    >(policies_value)
+                    {
+                        Ok(mut policies) => {
+                            let known_workspaces: std::collections::HashSet<String> =
+                                layout.workspaces.iter().map(|ws| ws.id.clone()).collect();
+                            policies
+                                .retain(|workspace_id, _| known_workspaces.contains(workspace_id));
+                            state.replace_workspace_github_auth_policies(policies);
+                        }
+                        Err(e) => {
+                            log_error(&format!(
+                                "Failed to parse GitHub auth policies, ignoring: {}",
+                                e
+                            ));
+                            state.replace_workspace_github_auth_policies(Default::default());
+                        }
+                    }
+                }
+                None => {
+                    state.replace_workspace_github_auth_policies(Default::default());
+                }
             }
 
             Ok(layout)
@@ -214,7 +249,9 @@ pub fn restore_window_state(
     // Check if the saved monitor is still available
     let monitors = window.available_monitors().unwrap_or_default();
     let saved_monitor_available = saved.monitor_name.as_ref().map_or(false, |name| {
-        monitors.iter().any(|m| m.name().map_or(false, |n| n == name))
+        monitors
+            .iter()
+            .any(|m| m.name().map_or(false, |n| n == name))
     });
 
     if !saved_monitor_available {
@@ -233,20 +270,14 @@ pub fn restore_window_state(
 
     // Find the target monitor's work area for clamping
     let target_monitor = monitors.iter().find(|m| {
-        m.name().map_or(false, |n| {
-            Some(n.to_string()) == saved.monitor_name
-        })
+        m.name()
+            .map_or(false, |n| Some(n.to_string()) == saved.monitor_name)
     });
 
     let (mon_x, mon_y, mon_w, mon_h) = if let Some(m) = target_monitor {
         let pos = m.position();
         let size = m.size();
-        (
-            pos.x,
-            pos.y,
-            size.width as i32,
-            size.height as i32,
-        )
+        (pos.x, pos.y, size.width as i32, size.height as i32)
     } else {
         // Shouldn't reach here since we checked above, but fallback
         return Ok(());
@@ -256,7 +287,10 @@ pub fn restore_window_state(
     let w = saved.width as i32;
     let _h = saved.height as i32;
     let min_visible = 100; // at least 100px must be on screen
-    let x = saved.x.max(mon_x - w + min_visible).min(mon_x + mon_w - min_visible);
+    let x = saved
+        .x
+        .max(mon_x - w + min_visible)
+        .min(mon_x + mon_w - min_visible);
     let y = saved.y.max(mon_y).min(mon_y + mon_h - min_visible);
 
     log_info(&format!(
@@ -308,6 +342,11 @@ pub fn save_on_exit(app_handle: &AppHandle, state: &Arc<AppState>) {
     match serde_json::to_value(&layout) {
         Ok(json_value) => {
             store.set(LAYOUT_KEY, json_value);
+            if let Ok(github_policies_value) =
+                serde_json::to_value(state.get_all_workspace_github_auth_policies())
+            {
+                store.set(GITHUB_AUTH_POLICIES_KEY, github_policies_value);
+            }
             if let Err(e) = store.save() {
                 log_error(&format!("Failed to save store on exit: {}", e));
             } else {
@@ -408,11 +447,17 @@ pub fn save_layout_internal(app_handle: &AppHandle, state: &Arc<AppState>) -> Re
         window_state,
     };
 
-    let json_value = serde_json::to_value(&layout)
-        .map_err(|e| format!("Failed to serialize layout: {}", e))?;
+    let json_value =
+        serde_json::to_value(&layout).map_err(|e| format!("Failed to serialize layout: {}", e))?;
 
     store.set(LAYOUT_KEY, json_value);
-    store.save().map_err(|e| format!("Failed to save store: {}", e))?;
+    let github_policies_value =
+        serde_json::to_value(state.get_all_workspace_github_auth_policies())
+            .map_err(|e| format!("Failed to serialize GitHub auth policies: {}", e))?;
+    store.set(GITHUB_AUTH_POLICIES_KEY, github_policies_value);
+    store
+        .save()
+        .map_err(|e| format!("Failed to save store: {}", e))?;
 
     Ok(())
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -3,7 +3,9 @@ use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 
 #[allow(deprecated)]
-use super::models::{SessionMetadata, SplitView, Terminal, WindowState, Workspace};
+use super::models::{
+    SessionMetadata, SplitView, Terminal, WindowState, Workspace, WorkspaceGitHubAuthPolicy,
+};
 
 #[allow(deprecated)]
 pub struct AppState {
@@ -26,6 +28,8 @@ pub struct AppState {
     pub zoomed_panes: RwLock<HashMap<String, String>>,
     /// Workspace ID for MCP-created terminals (Agent workspace in separate window)
     pub mcp_workspace_id: RwLock<Option<String>>,
+    /// Per-workspace GitHub token injection policy (workspace_id -> policy)
+    pub github_auth_policies: RwLock<HashMap<String, WorkspaceGitHubAuthPolicy>>,
     /// Window geometry and monitor for cross-session restoration
     pub window_state: RwLock<Option<WindowState>>,
 }
@@ -45,6 +49,7 @@ impl AppState {
             layout_trees: RwLock::new(HashMap::new()),
             zoomed_panes: RwLock::new(HashMap::new()),
             mcp_workspace_id: RwLock::new(None),
+            github_auth_policies: RwLock::new(HashMap::new()),
             window_state: RwLock::new(None),
         }
     }
@@ -57,6 +62,10 @@ impl AppState {
     pub fn remove_workspace(&self, id: &str) {
         let mut workspaces = self.workspaces.write();
         workspaces.remove(id);
+        drop(workspaces);
+
+        let mut policies = self.github_auth_policies.write();
+        policies.remove(id);
     }
 
     pub fn get_workspace(&self, id: &str) -> Option<Workspace> {
@@ -139,6 +148,40 @@ impl AppState {
     pub fn add_session_metadata(&self, id: String, metadata: SessionMetadata) {
         let mut meta = self.session_metadata.write();
         meta.insert(id, metadata);
+    }
+
+    pub fn set_workspace_github_auth_policy(
+        &self,
+        workspace_id: &str,
+        policy: WorkspaceGitHubAuthPolicy,
+    ) {
+        let mut policies = self.github_auth_policies.write();
+        policies.insert(workspace_id.to_string(), policy);
+    }
+
+    pub fn get_workspace_github_auth_policy(
+        &self,
+        workspace_id: &str,
+    ) -> WorkspaceGitHubAuthPolicy {
+        self.github_auth_policies
+            .read()
+            .get(workspace_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn get_all_workspace_github_auth_policies(
+        &self,
+    ) -> HashMap<String, WorkspaceGitHubAuthPolicy> {
+        self.github_auth_policies.read().clone()
+    }
+
+    pub fn replace_workspace_github_auth_policies(
+        &self,
+        policies: HashMap<String, WorkspaceGitHubAuthPolicy>,
+    ) {
+        let mut current = self.github_auth_policies.write();
+        *current = policies;
     }
 
     pub fn remove_session_metadata(&self, id: &str) {
@@ -266,9 +309,9 @@ impl AppState {
     ) -> Result<(), String> {
         let mut trees = self.layout_trees.write();
 
-        let tree = trees.get_mut(workspace_id).ok_or_else(|| {
-            format!("No layout tree for workspace {}", workspace_id)
-        })?;
+        let tree = trees
+            .get_mut(workspace_id)
+            .ok_or_else(|| format!("No layout tree for workspace {}", workspace_id))?;
 
         // If the tree is just a single leaf, remove the whole tree
         if let LayoutNode::Leaf { terminal_id: tid } = tree {
@@ -276,10 +319,7 @@ impl AppState {
                 trees.remove(workspace_id);
                 return Ok(());
             }
-            return Err(format!(
-                "Terminal {} not found in layout tree",
-                terminal_id
-            ));
+            return Err(format!("Terminal {} not found in layout tree", terminal_id));
         }
 
         // Try to remove the terminal and collapse
@@ -309,9 +349,9 @@ impl AppState {
         terminal_id_b: &str,
     ) -> Result<(), String> {
         let mut trees = self.layout_trees.write();
-        let tree = trees.get_mut(workspace_id).ok_or_else(|| {
-            format!("No layout tree for workspace {}", workspace_id)
-        })?;
+        let tree = trees
+            .get_mut(workspace_id)
+            .ok_or_else(|| format!("No layout tree for workspace {}", workspace_id))?;
 
         Self::swap_terminals(tree, terminal_id_a, terminal_id_b);
         Ok(())
@@ -330,8 +370,12 @@ impl AppState {
         }
         let mut zoomed = self.zoomed_panes.write();
         match terminal_id {
-            Some(tid) => { zoomed.insert(workspace_id.to_string(), tid); }
-            None => { zoomed.remove(workspace_id); }
+            Some(tid) => {
+                zoomed.insert(workspace_id.to_string(), tid);
+            }
+            None => {
+                zoomed.remove(workspace_id);
+            }
         }
     }
 
@@ -532,7 +576,7 @@ impl Default for AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::models::{AiToolMode, ShellType};
+    use crate::state::models::{AiToolMode, GitHubTokenRule, ShellType, WorkspaceGitHubAuthPolicy};
 
     #[test]
     fn test_workspace_add_and_get() {
@@ -686,6 +730,38 @@ mod tests {
         assert_eq!(m.cwd, Some("C:\\Users\\test".to_string()));
     }
 
+    #[test]
+    fn test_workspace_github_auth_policy_roundtrip() {
+        let state = AppState::new();
+        state.add_workspace(Workspace {
+            id: "ws-1".to_string(),
+            name: "Workspace".to_string(),
+            folder_path: "C:\\".to_string(),
+            tab_order: vec![],
+            shell_type: ShellType::Windows,
+            worktree_mode: false,
+            ai_tool_mode: AiToolMode::None,
+        });
+
+        let policy = WorkspaceGitHubAuthPolicy {
+            rules: vec![
+                GitHubTokenRule {
+                    pattern: "typesense/*".to_string(),
+                    token_env_var: "GH_TOKEN_TYPESENSE".to_string(),
+                },
+                GitHubTokenRule {
+                    pattern: "*".to_string(),
+                    token_env_var: "GH_TOKEN_FULL".to_string(),
+                },
+            ],
+            fallback_to_gh_auth: true,
+        };
+        state.set_workspace_github_auth_policy("ws-1", policy.clone());
+
+        let restored = state.get_workspace_github_auth_policy("ws-1");
+        assert_eq!(restored, policy);
+    }
+
     // ---------------------------------------------------------------
     // prune_stale_ids
     // ---------------------------------------------------------------
@@ -756,7 +832,8 @@ mod tests {
     #[test]
     fn prune_removes_dead_zoomed_pane() {
         let state = make_state_with_terminals(&["t1"]);
-        state.zoomed_panes
+        state
+            .zoomed_panes
             .write()
             .insert("ws-1".to_string(), "t2".to_string());
 
@@ -858,13 +935,8 @@ mod tests {
             },
         );
 
-        let result = state.split_terminal_in_tree(
-            "ws-1",
-            "t1",
-            "t2",
-            SplitDirection::Vertical,
-            0.5,
-        );
+        let result =
+            state.split_terminal_in_tree("ws-1", "t1", "t2", SplitDirection::Vertical, 0.5);
         assert!(result.is_ok());
 
         let tree = state.get_layout_tree("ws-1").unwrap();

--- a/src-tauri/src/state/models.rs
+++ b/src-tauri/src/state/models.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // Re-export layout tree types from protocol
 pub use godly_protocol::LayoutNode;
@@ -20,6 +20,37 @@ pub enum AiToolMode {
 impl Default for AiToolMode {
     fn default() -> Self {
         AiToolMode::None
+    }
+}
+
+fn default_github_fallback_to_gh_auth() -> bool {
+    true
+}
+
+/// Rule for selecting a GitHub token by matching a repository/path pattern.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitHubTokenRule {
+    /// Glob-like pattern (`*` and `?` supported), e.g. `typesense/*` or `*`.
+    pub pattern: String,
+    /// Name of an environment variable that contains the token value.
+    pub token_env_var: String,
+}
+
+/// Workspace-level policy for injecting `GH_TOKEN` / `GITHUB_TOKEN`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceGitHubAuthPolicy {
+    #[serde(default)]
+    pub rules: Vec<GitHubTokenRule>,
+    #[serde(default = "default_github_fallback_to_gh_auth")]
+    pub fallback_to_gh_auth: bool,
+}
+
+impl Default for WorkspaceGitHubAuthPolicy {
+    fn default() -> Self {
+        Self {
+            rules: Vec::new(),
+            fallback_to_gh_auth: true,
+        }
     }
 }
 
@@ -125,7 +156,7 @@ impl<'de> Deserialize<'de> for Workspace {
 pub struct SplitView {
     pub left_terminal_id: String,
     pub right_terminal_id: String,
-    pub direction: String,  // "horizontal" or "vertical"
+    pub direction: String, // "horizontal" or "vertical"
     pub ratio: f64,
 }
 
@@ -431,7 +462,10 @@ mod tests {
 
         assert_eq!(restored.terminals.len(), 2);
         assert_eq!(restored.terminals[0].id, "term-1");
-        assert_eq!(restored.terminals[0].cwd, Some("C:\\Projects\\myapp\\src".to_string()));
+        assert_eq!(
+            restored.terminals[0].cwd,
+            Some("C:\\Projects\\myapp\\src".to_string())
+        );
         assert_eq!(restored.terminals[1].id, "term-2");
         assert_eq!(
             restored.terminals[1].shell_type,
@@ -587,7 +621,12 @@ mod tests {
 
     #[test]
     fn test_ai_tool_mode_serialization_roundtrip() {
-        for mode in &[AiToolMode::None, AiToolMode::Claude, AiToolMode::Codex, AiToolMode::Both] {
+        for mode in &[
+            AiToolMode::None,
+            AiToolMode::Claude,
+            AiToolMode::Codex,
+            AiToolMode::Both,
+        ] {
             let json = serde_json::to_string(mode).unwrap();
             let deserialized: AiToolMode = serde_json::from_str(&json).unwrap();
             assert_eq!(deserialized, *mode);
@@ -753,7 +792,10 @@ mod tests {
         let restored: Layout = serde_json::from_str(&json).unwrap();
         assert_eq!(
             restored.terminals[0].shell_type,
-            ShellType::Custom { program: "nu.exe".to_string(), args: None }
+            ShellType::Custom {
+                program: "nu.exe".to_string(),
+                args: None
+            }
         );
         assert_eq!(restored.terminals[1].shell_type, ShellType::Windows);
     }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -62,7 +62,9 @@ impl WslConfig {
         };
 
         after_prefix.map(|s| {
-            let distribution = s.split('/').next()
+            let distribution = s
+                .split('/')
+                .next()
                 .filter(|d| !d.is_empty())
                 .map(|d| d.to_string());
             WslConfig { distribution }
@@ -137,6 +139,24 @@ pub fn get_repo_root(path: &str, wsl: Option<&WslConfig>) -> Result<String, Stri
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Return `remote.origin.url` for the repository containing `path`.
+/// Returns `Ok(None)` when `path` is not in a git repo or origin is unset.
+pub fn get_origin_url(path: &str, wsl: Option<&WslConfig>) -> Result<Option<String>, String> {
+    let output = run_git(&["config", "--get", "remote.origin.url"], path, wsl)
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(value))
+}
+
 /// Compute a short (8-char) hex hash of a string (used to namespace temp dirs).
 fn short_hash(input: &str) -> String {
     let mut hasher = DefaultHasher::new();
@@ -148,7 +168,11 @@ fn short_hash(input: &str) -> String {
 fn wt_name_from(custom_name: Option<&str>, terminal_id: &str) -> String {
     match custom_name {
         Some(name) if !name.is_empty() => format!("{}{}", BRANCH_PREFIX, name),
-        _ => format!("{}{}", BRANCH_PREFIX, &terminal_id[..6.min(terminal_id.len())]),
+        _ => format!(
+            "{}{}",
+            BRANCH_PREFIX,
+            &terminal_id[..6.min(terminal_id.len())]
+        ),
     }
 }
 
@@ -170,7 +194,11 @@ fn worktree_path_wsl(repo_root: &str, terminal_id: &str, custom_name: Option<&st
 /// Detect the default branch name (master or main) for the repo.
 fn detect_default_branch(repo_root: &str, wsl: Option<&WslConfig>) -> Option<String> {
     // Try symbolic-ref first (works when origin/HEAD is set)
-    if let Ok(output) = run_git(&["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], repo_root, wsl) {
+    if let Ok(output) = run_git(
+        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        repo_root,
+        wsl,
+    ) {
         if output.status.success() {
             let refname = String::from_utf8_lossy(&output.stdout).trim().to_string();
             // "origin/main" -> "main"
@@ -205,7 +233,10 @@ fn detect_default_branch(repo_root: &str, wsl: Option<&WslConfig>) -> Option<Str
 fn fetch_latest(repo_root: &str, wsl: Option<&WslConfig>) -> Option<String> {
     let branch = detect_default_branch(repo_root, wsl)?;
 
-    eprintln!("[worktree] Fetching origin/{} before creating worktree...", branch);
+    eprintln!(
+        "[worktree] Fetching origin/{} before creating worktree...",
+        branch
+    );
 
     match run_git(&["fetch", "origin", &branch, "--no-tags"], repo_root, wsl) {
         Ok(output) => {
@@ -229,14 +260,25 @@ fn fetch_latest(repo_root: &str, wsl: Option<&WslConfig>) -> Option<String> {
 /// If `custom_name` is provided, it is used as the branch/folder suffix instead of the terminal id prefix.
 /// Fetches latest from origin before creating the worktree so it branches from the latest state.
 /// Returns a `WorktreeResult` with the path and branch name.
-pub fn create_worktree(repo_root: &str, terminal_id: &str, custom_name: Option<&str>, wsl: Option<&WslConfig>) -> Result<WorktreeResult, String> {
+pub fn create_worktree(
+    repo_root: &str,
+    terminal_id: &str,
+    custom_name: Option<&str>,
+    wsl: Option<&WslConfig>,
+) -> Result<WorktreeResult, String> {
     create_worktree_with_options(repo_root, terminal_id, custom_name, wsl, false)
 }
 
 /// Create a new worktree with configurable fetch behavior.
 /// When `skip_fetch` is true, branches from local HEAD instead of fetching from origin first.
 /// This saves 100-500ms of network latency, useful for rapid-fire workflows like Quick Claude.
-pub fn create_worktree_with_options(repo_root: &str, terminal_id: &str, custom_name: Option<&str>, wsl: Option<&WslConfig>, skip_fetch: bool) -> Result<WorktreeResult, String> {
+pub fn create_worktree_with_options(
+    repo_root: &str,
+    terminal_id: &str,
+    custom_name: Option<&str>,
+    wsl: Option<&WslConfig>,
+    skip_fetch: bool,
+) -> Result<WorktreeResult, String> {
     let start_point = if skip_fetch {
         eprintln!("[worktree] Skipping fetch (skip_fetch=true), branching from local HEAD");
         None
@@ -271,7 +313,10 @@ pub fn create_worktree_with_options(repo_root: &str, terminal_id: &str, custom_n
         }
 
         // Return the Linux path — the daemon's windows_to_wsl_path passes it through unchanged
-        Ok(WorktreeResult { path: wt_linux_path, branch: branch_name })
+        Ok(WorktreeResult {
+            path: wt_linux_path,
+            branch: branch_name,
+        })
     } else {
         // Windows: create worktree in %TEMP%
         let wt_path = worktree_path(repo_root, terminal_id, custom_name);
@@ -296,12 +341,18 @@ pub fn create_worktree_with_options(repo_root: &str, terminal_id: &str, custom_n
             return Err(format!("git worktree add failed: {}", stderr.trim()));
         }
 
-        Ok(WorktreeResult { path: wt_path_str, branch: branch_name })
+        Ok(WorktreeResult {
+            path: wt_path_str,
+            branch: branch_name,
+        })
     }
 }
 
 /// List all worktrees for the repo at `repo_root`.
-pub fn list_worktrees(repo_root: &str, wsl: Option<&WslConfig>) -> Result<Vec<WorktreeInfo>, String> {
+pub fn list_worktrees(
+    repo_root: &str,
+    wsl: Option<&WslConfig>,
+) -> Result<Vec<WorktreeInfo>, String> {
     let output = run_git(&["worktree", "list", "--porcelain"], repo_root, wsl)
         .map_err(|e| format!("Failed to run git worktree list: {}", e))?;
 
@@ -370,7 +421,12 @@ pub fn list_worktrees(repo_root: &str, wsl: Option<&WslConfig>) -> Result<Vec<Wo
 }
 
 /// Remove a single worktree by its path.
-pub fn remove_worktree(repo_root: &str, wt_path: &str, force: bool, wsl: Option<&WslConfig>) -> Result<(), String> {
+pub fn remove_worktree(
+    repo_root: &str,
+    wt_path: &str,
+    force: bool,
+    wsl: Option<&WslConfig>,
+) -> Result<(), String> {
     let mut args = vec!["worktree", "remove", wt_path];
     if force {
         args.push("--force");
@@ -390,7 +446,11 @@ pub fn remove_worktree(repo_root: &str, wt_path: &str, force: bool, wsl: Option<
 /// Remove all godly-managed worktrees with progress reporting.
 /// Calls `on_progress` at each stage: "listing", "removing", and "done".
 /// Returns the number of worktrees removed.
-pub fn cleanup_all_worktrees_with_progress<F>(repo_root: &str, on_progress: F, wsl: Option<&WslConfig>) -> Result<u32, String>
+pub fn cleanup_all_worktrees_with_progress<F>(
+    repo_root: &str,
+    on_progress: F,
+    wsl: Option<&WslConfig>,
+) -> Result<u32, String>
 where
     F: Fn(&CleanupProgress),
 {
@@ -433,12 +493,20 @@ where
     };
 
     let total = managed.len() as u32;
-    eprintln!("[worktree] cleanup_all: found {} godly-managed worktrees", total);
+    eprintln!(
+        "[worktree] cleanup_all: found {} godly-managed worktrees",
+        total
+    );
 
     let mut removed = 0u32;
     for (i, wt) in managed.iter().enumerate() {
         let name = wt.branch.clone();
-        eprintln!("[worktree] cleanup_all: removing {} ({}/{})", name, i + 1, total);
+        eprintln!(
+            "[worktree] cleanup_all: removing {} ({}/{})",
+            name,
+            i + 1,
+            total
+        );
 
         on_progress(&CleanupProgress {
             step: "removing".to_string(),
@@ -454,7 +522,11 @@ where
     }
 
     let elapsed = start.elapsed();
-    eprintln!("[worktree] cleanup_all: done — removed {} worktrees in {:.1}s", removed, elapsed.as_secs_f64());
+    eprintln!(
+        "[worktree] cleanup_all: done — removed {} worktrees in {:.1}s",
+        removed,
+        elapsed.as_secs_f64()
+    );
 
     on_progress(&CleanupProgress {
         step: "done".to_string(),
@@ -544,7 +616,10 @@ mod tests {
         let terminal_id = "abcdef-1234-5678";
 
         let result = create_worktree(repo_root, terminal_id, None, None).expect("create worktree");
-        assert!(Path::new(&result.path).is_dir(), "worktree directory should exist");
+        assert!(
+            Path::new(&result.path).is_dir(),
+            "worktree directory should exist"
+        );
         assert_eq!(result.branch, "wt-abcdef");
 
         // Verify branch exists
@@ -566,8 +641,12 @@ mod tests {
         let repo_root = repo.path().to_str().unwrap();
         let terminal_id = "abcdef-1234-5678";
 
-        let result = create_worktree(repo_root, terminal_id, Some("my-feature"), None).expect("create worktree with custom name");
-        assert!(Path::new(&result.path).is_dir(), "worktree directory should exist");
+        let result = create_worktree(repo_root, terminal_id, Some("my-feature"), None)
+            .expect("create worktree with custom name");
+        assert!(
+            Path::new(&result.path).is_dir(),
+            "worktree directory should exist"
+        );
         assert_eq!(result.branch, "wt-my-feature");
 
         // Verify branch exists
@@ -577,7 +656,10 @@ mod tests {
             .output()
             .expect("git branch list");
         let branches = String::from_utf8_lossy(&output.stdout);
-        assert!(branches.contains("wt-my-feature"), "custom branch should exist");
+        assert!(
+            branches.contains("wt-my-feature"),
+            "custom branch should exist"
+        );
 
         // Cleanup
         let _ = std::fs::remove_dir_all(&result.path);
@@ -614,7 +696,10 @@ mod tests {
         assert!(Path::new(&result.path).is_dir());
 
         remove_worktree(repo_root, &result.path, false, None).expect("remove worktree");
-        assert!(!Path::new(&result.path).is_dir(), "worktree should be removed");
+        assert!(
+            !Path::new(&result.path).is_dir(),
+            "worktree should be removed"
+        );
     }
 
     #[test]
@@ -672,20 +757,35 @@ mod tests {
         let events: Arc<Mutex<Vec<CleanupProgress>>> = Arc::new(Mutex::new(Vec::new()));
         let events_clone = events.clone();
 
-        let removed = cleanup_all_worktrees_with_progress(repo_root, move |progress| {
-            events_clone.lock().unwrap().push(progress.clone());
-        }, None)
+        let removed = cleanup_all_worktrees_with_progress(
+            repo_root,
+            move |progress| {
+                events_clone.lock().unwrap().push(progress.clone());
+            },
+            None,
+        )
         .expect("cleanup should succeed");
 
         assert_eq!(removed, 2, "should have removed 2 worktrees");
 
         // Verify worktree directories were actually removed
-        assert!(!Path::new(&wt1.path).is_dir(), "worktree 1 directory should be deleted");
-        assert!(!Path::new(&wt2.path).is_dir(), "worktree 2 directory should be deleted");
+        assert!(
+            !Path::new(&wt1.path).is_dir(),
+            "worktree 1 directory should be deleted"
+        );
+        assert!(
+            !Path::new(&wt2.path).is_dir(),
+            "worktree 2 directory should be deleted"
+        );
 
         let collected = events.lock().unwrap();
         // Exactly 4 events: listing, removing x2, done
-        assert_eq!(collected.len(), 4, "expected exactly 4 progress events, got {}", collected.len());
+        assert_eq!(
+            collected.len(),
+            4,
+            "expected exactly 4 progress events, got {}",
+            collected.len()
+        );
 
         // Event 0: listing
         assert_eq!(collected[0].step, "listing");
@@ -696,12 +796,18 @@ mod tests {
         assert_eq!(collected[1].step, "removing");
         assert_eq!(collected[1].current, 1);
         assert_eq!(collected[1].total, 2);
-        assert!(!collected[1].worktree_name.is_empty(), "worktree_name should not be empty");
+        assert!(
+            !collected[1].worktree_name.is_empty(),
+            "worktree_name should not be empty"
+        );
 
         assert_eq!(collected[2].step, "removing");
         assert_eq!(collected[2].current, 2);
         assert_eq!(collected[2].total, 2);
-        assert!(!collected[2].worktree_name.is_empty(), "worktree_name should not be empty");
+        assert!(
+            !collected[2].worktree_name.is_empty(),
+            "worktree_name should not be empty"
+        );
 
         // Event 3: done
         assert_eq!(collected[3].step, "done");
@@ -740,14 +846,22 @@ mod tests {
     #[test]
     fn test_worktree_path_wsl() {
         let path = worktree_path_wsl("/home/user/project", "abcdef-1234", None);
-        let expected = format!("/tmp/{}/{}/wt-abcdef", WORKTREES_DIR, short_hash("/home/user/project"));
+        let expected = format!(
+            "/tmp/{}/{}/wt-abcdef",
+            WORKTREES_DIR,
+            short_hash("/home/user/project")
+        );
         assert_eq!(path, expected);
     }
 
     #[test]
     fn test_worktree_path_wsl_custom_name() {
         let path = worktree_path_wsl("/home/user/project", "abcdef-1234", Some("my-feature"));
-        let expected = format!("/tmp/{}/{}/wt-my-feature", WORKTREES_DIR, short_hash("/home/user/project"));
+        let expected = format!(
+            "/tmp/{}/{}/wt-my-feature",
+            WORKTREES_DIR,
+            short_hash("/home/user/project")
+        );
         assert_eq!(path, expected);
     }
 
@@ -755,7 +869,10 @@ mod tests {
     fn test_worktree_path_wsl_different_repos_different_paths() {
         let path_a = worktree_path_wsl("/home/user/repo-a", "abcdef-1234", None);
         let path_b = worktree_path_wsl("/home/user/repo-b", "abcdef-1234", None);
-        assert_ne!(path_a, path_b, "different repos must produce different worktree paths");
+        assert_ne!(
+            path_a, path_b,
+            "different repos must produce different worktree paths"
+        );
     }
 
     #[test]

--- a/src/services/workspace-service.ts
+++ b/src/services/workspace-service.ts
@@ -15,6 +15,26 @@ export interface WorkspaceData {
   claude_code_mode?: boolean;
 }
 
+interface GitHubTokenRuleData {
+  pattern: string;
+  token_env_var: string;
+}
+
+interface WorkspaceGitHubAuthPolicyData {
+  rules?: GitHubTokenRuleData[];
+  fallback_to_gh_auth?: boolean;
+}
+
+export interface WorkspaceGitHubAuthRule {
+  pattern: string;
+  tokenEnvVar: string;
+}
+
+export interface WorkspaceGitHubAuthPolicy {
+  rules: WorkspaceGitHubAuthRule[];
+  fallbackToGhAuth: boolean;
+}
+
 export interface WorktreeInfo {
   path: string;
   branch: string;
@@ -113,6 +133,31 @@ class WorkspaceService {
   async toggleWorktreeMode(workspaceId: string, enabled: boolean): Promise<void> {
     await invoke('toggle_worktree_mode', { workspaceId, enabled });
     store.updateWorkspace(workspaceId, { worktreeMode: enabled });
+  }
+
+  async getWorkspaceGitHubAuthPolicy(workspaceId: string): Promise<WorkspaceGitHubAuthPolicy> {
+    const policy = await invoke<WorkspaceGitHubAuthPolicyData>('get_workspace_github_auth_policy', { workspaceId });
+    return {
+      rules: (policy.rules ?? []).map(rule => ({
+        pattern: rule.pattern,
+        tokenEnvVar: rule.token_env_var,
+      })),
+      fallbackToGhAuth: policy.fallback_to_gh_auth ?? true,
+    };
+  }
+
+  async setWorkspaceGitHubAuthPolicy(
+    workspaceId: string,
+    policy: WorkspaceGitHubAuthPolicy
+  ): Promise<void> {
+    const payload: WorkspaceGitHubAuthPolicyData = {
+      rules: policy.rules.map(rule => ({
+        pattern: rule.pattern,
+        token_env_var: rule.tokenEnvVar,
+      })),
+      fallback_to_gh_auth: policy.fallbackToGhAuth,
+    };
+    await invoke('set_workspace_github_auth_policy', { workspaceId, policy: payload });
   }
 
   async setAiToolMode(workspaceId: string, mode: AiToolMode): Promise<void> {


### PR DESCRIPTION
## Summary
- add workspace-level GitHub auth policy models (ules[] + allback_to_gh_auth)
- add Tauri commands to set/get workspace GitHub auth policy with validation
- resolve and inject GH_TOKEN/GITHUB_TOKEN per workspace when creating terminals and quick sessions
- support wildcard pattern matching against repo identity/path and fallback to gh auth token
- persist workspace GitHub auth policies in layout store and restore on startup
- add frontend workspace service methods/types for get/set policy operations

## Notes
- cargo check --manifest-path src-tauri/Cargo.toml -p godly-terminal --lib fails in this environment at build-script time due missing resource path 	arget\\release\\godly-mcp.exe.