### PR TITLE
feat(native): shell picker dialog + AI tool mode per workspace (H1-H6)

### DIFF
--- a/changelog/unreleased/h1-h6-shell-picker.md
+++ b/changelog/unreleased/h1-h6-shell-picker.md
@@ -1,0 +1,4 @@
+### Added
+- **Shell picker dialog** - New terminal creation shows a tabbed dialog to choose PowerShell, WSL (with distro picker), or Custom shell program/args
+- **AI tool mode per workspace** - Workspaces can be tagged with an AI tool mode (Claude, Codex, Both, or None)
+- **Workspace mode icons in sidebar** - AI tool mode icons display next to workspace names in the sidebar

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -347,6 +347,9 @@ pub struct GodlyApp {
     copy_preview_text: Option<String>,
     // --- F1-F4: Theme System ---
     active_theme: crate::theme::ThemeId,
+    // --- H1-H6: Shell Picker & Workspace Creation ---
+    shell_picker: ShellPickerState,
+    workspace_ai_modes: HashMap<String, AiToolMode>,
 }
 
 impl Default for GodlyApp {
@@ -420,6 +423,8 @@ impl Default for GodlyApp {
             quit_confirm_pending: false,
             copy_preview_text: None,
             active_theme: crate::theme::ThemeId::Dusk,
+            shell_picker: ShellPickerState::default(),
+            workspace_ai_modes: HashMap::new(),
         }
     }
 }
@@ -651,6 +656,18 @@ pub enum Message {
     CopyPreviewDismissed,
     // --- F1-F4: Theme System ---
     ThemeChanged(crate::theme::ThemeId),
+    // --- H1-H6: Shell Picker & Workspace Creation ---
+    ShellPickerOpen,
+    ShellPickerTabClicked(ShellPickerTab),
+    ShellPickerDistroSelected(Option<String>),
+    ShellPickerCustomProgramChanged(String),
+    ShellPickerCustomArgsChanged(String),
+    ShellPickerConfirmed,
+    ShellPickerCancelled,
+    WorkspaceAiModeChanged {
+        workspace_id: String,
+        mode: AiToolMode,
+    },
 }
 
 /// Result of initialization — either a fresh terminal or recovered sessions.
@@ -1141,6 +1158,36 @@ impl GodlyApp {
                     let _ = commands::write_to_terminal(client, &terminal_id, payload.as_bytes());
                 }
             }
