### PR TITLE
fix: correct tauri resource targets for sidecar binaries

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,12 +42,12 @@
       }
     },
     "resources": {
-      "target/release/godly-daemon.exe": "./",
-      "target/release/godly-mcp.exe": "./",
-      "target/release/godly-notify.exe": "./",
-      "target/release/godly-pty-shim.exe": "./",
-      "target/release/godly-remote.exe": "./",
-      "target/release/godly-native.exe": "./",
+      "target/release/godly-daemon.exe": "godly-daemon.exe",
+      "target/release/godly-mcp.exe": "godly-mcp.exe",
+      "target/release/godly-notify.exe": "godly-notify.exe",
+      "target/release/godly-pty-shim.exe": "godly-pty-shim.exe",
+      "target/release/godly-remote.exe": "godly-remote.exe",
+      "target/release/godly-native.exe": "godly-native.exe",
       "sounds/*": "sounds/",
       "soundpacks/**/*": "soundpacks/"
     }


### PR DESCRIPTION
Summary: replace sidecar resource destination ./ entries with explicit filenames in tauri config, preventing tauri-build copy failures on Windows. Validation: cargo build --bins --features staging,tauri/custom-protocol --release