### PR TITLE
fix: prevent stuck mouse drag when button released outside window

### DIFF
--- a/changelog/unreleased/581-fix-stuck-mouse-drag.md
+++ b/changelog/unreleased/581-fix-stuck-mouse-drag.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Stuck mouse drag on window blur** — Split divider resize, scrollbar drag, text selection, and tab/workspace drag no longer get stuck when the mouse button is released outside the app window (#581)

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -368,6 +368,9 @@ export class App {
       const rect = this.terminalContainer.getBoundingClientRect();
 
       const onMouseMove = (moveEvent: MouseEvent) => {
+        // Guard: if button was released outside the window, clean up
+        if (moveEvent.buttons === 0) { onMouseUp(); return; }
+
         let ratio: number;
         if (isHorizontal) {
           ratio = (moveEvent.clientX - rect.left) / rect.width;

--- a/src/components/SplitContainer.ts
+++ b/src/components/SplitContainer.ts
@@ -221,6 +221,9 @@ export class SplitContainer {
       const dividers = Array.from(container.querySelectorAll(':scope > .split-grid-divider')) as HTMLElement[];
 
       const onMouseMove = (moveEvent: MouseEvent) => {
+        // Guard: if button was released outside the window, clean up
+        if (moveEvent.buttons === 0) { onMouseUp(); return; }
+
         let ratio: number;
         if (axis === 'horizontal') {
           ratio = (moveEvent.clientX - rect.left) / rect.width;
@@ -343,6 +346,9 @@ export class SplitContainer {
       const rect = parentContainer.getBoundingClientRect();
 
       const onMouseMove = (moveEvent: MouseEvent) => {
+        // Guard: if button was released outside the window, clean up
+        if (moveEvent.buttons === 0) { onMouseUp(); return; }
+
         let ratio: number;
         if (isHorizontal) {
           ratio = (moveEvent.clientX - rect.left) / rect.width;

--- a/src/components/TabBar.ts
+++ b/src/components/TabBar.ts
@@ -755,6 +755,15 @@ export class TabBar {
 
       tab.addEventListener('pointermove', onMove);
       tab.addEventListener('pointerup', onUp);
+      // Guard: if pointer capture is lost (e.g., window blur), clean up
+      tab.addEventListener('lostpointercapture', () => {
+        tab.removeEventListener('pointermove', onMove);
+        tab.removeEventListener('pointerup', onUp);
+        if (dragging) {
+          tab.classList.remove('dragging');
+          endDrag();
+        }
+      }, { once: true });
     });
   }
 

--- a/src/components/TerminalRenderer.ts
+++ b/src/components/TerminalRenderer.ts
@@ -711,6 +711,8 @@ export class TerminalRenderer {
 
       // Register document-level listeners so we receive events even when cursor leaves canvas
       this.onDocumentSelectionMouseMove = (moveEvent: MouseEvent) => {
+        // Guard: if button was released outside the window, clean up
+        if (moveEvent.buttons === 0) { this.onDocumentSelectionMouseUp?.(moveEvent); return; }
         moveEvent.preventDefault();
         const gridRows = this.currentSnapshot?.dimensions.rows ?? 24;
         const raw = this.pixelToGridRaw(moveEvent.clientX, moveEvent.clientY);
@@ -859,6 +861,8 @@ export class TerminalRenderer {
     this.handleScrollbarDragAt(e.clientY);
 
     this.onDocumentMouseMove = (moveEvent: MouseEvent) => {
+      // Guard: if button was released outside the window, clean up
+      if (moveEvent.buttons === 0) { this.onDocumentMouseUp?.(moveEvent); return; }
       moveEvent.preventDefault();
       this.handleScrollbarDragAt(moveEvent.clientY);
     };

--- a/src/components/WorkspaceSidebar.ts
+++ b/src/components/WorkspaceSidebar.ts
@@ -487,6 +487,15 @@ export class WorkspaceSidebar {
 
       item.addEventListener('pointermove', onMove);
       item.addEventListener('pointerup', onUp);
+      // Guard: if pointer capture is lost (e.g., window blur), clean up
+      item.addEventListener('lostpointercapture', () => {
+        item.removeEventListener('pointermove', onMove);
+        item.removeEventListener('pointerup', onUp);
+        if (dragging) {
+          item.classList.remove('dragging');
+          endDrag();
+        }
+      }, { once: true });
     });
   }
 


### PR DESCRIPTION
## Summary

- Add `e.buttons === 0` guard to all document-level `mousemove` handlers so they self-clean when the mouse button is released outside the WebView
- Add `lostpointercapture` handlers to pointer-capture-based drags (TabBar, WorkspaceSidebar)

**Affected components:** SplitContainer (2 divider types), App.ts split divider, TerminalRenderer (scrollbar + selection drag), TabBar, WorkspaceSidebar

## Test plan

- [ ] Start divider resize drag, Alt-Tab away, release mouse, Alt-Tab back — divider should NOT follow cursor
- [ ] Start tab drag, move mouse outside window, release, move back — no stuck ghost/drag state  
- [ ] Start text selection, move outside window, release, move back — selection should stop
- [ ] Normal drag operations still work correctly (divider resize, tab reorder, text selection)

fixes #581