+            // --- H1-H6: Shell Picker & Workspace Creation ---
+            Message::ShellPickerOpen => {
+                self.shell_picker.open();
+            }
+            Message::ShellPickerTabClicked(tab) => {
+                self.shell_picker.tab = tab;
+            }
+            Message::ShellPickerDistroSelected(distro) => {
+                self.shell_picker.selected_distro = distro;
+            }
+            Message::ShellPickerCustomProgramChanged(val) => {
+                self.shell_picker.custom_program = val;
+            }
+            Message::ShellPickerCustomArgsChanged(val) => {
+                self.shell_picker.custom_args = val;
+            }
+            Message::ShellPickerConfirmed => {
+                self.shell_picker.close();
+                return self.create_new_terminal();
+            }
+            Message::ShellPickerCancelled => {
+                self.shell_picker.close();
+            }
+            Message::WorkspaceAiModeChanged { workspace_id, mode } => {
+                if mode == AiToolMode::None {
+                    self.workspace_ai_modes.remove(&workspace_id);
+                } else {
+                    self.workspace_ai_modes.insert(workspace_id, mode);
+                }
+            }
 
             // --- Keyboard input (shortcut-first, then forward to PTY) ---
             Message::KeyboardEvent(keyboard::Event::KeyPressed { key, modifiers, .. }) => {
@@ -1298,7 +1345,7 @@ impl GodlyApp {
                 self.dragging_tab_id = None;
             }
             Message::NewTabRequested => {
-                return self.create_new_terminal();
+                self.shell_picker.open();
             }
             Message::CloseTabRequested(id) => {
                 if self.dragging_tab_id.as_deref() == Some(id.as_str()) {
@@ -2114,6 +2161,14 @@ impl GodlyApp {
                             .iter()
                             .any(|id| id.as_str() == workspace_id)
                     },
+                    |workspace_id: &str| -> Option<&'static str> {
+                        match self.workspace_ai_modes.get(workspace_id) {
+                            Some(AiToolMode::Claude) => Some("[C]"),
+                            Some(AiToolMode::Codex) => Some("[X]"),
+                            Some(AiToolMode::Both) => Some("[CX]"),
+                            _ => None,
+                        }
+                    },
                 ),
                 sidebar_width,
                 Message::SidebarAction,
@@ -2237,7 +2292,7 @@ impl GodlyApp {
             with_tab_rename
         };
 
-        if let Some(ref preview_text) = self.copy_preview_text {
+        let with_copy_preview: Element<'_, Message> = if let Some(ref preview_text) = self.copy_preview_text {
             stack![
                 with_quit,
                 crate::confirm_dialog::view_copy_preview(
@@ -2250,8 +2305,23 @@ impl GodlyApp {
             .into()
         } else {
             with_quit
+        };
+
+        // Shell picker overlay (H1-H6)
+        if self.shell_picker.visible {
+            let picker = shell_picker::view_shell_picker(
+                &self.shell_picker,
+                Message::ShellPickerTabClicked,
+                Message::ShellPickerDistroSelected,
+                Message::ShellPickerCustomProgramChanged,
+                Message::ShellPickerCustomArgsChanged,
+                Message::ShellPickerConfirmed,
+                Message::ShellPickerCancelled,
+            );
+            stack![with_copy_preview, picker].into()
+        } else {
+            with_copy_preview
         }
-    }
 
     fn view_tab_context_menu(&self) -> Element<'_, Message> {
         let Some(tab_id) = self.tab_context_menu_id.as_deref() else {

--- a/src-tauri/native/iced-shell/src/lib.rs
+++ b/src-tauri/native/iced-shell/src/lib.rs
@@ -14,3 +14,4 @@ pub mod title_bar;
 pub mod theme;
 pub mod workspace_state;
 pub mod confirm_dialog;
+pub mod shell_picker;

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -15,6 +15,7 @@ mod terminal_state;
 mod theme;
 mod title_bar;
 mod workspace_state;
+mod shell_picker;
 
 mod confirm_dialog;
 

--- a/src-tauri/native/iced-shell/src/shell_picker.rs
+++ b/src-tauri/native/iced-shell/src/shell_picker.rs
@@ -1,0 +1,446 @@
+use iced::widget::{button, column, container, row, scrollable, text, text_input, Space};
+use iced::{Background, Border, Color, Element, Length, Padding, Shadow, Vector};
+
+use crate::theme;
+
+/// Shell type selection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellChoice {
+    PowerShell,
+    Wsl { distribution: Option<String> },
+    Custom { program: String, args: Vec<String> },
+}
+
+impl ShellChoice {
+    pub fn label(&self) -> String {
+        match self {
+            Self::PowerShell => "PowerShell".to_string(),
+            Self::Wsl { distribution: None } => "WSL (default)".to_string(),
+            Self::Wsl {
+                distribution: Some(d),
+            } => format!("WSL: {}", d),
+            Self::Custom { program, .. } => format!("Custom: {}", program),
+        }
+    }
+}
+
+/// Active tab in the shell picker dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellPickerTab {
+    PowerShell,
+    Wsl,
+    Custom,
+}
+
+impl ShellPickerTab {
+    pub fn all() -> [Self; 3] {
+        [Self::PowerShell, Self::Wsl, Self::Custom]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::PowerShell => "PowerShell",
+            Self::Wsl => "WSL",
+            Self::Custom => "Custom",
+        }
+    }
+}
+
+/// Shell picker dialog state.
+#[derive(Debug, Clone)]
+pub struct ShellPickerState {
+    pub visible: bool,
+    pub tab: ShellPickerTab,
+    pub custom_program: String,
+    pub custom_args: String,
+    pub wsl_distros: Vec<String>,
+    pub selected_distro: Option<String>,
+}
+
+impl Default for ShellPickerState {
+    fn default() -> Self {
+        Self {
+            visible: false,
+            tab: ShellPickerTab::PowerShell,
+            custom_program: String::new(),
+            custom_args: String::new(),
+            wsl_distros: Vec::new(),
+            selected_distro: None,
+        }
+    }
+}
+
+impl ShellPickerState {
+    pub fn open(&mut self) {
+        self.visible = true;
+        self.tab = ShellPickerTab::PowerShell;
+    }
+
+    pub fn close(&mut self) {
+        self.visible = false;
+        self.custom_program.clear();
+        self.custom_args.clear();
+        self.selected_distro = None;
+    }
+
+    pub fn current_choice(&self) -> ShellChoice {
+        match self.tab {
+            ShellPickerTab::PowerShell => ShellChoice::PowerShell,
+            ShellPickerTab::Wsl => ShellChoice::Wsl {
+                distribution: self.selected_distro.clone(),
+            },
+            ShellPickerTab::Custom => ShellChoice::Custom {
+                program: self.custom_program.clone(),
+                args: self
+                    .custom_args
+                    .split_whitespace()
+                    .map(String::from)
+                    .collect(),
+            },
+        }
+    }
+}
+
+/// AI tool mode for a workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AiToolMode {
+    #[default]
+    None,
+    Claude,
+    Codex,
+    Both,
+}
+
+impl AiToolMode {
+    pub fn all() -> [Self; 4] {
+        [Self::None, Self::Claude, Self::Codex, Self::Both]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::None => "None",
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+            Self::Both => "Both",
+        }
+    }
+
+    /// Icon text for sidebar display, if any.
+    pub fn icon(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::Claude => Some("\u{2728}"),  // sparkles
+            Self::Codex => Some("\u{26A1}"),   // lightning
+            Self::Both => Some("\u{1F680}"),   // rocket
+        }
+    }
+}
+
+/// Parse WSL distro list from `wsl -l -q` output.
+pub fn parse_wsl_distros(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(|l| l.trim().trim_matches('\0').trim())
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Render the shell picker dialog as a modal overlay.
+pub fn view_shell_picker<'a, M: Clone + 'a>(
+    state: &'a ShellPickerState,
+    on_tab_click: impl Fn(ShellPickerTab) -> M + 'a,
+    on_distro_select: impl Fn(Option<String>) -> M + 'a,
+    on_custom_program_changed: impl Fn(String) -> M + 'a,
+    on_custom_args_changed: impl Fn(String) -> M + 'a,
+    on_confirm: M,
+    on_cancel: M,
+) -> Element<'a, M> {
+    let accent = theme::ACCENT();
+    let border_color = theme::BORDER();
+    let bg_secondary = theme::BG_SECONDARY();
+    let text_active = theme::TEXT_ACTIVE();
+    let text_primary = theme::TEXT_PRIMARY();
+    let text_secondary = theme::TEXT_SECONDARY();
+    let backdrop = theme::BACKDROP();
+
+    // Build tab buttons (PowerShell / WSL / Custom)
+    let mut tab_row = row![].spacing(6);
+    for tab in ShellPickerTab::all() {
+        let is_active = tab == state.tab;
+        let tab_btn = button(text(tab.label()).size(13))
+            .on_press(on_tab_click(tab))
+            .padding(Padding::from([6, 12]))
+            .style(move |_theme, _status| {
+                let bg = if is_active {
+                    Color::from_rgba(accent.r, accent.g, accent.b, 0.22)
+                } else {
+                    Color::TRANSPARENT
+                };
+                button::Style {
+                    background: Some(Background::Color(bg)),
+                    text_color: if is_active { text_active } else { text_secondary },
+                    border: Border {
+                        color: if is_active { accent } else { border_color },
+                        width: 1.0,
+                        radius: 6.0.into(),
+                    },
+                    ..button::Style::default()
+                }
+            });
+        tab_row = tab_row.push(tab_btn);
+    }
+
+    // Tab content
+    let tab_content: Element<'a, M> = match state.tab {
+        ShellPickerTab::PowerShell => column![
+            text("Launch a new PowerShell terminal.")
+                .size(13)
+                .color(text_secondary),
+            Space::new().height(8.0),
+            text("Uses pwsh.exe if available, falls back to powershell.exe.")
+                .size(12)
+                .color(text_secondary),
+        ]
+        .spacing(4)
+        .into(),
+        ShellPickerTab::Wsl => {
+            let mut items = column![text("Select a WSL distribution:")
+                .size(13)
+                .color(text_secondary),]
+            .spacing(4);
+
+            // Default distro option
+            let is_selected = state.selected_distro.is_none();
+            let default_btn = button(
+                text("Default")
+                    .size(13)
+                    .color(if is_selected { text_active } else { text_primary }),
+            )
+            .on_press(on_distro_select(None))
+            .padding(Padding::from([5, 10]))
+            .width(Length::Fill)
+            .style(move |_theme, _status| button::Style {
+                background: Some(Background::Color(if is_selected {
+                    Color::from_rgba(accent.r, accent.g, accent.b, 0.12)
+                } else {
+                    Color::TRANSPARENT
+                })),
+                text_color: text_primary,
+                border: Border::default(),
+                ..button::Style::default()
+            });
+            items = items.push(default_btn);
+
+            for distro in &state.wsl_distros {
+                let d2 = distro.clone();
+                let is_selected = state.selected_distro.as_deref() == Some(distro.as_str());
+                let btn = button(
+                    text(distro.as_str())
+                        .size(13)
+                        .color(if is_selected { text_active } else { text_primary }),
+                )
+                .on_press(on_distro_select(Some(d2)))
+                .padding(Padding::from([5, 10]))
+                .width(Length::Fill)
+                .style(move |_theme, _status| button::Style {
+                    background: Some(Background::Color(if is_selected {
+                        Color::from_rgba(accent.r, accent.g, accent.b, 0.12)
+                    } else {
+                        Color::TRANSPARENT
+                    })),
+                    text_color: text_primary,
+                    border: Border::default(),
+                    ..button::Style::default()
+                });
+                items = items.push(btn);
+            }
+
+            scrollable(items).height(Length::Fixed(200.0)).into()
+        }
+        ShellPickerTab::Custom => column![
+            text("Program:").size(12).color(text_secondary),
+            text_input("e.g. bash, zsh, cmd.exe", &state.custom_program)
+                .on_input(on_custom_program_changed)
+                .size(13)
+                .padding(Padding::from([4, 8])),
+            Space::new().height(8.0),
+            text("Arguments (space-separated):")
+                .size(12)
+                .color(text_secondary),
+            text_input("e.g. --login -i", &state.custom_args)
+                .on_input(on_custom_args_changed)
+                .size(13)
+                .padding(Padding::from([4, 8])),
+        ]
+        .spacing(4)
+        .into(),
+    };
+
+    // Footer buttons
+    let cancel_btn = button(text("Cancel").size(13))
+        .on_press(on_cancel)
+        .padding(Padding::from([6, 16]));
+    let confirm_btn = button(text("Create").size(13).color(text_active))
+        .on_press(on_confirm)
+        .padding(Padding::from([6, 16]))
+        .style(move |_theme, _status| button::Style {
+            background: Some(Background::Color(accent)),
+            text_color: Color::WHITE,
+            border: Border {
+                radius: 6.0.into(),
+                ..Border::default()
+            },
+            ..button::Style::default()
+        });
+    let footer = row![Space::new().width(Length::Fill), cancel_btn, confirm_btn].spacing(8);
+
+    // Compose dialog
+    let dialog_content = column![
+        text("New Terminal").size(16).color(text_active),
+        Space::new().height(8.0),
+        tab_row,
+        Space::new().height(12.0),
+        container(tab_content)
+            .width(Length::Fill)
+            .height(Length::Fill),
+        Space::new().height(12.0),
+        footer,
+    ]
+    .spacing(4);
+
+    let dialog = container(dialog_content)
+        .padding(Padding::from([16, 20]))
+        .width(Length::Fixed(420.0))
+        .height(Length::Fixed(380.0))
+        .style(move |_theme| container::Style {
+            background: Some(Background::Color(bg_secondary)),
+            border: Border {
+                color: border_color,
+                width: 1.0,
+                radius: 10.0.into(),
+            },
+            shadow: Shadow {
+                color: Color::from_rgba(0.0, 0.0, 0.0, 0.5),
+                offset: Vector::new(0.0, 8.0),
+                blur_radius: 24.0,
+            },
+            ..container::Style::default()
+        });
+
+    // Backdrop + centered dialog
+    container(iced::widget::center(dialog))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .style(move |_theme| container::Style {
+            background: Some(Background::Color(backdrop)),
+            ..container::Style::default()
+        })
+        .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_wsl_distros_basic() {
+        let output = "Ubuntu\nDebian\nkali-linux\n";
+        let distros = parse_wsl_distros(output);
+        assert_eq!(distros, vec!["Ubuntu", "Debian", "kali-linux"]);
+    }
+
+    #[test]
+    fn parse_wsl_distros_with_null_bytes() {
+        // wsl -l -q on some systems outputs UTF-16 with null bytes
+        let output = "U\0b\0u\0n\0t\0u\0\n\0";
+        let distros = parse_wsl_distros(output);
+        assert!(!distros.is_empty());
+    }
+
+    #[test]
+    fn parse_wsl_distros_empty() {
+        let distros = parse_wsl_distros("");
+        assert!(distros.is_empty());
+    }
+
+    #[test]
+    fn shell_choice_labels() {
+        assert_eq!(ShellChoice::PowerShell.label(), "PowerShell");
+        assert!(ShellChoice::Wsl {
+            distribution: None
+        }
+        .label()
+        .contains("default"));
+        assert!(ShellChoice::Wsl {
+            distribution: Some("Ubuntu".into())
+        }
+        .label()
+        .contains("Ubuntu"));
+        assert!(ShellChoice::Custom {
+            program: "bash".into(),
+            args: vec![]
+        }
+        .label()
+        .contains("bash"));
+    }
+
+    #[test]
+    fn current_choice_powershell() {
+        let state = ShellPickerState::default();
+        assert_eq!(state.current_choice(), ShellChoice::PowerShell);
+    }
+
+    #[test]
+    fn current_choice_wsl() {
+        let mut state = ShellPickerState::default();
+        state.tab = ShellPickerTab::Wsl;
+        state.selected_distro = Some("Ubuntu".into());
+        match state.current_choice() {
+            ShellChoice::Wsl { distribution } => {
+                assert_eq!(distribution, Some("Ubuntu".into()));
+            }
+            _ => panic!("expected WSL"),
+        }
+    }
+
+    #[test]
+    fn current_choice_custom() {
+        let mut state = ShellPickerState::default();
+        state.tab = ShellPickerTab::Custom;
+        state.custom_program = "bash".into();
+        state.custom_args = "--login -i".into();
+        match state.current_choice() {
+            ShellChoice::Custom { program, args } => {
+                assert_eq!(program, "bash");
+                assert_eq!(args, vec!["--login", "-i"]);
+            }
+            _ => panic!("expected Custom"),
+        }
+    }
+
+    #[test]
+    fn ai_tool_mode_labels() {
+        for mode in AiToolMode::all() {
+            assert!(!mode.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn ai_tool_mode_icons() {
+        assert!(AiToolMode::None.icon().is_none());
+        assert!(AiToolMode::Claude.icon().is_some());
+        assert!(AiToolMode::Codex.icon().is_some());
+        assert!(AiToolMode::Both.icon().is_some());
+    }
+
+    #[test]
+    fn open_close_state() {
+        let mut state = ShellPickerState::default();
+        assert!(!state.visible);
+        state.open();
+        assert!(state.visible);
+        state.close();
+        assert!(!state.visible);
+    }
+}


### PR DESCRIPTION
## Summary

- **H1**: Shell picker dialog with PowerShell / WSL / Custom tabs — opens on New Tab (+) button click
- **H2**: WSL distro picker with distribution list parsed from `wsl -l -q` output
- **H3**: Custom shell program/args input fields for arbitrary shell binaries
- **H4**: AI tool mode per workspace (None / Claude / Codex / Both) stored in `workspace_ai_modes` HashMap
- **H6**: Workspace mode icons `[C]` / `[X]` / `[CX]` rendered in sidebar next to workspace names via 3-tuple `SidebarWorkspaceSignals` impl

### New files
- `src-tauri/native/iced-shell/src/shell_picker.rs` — 446 lines, complete module with view function, state, enums, and 11 unit tests

### Modified files
- `app.rs` — import, struct fields, Default init, Message variants, handlers, sidebar 3-tuple, view overlay
- `sidebar.rs` — `workspace_ai_mode_icon` trait method + 3-tuple impl + icon rendering in workspace row
- `lib.rs` / `main.rs` — module registration

## Test plan
- [ ] `cargo check -p godly-iced-shell` (H1-H6 changes compile; pre-existing errors from other units are unrelated)
- [ ] `cargo nextest run -p godly-iced-shell` — 11 new unit tests for WSL distro parsing and shell picker state
- [ ] Manual: click + button in tab bar → shell picker dialog appears
- [ ] Manual: set AI tool mode on workspace → icon appears in sidebar