### PR TITLE
fix: set GODLY_INSTANCE before native frontend dispatch

### DIFF
--- a/changelog/unreleased/fix-staging-isolation-native-mode.md
+++ b/changelog/unreleased/fix-staging-isolation-native-mode.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Fix staging isolation broken by native frontend mode** — The `GODLY_INSTANCE=staging` env var was set inside `lib::run()`, but the native frontend path in `main.rs` spawns `godly-native.exe` and exits without calling `run()`. The child process inherited no instance var, causing it to connect to the production daemon instead of the staging one. Moved the env var setup to `main()` before the frontend mode dispatch.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,15 @@
 )]
 
 fn main() {
+    // When built with --features staging, set GODLY_INSTANCE before anything else.
+    // This must happen here (not in lib::run()) because the Native frontend path
+    // spawns godly-native.exe and exits without ever calling run(). The child
+    // process inherits this env var, ensuring it connects to the staging daemon.
+    #[cfg(feature = "staging")]
+    unsafe {
+        std::env::set_var("GODLY_INSTANCE", "staging");
+    }
+
     let mode = godly_protocol::frontend_mode();
 
     match mode {


### PR DESCRIPTION
## Summary

- **Root cause:** The `staging` feature set `GODLY_INSTANCE=staging` inside `lib::run()`, but the native frontend path (the new default since #573) spawns `godly-native.exe` and exits without calling `run()`. The child process inherited no instance var, connecting to the production daemon instead of the staging one.
- **Fix:** Move the env var setup to `main()` before the frontend mode dispatch so child processes (including `godly-native.exe`) inherit it correctly.
- **Impact:** Staging sessions were created on the production daemon, causing cross-talk when clicking in production and no tab persistence on staging restart.

## Test plan

- [ ] Build staging: `pnpm staging:build && pnpm staging:install`
- [ ] Open both production and staging simultaneously
- [ ] Verify staging sessions survive clicking around in production
- [ ] Close and reopen staging — tabs should restore


🤖 Generated with [Claude Code](https://claude.com/claude-code)