### PR TITLE
feat: add theme system with 11 built-in themes

### DIFF
--- a/changelog/unreleased/f1-f4-theme-system.md
+++ b/changelog/unreleased/f1-f4-theme-system.md
@@ -1,0 +1,5 @@
+### Added
+- **Theme system** — 11 built-in color themes (Dusk, Tokyo Night, Dracula, Nord, Gruvbox Dark, One Dark, Catppuccin, Solarized Dark, Monokai, Ayu Dark, Rosé Pine) with full UI + terminal ANSI palettes
+- **Appearance tab** in Settings dialog for selecting themes with color preview swatches
+- **Dynamic theme switching** — themes apply instantly to all UI chrome and terminal rendering via global RwLock
+- **Per-theme terminal colors** — each theme provides 16 ANSI colors, foreground, background, cursor, and selection colors

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -37,11 +39,13 @@ use crate::tab_bar::{self, TAB_BAR_HEIGHT};
 use crate::title_bar;
 use crate::terminal_state::TerminalCollection;
 use crate::theme::{
-    ACCENT, BACKDROP, BG_SECONDARY, BG_TERTIARY, BORDER, EMPTY_STATE_BG, PANE_BG, PANE_BORDER,
+    ACCENT, BACKDROP, BG_PRIMARY, BG_SECONDARY, BG_TERTIARY, BORDER, EMPTY_STATE_BG, PANE_BG, PANE_BORDER,
     PANE_FOCUSED_BORDER, RADIUS_MD, RADIUS_LG, SHADOW_COLOR, TEXT_ACTIVE, TEXT_PRIMARY,
     TEXT_SECONDARY,
 };
+use crate::url_detector;
 use crate::workspace_state::WorkspaceCollection;
+use crate::shell_picker::{self, AiToolMode, ShellPickerState, ShellPickerTab};
 
 #[path = "mru_switcher.rs"]
 mod mru_switcher;
@@ -341,6 +345,8 @@ pub struct GodlyApp {
     // --- K2/K3: Quit Confirmation + Copy Preview ---
     quit_confirm_pending: bool,
     copy_preview_text: Option<String>,
+    // --- F1-F4: Theme System ---
+    active_theme: crate::theme::ThemeId,
 }
 
 impl Default for GodlyApp {
@@ -413,6 +419,7 @@ impl Default for GodlyApp {
             mru_switcher: None,
             quit_confirm_pending: false,
             copy_preview_text: None,
+            active_theme: crate::theme::ThemeId::Dusk,
         }
     }
 }
@@ -630,6 +637,9 @@ pub enum Message {
     ClipboardPasted { terminal_id: String, text: String },
     /// Clipboard read failed in background.
     ClipboardPasteFailed(String),
+    // --- G3: URL Detection ---
+    /// URL clicked (Ctrl+Click) — open in default browser.
+    UrlClicked(String),
     /// File path dropped on window.
     FileDropped(PathBuf),
     // --- K2/K3: Quit Confirmation + Copy Preview ---
@@ -639,6 +649,8 @@ pub enum Message {
     CopyPreviewShow(String),
     CopyPreviewConfirmed,
     CopyPreviewDismissed,
+    // --- F1-F4: Theme System ---
+    ThemeChanged(crate::theme::ThemeId),
 }
 
 /// Result of initialization — either a fresh terminal or recovered sessions.
@@ -766,6 +778,28 @@ impl GodlyApp {
             .unwrap_or_else(|| inset_terminal_pane_rect(self.terminal_content_area()));
 
         grid_dimensions_for_viewport(viewport, self.font_metrics)
+    }
+
+    /// G3: Detect if the cursor is currently over a URL in the terminal grid.
+    fn detect_url_under_cursor(&self) -> Option<String> {
+        let grid_pos = self.active_terminal_pointer_grid(false)?;
+        let terminal_id = self.target_terminal_id()?;
+        let term = self.terminals.get(terminal_id)?;
+        let grid = term.grid.as_ref()?;
+        let row_idx = grid_pos.row as usize;
+        let row = grid.rows.get(row_idx)?;
+        let line: String = row
+            .cells
+            .iter()
+            .map(|c| {
+                if c.content.is_empty() {
+                    " "
+                } else {
+                    c.content.as_str()
+                }
+            })
+            .collect();
+        url_detector::url_at_col(&line, grid_pos.col as usize)
     }
 
     fn active_terminal_pointer_grid(&self, clamp_to_viewport: bool) -> Option<GridPos> {
@@ -1093,6 +1127,13 @@ impl GodlyApp {
                     log::error!("Clipboard paste failed: {}", e);
                 }
             }
+            // --- G3: URL Click-to-Open ---
+            Message::UrlClicked(url) => {
+                let _ = std::process::Command::new("cmd")
+                    .args(["/C", "start", "", &url])
+                    .creation_flags(0x08000000) // CREATE_NO_WINDOW
+                    .spawn();
+            }
             Message::FileDropped(path) => {
                 let target_terminal = self.target_terminal_id().map(str::to_string);
                 if let (Some(terminal_id), Some(client)) = (target_terminal, &self.client) {
@@ -1140,6 +1181,7 @@ impl GodlyApp {
                 }
             }
             Message::KeyboardEvent(keyboard::Event::ModifiersChanged(modifiers)) => {
+                self.ctrl_held = modifiers.control();
                 if should_commit_mru_switcher_on_modifiers_changed(
                     self.mru_switcher.is_some(),
                     modifiers,
@@ -1379,12 +1421,20 @@ impl GodlyApp {
                 if x != 0.0 || y != 0.0 {
                     self.cursor_position = Some(Point::new(x, y));
                 }
+                // G3: Ctrl+Click opens URL under cursor
+                if self.ctrl_held {
+                    if let Some(url) = self.detect_url_under_cursor() {
+                        return Task::done(Message::UrlClicked(url));
+                    }
+                }
                 if let Some(pos) = self.active_terminal_pointer_grid(false) {
                     self.selection.start(pos);
                 }
             }
             Message::SelectionUpdate { x, y } => {
                 self.cursor_position = Some(Point::new(x, y));
+                // G3: Track hovered URL for visual feedback
+                self.hovered_url = self.detect_url_under_cursor();
                 if self.sidebar_resizing {
                     self.sidebar_width = sidebar::clamp_sidebar_width(x);
                     return Task::none();
@@ -1988,6 +2038,10 @@ impl GodlyApp {
             Message::CopyPreviewDismissed => {
                 self.copy_preview_text = None;
             }
+            Message::ThemeChanged(id) => {
+                self.active_theme = id;
+                crate::theme::set_active_theme(id);
+            }
         }
         Task::none()
     }
@@ -2083,6 +2137,10 @@ impl GodlyApp {
         let with_settings: Element<'_, Message> = if self.settings_open {
             let tabs = &[
                 SettingsTab {
+                    id: "appearance",
+                    label: "Appearance",
+                },
+                SettingsTab {
                     id: "shortcuts",
                     label: "Shortcuts",
                 },
@@ -2112,6 +2170,7 @@ impl GodlyApp {
                 },
             ];
             let tab_content = match self.settings_tab.as_str() {
+                "appearance" => self.view_appearance_tab(),
                 "notifications" => self.view_notifications_tab(),
                 "quick-claude" => self.view_quick_claude_tab(),
                 "ai-tools" => self.view_ai_tools_tab(),
@@ -2204,7 +2263,7 @@ impl GodlyApp {
 
         let title = text(format!("Tab Actions: {}", term.tab_label()))
             .size(14)
-            .color(TEXT_ACTIVE);
+            .color(TEXT_ACTIVE());
         let rename_id = tab_id.to_string();
         let split_right_id = tab_id.to_string();
         let split_down_id = tab_id.to_string();
@@ -2212,18 +2271,18 @@ impl GodlyApp {
         let close_id = tab_id.to_string();
 
         let action_btn = |label: &'static str, msg: Message| {
-            button(text(label).size(12).color(TEXT_PRIMARY))
+            button(text(label).size(12).color(TEXT_PRIMARY()))
                 .on_press(msg)
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
                 .style(|_theme, status| {
                     let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => iced::Color::TRANSPARENT,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(bg)),
-                        text_color: TEXT_PRIMARY,
+                        text_color: TEXT_PRIMARY(),
                         border: iced::Border::default(),
                         ..button::Style::default()
                     }
@@ -2257,9 +2316,9 @@ impl GodlyApp {
         .padding(Padding::from([10, 10]))
         .width(Length::Fixed(260.0))
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(BG_SECONDARY)),
+            background: Some(iced::Background::Color(BG_SECONDARY())),
             border: iced::Border {
-                color: BORDER,
+                color: BORDER(),
                 width: 1.0,
                 radius: RADIUS_MD.into(),
             },
@@ -2275,7 +2334,7 @@ impl GodlyApp {
             .width(Length::Fill)
             .height(Length::Fill)
             .style(|_theme| container::Style {
-                background: Some(iced::Background::Color(BACKDROP)),
+                background: Some(iced::Background::Color(BACKDROP())),
                 ..container::Style::default()
             })
             .into()
@@ -2283,7 +2342,7 @@ impl GodlyApp {
 
     fn view_tab_rename_dialog(&self) -> Element<'_, Message> {
         let dialog = container(column![
-            text("Rename Tab").size(16).color(TEXT_ACTIVE),
+            text("Rename Tab").size(16).color(TEXT_ACTIVE()),
             text_input(
                 "Tab name (empty clears custom name)",
                 &self.rename_tab_value
@@ -2294,38 +2353,38 @@ impl GodlyApp {
             .size(14),
             row![
                 Space::new().width(Length::Fill),
-                button(text("Cancel").size(12).color(TEXT_PRIMARY))
+                button(text("Cancel").size(12).color(TEXT_PRIMARY()))
                     .on_press(Message::TabRenameCancelled)
                     .padding(Padding::from([4, 9]))
                     .style(|_theme, status| {
                         let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                             _ => iced::Color::TRANSPARENT,
                         };
                         button::Style {
                             background: Some(iced::Background::Color(bg)),
-                            text_color: TEXT_PRIMARY,
+                            text_color: TEXT_PRIMARY(),
                             border: iced::Border {
-                                color: BORDER,
+                                color: BORDER(),
                                 width: 1.0,
                                 radius: 4.0.into(),
                             },
                             ..button::Style::default()
                         }
                     }),
-                button(text("Rename").size(12).color(TEXT_ACTIVE))
+                button(text("Rename").size(12).color(TEXT_ACTIVE()))
                     .on_press(Message::TabRenameSubmitted)
                     .padding(Padding::from([4, 9]))
                     .style(|_theme, status| {
                         let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
-                            _ => BG_SECONDARY,
+                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
+                            _ => BG_SECONDARY(),
                         };
                         button::Style {
                             background: Some(iced::Background::Color(bg)),
-                            text_color: TEXT_ACTIVE,
+                            text_color: TEXT_ACTIVE(),
                             border: iced::Border {
-                                color: BORDER,
+                                color: BORDER(),
                                 width: 1.0,
                                 radius: 4.0.into(),
                             },
@@ -2338,9 +2397,9 @@ impl GodlyApp {
         .padding(Padding::from([14, 16]))
         .width(Length::Fixed(360.0))
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(BG_SECONDARY)),
+            background: Some(iced::Background::Color(BG_SECONDARY())),
             border: iced::Border {
-                color: BORDER,
+                color: BORDER(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -2351,7 +2410,7 @@ impl GodlyApp {
             .width(Length::Fill)
             .height(Length::Fill)
             .style(|_theme| container::Style {
-                background: Some(iced::Background::Color(BACKDROP)),
+                background: Some(iced::Background::Color(BACKDROP())),
                 ..container::Style::default()
             })
             .into()
@@ -2397,19 +2456,102 @@ impl GodlyApp {
             .mru_terminal_ids_for_workspace(Some(workspace_id))
     }
 
+    /// Render the Appearance tab (theme selection grid with preview swatches).
+    fn view_appearance_tab(&self) -> Element<'_, Message> {
+        use crate::theme::ThemeId;
+        use iced::widget::{button, row, scrollable, text, Space};
+        use iced::Theme;
+
+        let all_themes = ThemeId::all();
+        let mut grid_children: Vec<Element<'_, Message>> = Vec::new();
+
+        for &theme_id in all_themes {
+            let colors = theme_id.preview_colors();
+            let is_active = self.active_theme == theme_id;
+
+            // Build swatch row
+            let mut swatches = row![].spacing(2);
+            for c in &colors {
+                let color_val = *c;
+                swatches = swatches.push(
+                    container(Space::with_width(16).height(16))
+                        .style(move |_t: &Theme| container::Style {
+                            background: Some(iced::Background::Color(color_val)),
+                            border: iced::Border {
+                                radius: 2.0.into(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }),
+                );
+            }
+
+            let label = text(theme_id.name())
+                .size(13)
+                .color(if is_active { TEXT_ACTIVE() } else { TEXT_PRIMARY() });
+
+            let btn_content = column![label, swatches].spacing(4).padding(8);
+
+            let border_color = if is_active { ACCENT() } else { BORDER() };
+            let bg_color = if is_active { BG_TERTIARY() } else { BG_SECONDARY() };
+
+            let theme_button = button(btn_content)
+                .on_press(Message::ThemeChanged(theme_id))
+                .padding(0)
+                .style(move |_t: &Theme, _status| button::Style {
+                    background: Some(iced::Background::Color(bg_color)),
+                    border: iced::Border {
+                        color: border_color,
+                        width: if is_active { 2.0 } else { 1.0 },
+                        radius: RADIUS_MD.into(),
+                    },
+                    text_color: TEXT_PRIMARY(),
+                    ..Default::default()
+                });
+
+            grid_children.push(theme_button.width(Length::FillPortion(1)).into());
+        }
+
+        // Arrange in rows of 3
+        let mut rows: Vec<Element<'_, Message>> = Vec::new();
+        for chunk in grid_children.chunks_mut(3) {
+            let mut r = row![].spacing(8);
+            for child in chunk.iter_mut() {
+                let taken = std::mem::replace(child, Space::with_width(0).height(0).into());
+                r = r.push(taken);
+            }
+            rows.push(r.into());
+        }
+
+        let mut col = column![
+            text("Theme").size(16).color(TEXT_PRIMARY()),
+            text("Choose a color theme for the terminal and UI.")
+                .size(13)
+                .color(TEXT_SECONDARY()),
+        ]
+        .spacing(8)
+        .padding(16);
+
+        for r in rows {
+            col = col.push(r);
+        }
+
+        scrollable(col).height(Length::Fill).into()
+    }
+
     fn view_toast_overlay(&self) -> Element<'_, Message> {
         let mut toasts_column = column![].spacing(8).width(Length::Fixed(320.0));
         for toast in &self.toasts {
             let card = container(column![
-                text(&toast.title).size(13).color(TEXT_ACTIVE),
-                text(&toast.message).size(11).color(TEXT_PRIMARY),
+                text(&toast.title).size(13).color(TEXT_ACTIVE()),
+                text(&toast.message).size(11).color(TEXT_PRIMARY()),
             ])
             .padding(Padding::from([8, 10]))
             .width(Length::Fill)
             .style(|_theme| container::Style {
-                background: Some(iced::Background::Color(BG_SECONDARY)),
+                background: Some(iced::Background::Color(BG_SECONDARY())),
                 border: iced::Border {
-                    color: BORDER,
+                    color: BORDER(),
                     width: 1.0,
                     radius: RADIUS_MD.into(),
                 },
@@ -2440,22 +2582,22 @@ impl GodlyApp {
         let mut preset_row = row![].spacing(8);
         for preset in NotificationSoundPreset::all() {
             let is_active = self.notification_sound_preset == preset;
-            let bg = if is_active { BG_TERTIARY } else { BG_SECONDARY };
-            let fg = if is_active { TEXT_ACTIVE } else { TEXT_PRIMARY };
+            let bg = if is_active { BG_TERTIARY() } else { BG_SECONDARY() };
+            let fg = if is_active { TEXT_ACTIVE() } else { TEXT_PRIMARY() };
 
             let btn = button(text(preset.label()).size(12).color(fg))
                 .on_press(Message::NotificationSoundPresetSelected(preset))
                 .padding(Padding::from([4, 9]))
                 .style(move |_theme, status| {
                     let hover_bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => bg,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(hover_bg)),
                         text_color: fg,
                         border: iced::Border {
-                            color: BORDER,
+                            color: BORDER(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -2475,7 +2617,7 @@ impl GodlyApp {
             .padding(Padding::from([4, 8]))
             .size(12)
             .width(Length::Fill),
-            button(text("Add").size(12).color(TEXT_PRIMARY))
+            button(text("Add").size(12).color(TEXT_PRIMARY()))
                 .on_press(Message::AddWorkspaceMutePattern)
                 .padding(Padding::from([4, 9]))
         ]
@@ -2488,15 +2630,15 @@ impl GodlyApp {
             mute_pattern_list = mute_pattern_list.push(
                 text("No workspace mute patterns configured.")
                     .size(11)
-                    .color(TEXT_SECONDARY),
+                    .color(TEXT_SECONDARY()),
             );
         } else {
             for pattern in &self.workspace_mute_patterns {
                 let remove_pattern = pattern.clone();
                 let row = row![
-                    text(pattern).size(12).color(TEXT_PRIMARY),
+                    text(pattern).size(12).color(TEXT_PRIMARY()),
                     Space::new().width(Length::Fill),
-                    button(text("Remove").size(11).color(TEXT_PRIMARY))
+                    button(text("Remove").size(11).color(TEXT_PRIMARY()))
                         .on_press(Message::RemoveWorkspaceMutePattern(remove_pattern))
                         .padding(Padding::from([2, 7]))
                 ]
@@ -2509,21 +2651,21 @@ impl GodlyApp {
 
         container(
             column![
-                text("Notification Sounds").size(14).color(TEXT_ACTIVE),
+                text("Notification Sounds").size(14).color(TEXT_ACTIVE()),
                 text("Choose a sound preset for bell events.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
-                button(text(toggle_label).size(12).color(TEXT_PRIMARY))
+                    .color(TEXT_PRIMARY()),
+                button(text(toggle_label).size(12).color(TEXT_PRIMARY()))
                     .on_press(Message::NotificationSoundsToggled)
                     .padding(Padding::from([4, 9])),
                 preset_row,
-                button(text("Play Test Sound").size(12).color(TEXT_PRIMARY))
+                button(text("Play Test Sound").size(12).color(TEXT_PRIMARY()))
                     .on_press(Message::NotificationSoundTest)
                     .padding(Padding::from([4, 9])),
-                text("Workspace mute patterns").size(14).color(TEXT_ACTIVE),
+                text("Workspace mute patterns").size(14).color(TEXT_ACTIVE()),
                 text("Use * wildcard. Matches workspace id or name.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
+                    .color(TEXT_PRIMARY()),
                 add_pattern_row,
                 mute_pattern_list,
             ]
@@ -2544,21 +2686,21 @@ impl GodlyApp {
         let mut layout_row = row![].spacing(8).align_y(iced::Alignment::Center);
         for layout in QuickClaudeLayout::all() {
             let is_active = self.quick_claude_layout == layout;
-            let bg = if is_active { BG_TERTIARY } else { BG_SECONDARY };
-            let fg = if is_active { TEXT_ACTIVE } else { TEXT_PRIMARY };
+            let bg = if is_active { BG_TERTIARY() } else { BG_SECONDARY() };
+            let fg = if is_active { TEXT_ACTIVE() } else { TEXT_PRIMARY() };
             let layout_button = button(text(layout.label()).size(12).color(fg))
                 .on_press(Message::QuickClaudeLayoutSelected(layout))
                 .padding(Padding::from([4, 9]))
                 .style(move |_theme, status| {
                     let hover_bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => bg,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(hover_bg)),
                         text_color: fg,
                         border: iced::Border {
-                            color: BORDER,
+                            color: BORDER(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -2573,24 +2715,24 @@ impl GodlyApp {
             presets_list = presets_list.push(
                 text("No Quick Claude presets yet.")
                     .size(11)
-                    .color(TEXT_SECONDARY),
+                    .color(TEXT_SECONDARY()),
             );
         } else {
             for (index, preset) in self.quick_claude_presets.iter().enumerate() {
                 let is_editing = self.quick_claude_edit_index == Some(index);
                 let card_bg = if is_editing {
-                    BG_TERTIARY
+                    BG_TERTIARY()
                 } else {
-                    BG_SECONDARY
+                    BG_SECONDARY()
                 };
                 let card = container(column![
                     row![
-                        text(&preset.name).size(13).color(TEXT_ACTIVE),
+                        text(&preset.name).size(13).color(TEXT_ACTIVE()),
                         Space::new().width(Length::Fill),
-                        button(text("Edit").size(11).color(TEXT_PRIMARY))
+                        button(text("Edit").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::QuickClaudeEditPreset(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Delete").size(11).color(TEXT_PRIMARY))
+                        button(text("Delete").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::QuickClaudeDeletePreset(index))
                             .padding(Padding::from([2, 7])),
                     ]
@@ -2598,15 +2740,15 @@ impl GodlyApp {
                     .align_y(iced::Alignment::Center),
                     text(format!("Layout: {}", preset.layout.label()))
                         .size(11)
-                        .color(TEXT_SECONDARY),
-                    text(&preset.prompt_template).size(11).color(TEXT_PRIMARY),
+                        .color(TEXT_SECONDARY()),
+                    text(&preset.prompt_template).size(11).color(TEXT_PRIMARY()),
                 ])
                 .padding(Padding::from([8, 10]))
                 .width(Length::Fill)
                 .style(move |_theme| container::Style {
                     background: Some(iced::Background::Color(card_bg)),
                     border: iced::Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -2618,10 +2760,10 @@ impl GodlyApp {
 
         container(
             column![
-                text("Quick Claude Presets").size(14).color(TEXT_ACTIVE),
+                text("Quick Claude Presets").size(14).color(TEXT_ACTIVE()),
                 text("Configure reusable launch presets.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
+                    .color(TEXT_PRIMARY()),
                 text_input("Preset name", &self.quick_claude_name_input)
                     .on_input(Message::QuickClaudeNameInputChanged)
                     .padding(Padding::from([4, 8]))
@@ -2630,18 +2772,18 @@ impl GodlyApp {
                     .on_input(Message::QuickClaudePromptInputChanged)
                     .padding(Padding::from([4, 8]))
                     .size(12),
-                text("Layout").size(12).color(TEXT_SECONDARY),
+                text("Layout").size(12).color(TEXT_SECONDARY()),
                 layout_row,
                 row![
-                    button(text(save_label).size(12).color(TEXT_PRIMARY))
+                    button(text(save_label).size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::QuickClaudeSavePreset)
                         .padding(Padding::from([4, 9])),
-                    button(text("Clear").size(12).color(TEXT_PRIMARY))
+                    button(text("Clear").size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::QuickClaudeClearEditor)
                         .padding(Padding::from([4, 9])),
                 ]
                 .spacing(8),
-                text("Saved Presets").size(12).color(TEXT_SECONDARY),
+                text("Saved Presets").size(12).color(TEXT_SECONDARY()),
                 presets_list,
             ]
             .spacing(10)
@@ -2663,25 +2805,25 @@ impl GodlyApp {
             tools_list = tools_list.push(
                 text("No AI tools configured.")
                     .size(11)
-                    .color(TEXT_SECONDARY),
+                    .color(TEXT_SECONDARY()),
             );
         } else {
             for (index, entry) in self.ai_tools.iter().enumerate() {
                 let is_editing = self.ai_tool_edit_index == Some(index);
                 let card_bg = if is_editing {
-                    BG_TERTIARY
+                    BG_TERTIARY()
                 } else {
-                    BG_SECONDARY
+                    BG_SECONDARY()
                 };
                 let icon_line = entry.icon_tag.as_deref().unwrap_or("-");
                 let card = container(column![
                     row![
-                        text(&entry.display_name).size(13).color(TEXT_ACTIVE),
+                        text(&entry.display_name).size(13).color(TEXT_ACTIVE()),
                         Space::new().width(Length::Fill),
-                        button(text("Edit").size(11).color(TEXT_PRIMARY))
+                        button(text("Edit").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::AiToolEdit(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Delete").size(11).color(TEXT_PRIMARY))
+                        button(text("Delete").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::AiToolDelete(index))
                             .padding(Padding::from([2, 7])),
                     ]
@@ -2689,17 +2831,17 @@ impl GodlyApp {
                     .align_y(iced::Alignment::Center),
                     text(format!("Command: {}", entry.command))
                         .size(11)
-                        .color(TEXT_PRIMARY),
+                        .color(TEXT_PRIMARY()),
                     text(format!("Icon: {}", icon_line))
                         .size(11)
-                        .color(TEXT_SECONDARY),
+                        .color(TEXT_SECONDARY()),
                 ])
                 .padding(Padding::from([8, 10]))
                 .width(Length::Fill)
                 .style(move |_theme| container::Style {
                     background: Some(iced::Background::Color(card_bg)),
                     border: iced::Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -2711,10 +2853,10 @@ impl GodlyApp {
 
         container(
             column![
-                text("AI Tools").size(14).color(TEXT_ACTIVE),
+                text("AI Tools").size(14).color(TEXT_ACTIVE()),
                 text("Register custom AI tool launch entries.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
+                    .color(TEXT_PRIMARY()),
                 text_input("Display name", &self.ai_tool_name_input)
                     .on_input(Message::AiToolNameInputChanged)
                     .padding(Padding::from([4, 8]))
@@ -2728,15 +2870,15 @@ impl GodlyApp {
                     .padding(Padding::from([4, 8]))
                     .size(12),
                 row![
-                    button(text(save_label).size(12).color(TEXT_PRIMARY))
+                    button(text(save_label).size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::AiToolSave)
                         .padding(Padding::from([4, 9])),
-                    button(text("Clear").size(12).color(TEXT_PRIMARY))
+                    button(text("Clear").size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::AiToolClearEditor)
                         .padding(Padding::from([4, 9])),
                 ]
                 .spacing(8),
-                text("Registered Tools").size(12).color(TEXT_SECONDARY),
+                text("Registered Tools").size(12).color(TEXT_SECONDARY()),
                 tools_list,
             ]
             .spacing(10)
@@ -2758,30 +2900,30 @@ impl GodlyApp {
             plugins_list = plugins_list.push(
                 text("No plugins configured.")
                     .size(11)
-                    .color(TEXT_SECONDARY),
+                    .color(TEXT_SECONDARY()),
             );
         } else {
             for (index, entry) in self.plugins.iter().enumerate() {
                 let is_editing = self.plugin_edit_index == Some(index);
                 let card_bg = if is_editing {
-                    BG_TERTIARY
+                    BG_TERTIARY()
                 } else {
-                    BG_SECONDARY
+                    BG_SECONDARY()
                 };
                 let status_label = if entry.enabled { "Enabled" } else { "Disabled" };
                 let toggle_label = if entry.enabled { "Disable" } else { "Enable" };
                 let card = container(column![
                     row![
-                        text(&entry.name).size(13).color(TEXT_ACTIVE),
+                        text(&entry.name).size(13).color(TEXT_ACTIVE()),
                         Space::new().width(Length::Fill),
-                        text(status_label).size(11).color(TEXT_SECONDARY),
-                        button(text(toggle_label).size(11).color(TEXT_PRIMARY))
+                        text(status_label).size(11).color(TEXT_SECONDARY()),
+                        button(text(toggle_label).size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::PluginToggleEnabled(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Edit").size(11).color(TEXT_PRIMARY))
+                        button(text("Edit").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::PluginEdit(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Delete").size(11).color(TEXT_PRIMARY))
+                        button(text("Delete").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::PluginDelete(index))
                             .padding(Padding::from([2, 7])),
                     ]
@@ -2789,14 +2931,14 @@ impl GodlyApp {
                     .align_y(iced::Alignment::Center),
                     text(format!("Source: {}", entry.source))
                         .size(11)
-                        .color(TEXT_PRIMARY),
+                        .color(TEXT_PRIMARY()),
                 ])
                 .padding(Padding::from([8, 10]))
                 .width(Length::Fill)
                 .style(move |_theme| container::Style {
                     background: Some(iced::Background::Color(card_bg)),
                     border: iced::Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -2808,10 +2950,10 @@ impl GodlyApp {
 
         container(
             column![
-                text("Plugins").size(14).color(TEXT_ACTIVE),
+                text("Plugins").size(14).color(TEXT_ACTIVE()),
                 text("Manage plugin entries for native shell runtime.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
+                    .color(TEXT_PRIMARY()),
                 text_input("Plugin name", &self.plugin_name_input)
                     .on_input(Message::PluginNameInputChanged)
                     .padding(Padding::from([4, 8]))
@@ -2821,15 +2963,15 @@ impl GodlyApp {
                     .padding(Padding::from([4, 8]))
                     .size(12),
                 row![
-                    button(text(save_label).size(12).color(TEXT_PRIMARY))
+                    button(text(save_label).size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::PluginSave)
                         .padding(Padding::from([4, 9])),
-                    button(text("Clear").size(12).color(TEXT_PRIMARY))
+                    button(text("Clear").size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::PluginClearEditor)
                         .padding(Padding::from([4, 9])),
                 ]
                 .spacing(8),
-                text("Registered Plugins").size(12).color(TEXT_SECONDARY),
+                text("Registered Plugins").size(12).color(TEXT_SECONDARY()),
                 plugins_list,
             ]
             .spacing(10)
@@ -2849,14 +2991,14 @@ impl GodlyApp {
         let mut flows_list = column![].spacing(8).width(Length::Fill);
         if self.flows.is_empty() {
             flows_list =
-                flows_list.push(text("No flows configured.").size(11).color(TEXT_SECONDARY));
+                flows_list.push(text("No flows configured.").size(11).color(TEXT_SECONDARY()));
         } else {
             for (index, entry) in self.flows.iter().enumerate() {
                 let is_editing = self.flow_edit_index == Some(index);
                 let card_bg = if is_editing {
-                    BG_TERTIARY
+                    BG_TERTIARY()
                 } else {
-                    BG_SECONDARY
+                    BG_SECONDARY()
                 };
                 let status_label = if entry.enabled { "Enabled" } else { "Disabled" };
                 let toggle_label = if entry.enabled { "Disable" } else { "Enable" };
@@ -2872,16 +3014,16 @@ impl GodlyApp {
                 };
                 let card = container(column![
                     row![
-                        text(&entry.name).size(13).color(TEXT_ACTIVE),
+                        text(&entry.name).size(13).color(TEXT_ACTIVE()),
                         Space::new().width(Length::Fill),
-                        text(status_label).size(11).color(TEXT_SECONDARY),
-                        button(text(toggle_label).size(11).color(TEXT_PRIMARY))
+                        text(status_label).size(11).color(TEXT_SECONDARY()),
+                        button(text(toggle_label).size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::FlowToggleEnabled(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Edit").size(11).color(TEXT_PRIMARY))
+                        button(text("Edit").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::FlowEdit(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Delete").size(11).color(TEXT_PRIMARY))
+                        button(text("Delete").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::FlowDelete(index))
                             .padding(Padding::from([2, 7])),
                     ]
@@ -2889,17 +3031,17 @@ impl GodlyApp {
                     .align_y(iced::Alignment::Center),
                     text(format!("Trigger: {}", entry.trigger))
                         .size(11)
-                        .color(TEXT_PRIMARY),
+                        .color(TEXT_PRIMARY()),
                     text(format!("Steps: {} | {}", steps_label, steps_preview))
                         .size(11)
-                        .color(TEXT_SECONDARY),
+                        .color(TEXT_SECONDARY()),
                 ])
                 .padding(Padding::from([8, 10]))
                 .width(Length::Fill)
                 .style(move |_theme| container::Style {
                     background: Some(iced::Background::Color(card_bg)),
                     border: iced::Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -2911,10 +3053,10 @@ impl GodlyApp {
 
         container(
             column![
-                text("Flows").size(14).color(TEXT_ACTIVE),
+                text("Flows").size(14).color(TEXT_ACTIVE()),
                 text("Create simple automation flow profiles with trigger and ordered steps.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
+                    .color(TEXT_PRIMARY()),
                 text_input("Flow name", &self.flow_name_input)
                     .on_input(Message::FlowNameInputChanged)
                     .padding(Padding::from([4, 8]))
@@ -2934,15 +3076,15 @@ impl GodlyApp {
                 .padding(Padding::from([4, 8]))
                 .size(12),
                 row![
-                    button(text(save_label).size(12).color(TEXT_PRIMARY))
+                    button(text(save_label).size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::FlowSave)
                         .padding(Padding::from([4, 9])),
-                    button(text("Clear").size(12).color(TEXT_PRIMARY))
+                    button(text("Clear").size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::FlowClearEditor)
                         .padding(Padding::from([4, 9])),
                 ]
                 .spacing(8),
-                text("Registered Flows").size(12).color(TEXT_SECONDARY),
+                text("Registered Flows").size(12).color(TEXT_SECONDARY()),
                 flows_list,
             ]
             .spacing(10)
@@ -2967,21 +3109,21 @@ impl GodlyApp {
         let mut auth_mode_row = row![].spacing(8).align_y(iced::Alignment::Center);
         for mode in RemoteAuthMode::all() {
             let is_active = self.remote_auth_mode == mode;
-            let bg = if is_active { BG_TERTIARY } else { BG_SECONDARY };
-            let fg = if is_active { TEXT_ACTIVE } else { TEXT_PRIMARY };
+            let bg = if is_active { BG_TERTIARY() } else { BG_SECONDARY() };
+            let fg = if is_active { TEXT_ACTIVE() } else { TEXT_PRIMARY() };
             let mode_button = button(text(mode.label()).size(12).color(fg))
                 .on_press(Message::RemoteAuthModeSelected(mode))
                 .padding(Padding::from([4, 9]))
                 .style(move |_theme, status| {
                     let hover_bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => bg,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(hover_bg)),
                         text_color: fg,
                         border: iced::Border {
-                            color: BORDER,
+                            color: BORDER(),
                             width: 1.0,
                             radius: 4.0.into(),
                         },
@@ -2996,15 +3138,15 @@ impl GodlyApp {
             remote_list = remote_list.push(
                 text("No remote profiles configured.")
                     .size(11)
-                    .color(TEXT_SECONDARY),
+                    .color(TEXT_SECONDARY()),
             );
         } else {
             for (index, profile) in self.remote_connections.iter().enumerate() {
                 let is_editing = self.remote_edit_index == Some(index);
                 let card_bg = if is_editing {
-                    BG_TERTIARY
+                    BG_TERTIARY()
                 } else {
-                    BG_SECONDARY
+                    BG_SECONDARY()
                 };
                 let status_label = if profile.enabled {
                     "Enabled"
@@ -3020,16 +3162,16 @@ impl GodlyApp {
                 };
                 let card = container(column![
                     row![
-                        text(&profile.name).size(13).color(TEXT_ACTIVE),
+                        text(&profile.name).size(13).color(TEXT_ACTIVE()),
                         Space::new().width(Length::Fill),
-                        text(status_label).size(11).color(TEXT_SECONDARY),
-                        button(text(toggle_label).size(11).color(TEXT_PRIMARY))
+                        text(status_label).size(11).color(TEXT_SECONDARY()),
+                        button(text(toggle_label).size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::RemoteToggleEnabled(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Edit").size(11).color(TEXT_PRIMARY))
+                        button(text("Edit").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::RemoteEdit(index))
                             .padding(Padding::from([2, 7])),
-                        button(text("Delete").size(11).color(TEXT_PRIMARY))
+                        button(text("Delete").size(11).color(TEXT_PRIMARY()))
                             .on_press(Message::RemoteDelete(index))
                             .padding(Padding::from([2, 7])),
                     ]
@@ -3040,15 +3182,15 @@ impl GodlyApp {
                         profile.username, profile.host, profile.port
                     ))
                     .size(11)
-                    .color(TEXT_PRIMARY),
-                    text(auth_display).size(11).color(TEXT_SECONDARY),
+                    .color(TEXT_PRIMARY()),
+                    text(auth_display).size(11).color(TEXT_SECONDARY()),
                 ])
                 .padding(Padding::from([8, 10]))
                 .width(Length::Fill)
                 .style(move |_theme| container::Style {
                     background: Some(iced::Background::Color(card_bg)),
                     border: iced::Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -3060,10 +3202,10 @@ impl GodlyApp {
 
         container(
             column![
-                text("Remote (SSH)").size(14).color(TEXT_ACTIVE),
+                text("Remote (SSH)").size(14).color(TEXT_ACTIVE()),
                 text("Configure SSH connection profiles for remote terminal sessions.")
                     .size(12)
-                    .color(TEXT_PRIMARY),
+                    .color(TEXT_PRIMARY()),
                 text_input("Profile name", &self.remote_name_input)
                     .on_input(Message::RemoteNameInputChanged)
                     .padding(Padding::from([4, 8]))
@@ -3080,22 +3222,22 @@ impl GodlyApp {
                     .on_input(Message::RemoteUsernameInputChanged)
                     .padding(Padding::from([4, 8]))
                     .size(12),
-                text("Auth Mode").size(12).color(TEXT_SECONDARY),
+                text("Auth Mode").size(12).color(TEXT_SECONDARY()),
                 auth_mode_row,
                 text_input(auth_placeholder, &self.remote_auth_value_input)
                     .on_input(Message::RemoteAuthValueInputChanged)
                     .padding(Padding::from([4, 8]))
                     .size(12),
                 row![
-                    button(text(save_label).size(12).color(TEXT_PRIMARY))
+                    button(text(save_label).size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::RemoteSave)
                         .padding(Padding::from([4, 9])),
-                    button(text("Clear").size(12).color(TEXT_PRIMARY))
+                    button(text("Clear").size(12).color(TEXT_PRIMARY()))
                         .on_press(Message::RemoteClearEditor)
                         .padding(Padding::from([4, 9])),
                 ]
                 .spacing(8),
-                text("Connection Profiles").size(12).color(TEXT_SECONDARY),
+                text("Connection Profiles").size(12).color(TEXT_SECONDARY()),
                 remote_list,
             ]
             .spacing(10)
@@ -3362,6 +3504,14 @@ impl GodlyApp {
                 }
                 Task::none()
             }
+            AppAction::TogglePerfOverlay => {
+                self.perf_overlay_visible = !self.perf_overlay_visible;
+                Task::none()
+            }
+            AppAction::Find => {
+                self.search.open();
+                Task::none()
+            }
         }
     }
 
@@ -3619,7 +3769,7 @@ impl GodlyApp {
 
     fn view_workspace_rename_dialog(&self) -> Element<'_, Message> {
         let dialog = container(column![
-            text("Rename Workspace").size(16).color(TEXT_ACTIVE),
+            text("Rename Workspace").size(16).color(TEXT_ACTIVE()),
             text_input("Workspace name", &self.rename_workspace_value)
                 .on_input(Message::WorkspaceRenameInputChanged)
                 .on_submit(Message::WorkspaceRenameSubmitted)
@@ -3627,38 +3777,38 @@ impl GodlyApp {
                 .size(14),
             row![
                 Space::new().width(Length::Fill),
-                button(text("Cancel").size(12).color(TEXT_PRIMARY))
+                button(text("Cancel").size(12).color(TEXT_PRIMARY()))
                     .on_press(Message::WorkspaceRenameCancelled)
                     .padding(Padding::from([4, 9]))
                     .style(|_theme, status| {
                         let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                             _ => iced::Color::TRANSPARENT,
                         };
                         button::Style {
                             background: Some(iced::Background::Color(bg)),
-                            text_color: TEXT_PRIMARY,
+                            text_color: TEXT_PRIMARY(),
                             border: iced::Border {
-                                color: BORDER,
+                                color: BORDER(),
                                 width: 1.0,
                                 radius: 4.0.into(),
                             },
                             ..button::Style::default()
                         }
                     }),
-                button(text("Rename").size(12).color(TEXT_ACTIVE))
+                button(text("Rename").size(12).color(TEXT_ACTIVE()))
                     .on_press(Message::WorkspaceRenameSubmitted)
                     .padding(Padding::from([4, 9]))
                     .style(|_theme, status| {
                         let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
-                            _ => BG_SECONDARY,
+                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
+                            _ => BG_SECONDARY(),
                         };
                         button::Style {
                             background: Some(iced::Background::Color(bg)),
-                            text_color: TEXT_ACTIVE,
+                            text_color: TEXT_ACTIVE(),
                             border: iced::Border {
-                                color: BORDER,
+                                color: BORDER(),
                                 width: 1.0,
                                 radius: 4.0.into(),
                             },
@@ -3671,9 +3821,9 @@ impl GodlyApp {
         .padding(Padding::from([14, 16]))
         .width(Length::Fixed(340.0))
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(BG_SECONDARY)),
+            background: Some(iced::Background::Color(BG_SECONDARY())),
             border: iced::Border {
-                color: BORDER,
+                color: BORDER(),
                 width: 1.0,
                 radius: 6.0.into(),
             },
@@ -3684,7 +3834,7 @@ impl GodlyApp {
             .width(Length::Fill)
             .height(Length::Fill)
             .style(|_theme| container::Style {
-                background: Some(iced::Background::Color(BACKDROP)),
+                background: Some(iced::Background::Color(BACKDROP())),
                 ..container::Style::default()
             })
             .into()
@@ -4153,16 +4303,19 @@ impl GodlyApp {
             None
         };
 
+        let term_palette = crate::theme::active_terminal_palette();
         let tc = TerminalCanvas {
             grid: term.grid.as_ref(),
             metrics: self.font_metrics,
             selection,
+            default_fg: term_palette.foreground,
+            default_bg: term_palette.background,
         };
 
         let border_color = if is_focused {
-            PANE_FOCUSED_BORDER
+            PANE_FOCUSED_BORDER()
         } else {
-            PANE_BORDER
+            PANE_BORDER()
         };
 
         container(canvas(tc).width(Length::Fill).height(Length::Fill))
@@ -4173,7 +4326,7 @@ impl GodlyApp {
                 TERMINAL_VIEWPORT_INSET_X,
             ]))
             .style(move |_theme| container::Style {
-                background: Some(iced::Background::Color(PANE_BG)),
+                background: Some(iced::Background::Color(PANE_BG())),
                 border: iced::Border {
                     color: border_color,
                     width: if is_focused { 2.0 } else { 1.0 },
@@ -4187,24 +4340,24 @@ impl GodlyApp {
     fn view_terminal_empty_state(&self) -> Element<'_, Message> {
         let card = container(
             column![
-                text("No terminals open").size(22).color(TEXT_ACTIVE),
+                text("No terminals open").size(22).color(TEXT_ACTIVE()),
                 text("Create a terminal in this workspace to start working.")
                     .size(13)
-                    .color(TEXT_SECONDARY),
-                button(text("Create terminal").size(13).color(BG_SECONDARY))
+                    .color(TEXT_SECONDARY()),
+                button(text("Create terminal").size(13).color(BG_SECONDARY()))
                     .on_press(Message::NewTabRequested)
                     .padding(Padding::from([8, 14]))
                     .style(|_theme, status| {
                         let background = match status {
                             button::Status::Hovered | button::Status::Pressed => {
-                                iced::Background::Color(PANE_FOCUSED_BORDER)
+                                iced::Background::Color(PANE_FOCUSED_BORDER())
                             }
-                            _ => iced::Background::Color(ACCENT),
+                            _ => iced::Background::Color(ACCENT()),
                         };
 
                         button::Style {
                             background: Some(background),
-                            text_color: BG_SECONDARY,
+                            text_color: BG_SECONDARY(),
                             border: iced::Border {
                                 color: iced::Color::TRANSPARENT,
                                 width: 0.0,
@@ -4220,9 +4373,9 @@ impl GodlyApp {
         .padding(Padding::from([18, 20]))
         .width(Length::Fixed(EMPTY_STATE_CARD_WIDTH))
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(EMPTY_STATE_BG)),
+            background: Some(iced::Background::Color(EMPTY_STATE_BG())),
             border: iced::Border {
-                color: PANE_BORDER,
+                color: PANE_BORDER(),
                 width: 1.0,
                 radius: 10.0.into(),
             },
@@ -4257,7 +4410,7 @@ impl GodlyApp {
                     .height(Length::Fill)
                     .style(move |_theme| container::Style {
                         background: Some(iced::Background::Color(iced::Color::from_rgba(
-                            ACCENT.r, ACCENT.g, ACCENT.b, alpha,
+                            ACCENT().r, ACCENT().g, ACCENT().b, alpha,
                         ))),
                         ..container::Style::default()
                     }),

--- a/src-tauri/native/iced-shell/src/mru_switcher.rs
+++ b/src-tauri/native/iced-shell/src/mru_switcher.rs
@@ -24,26 +24,26 @@ pub fn view_overlay<'a, Message: 'a>(
     }
 
     let mut list = column![
-        text("Recent Tabs").size(13).color(TEXT_SECONDARY),
+        text("Recent Tabs").size(13).color(TEXT_SECONDARY()),
         text("Release Ctrl to switch. Press Esc to cancel.")
             .size(11)
-            .color(TEXT_SECONDARY),
+            .color(TEXT_SECONDARY()),
     ]
     .spacing(6)
     .width(Length::Fixed(420.0));
 
     for entry in entries.into_iter().take(MAX_VISIBLE_ENTRIES) {
         let is_selected = Some(entry.terminal_id.as_str()) == selected_terminal_id;
-        let row_bg = if is_selected { BG_ACTIVE } else { BG_SECONDARY };
+        let row_bg = if is_selected { BG_ACTIVE() } else { BG_SECONDARY() };
         let label_color = if is_selected {
-            TEXT_ACTIVE
+            TEXT_ACTIVE()
         } else {
-            TEXT_PRIMARY
+            TEXT_PRIMARY()
         };
         let detail_color = if is_selected {
-            TEXT_PRIMARY
+            TEXT_PRIMARY()
         } else {
-            TEXT_SECONDARY
+            TEXT_SECONDARY()
         };
         let badge = if is_selected { "Selected" } else { "" };
 
@@ -67,7 +67,7 @@ pub fn view_overlay<'a, Message: 'a>(
                 .style(move |_theme| container::Style {
                     background: Some(iced::Background::Color(row_bg)),
                     border: iced::Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     },
@@ -80,9 +80,9 @@ pub fn view_overlay<'a, Message: 'a>(
         .padding(Padding::from([12, 12]))
         .width(Length::Fixed(440.0))
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(BG_SECONDARY)),
+            background: Some(iced::Background::Color(BG_SECONDARY())),
             border: iced::Border {
-                color: BORDER,
+                color: BORDER(),
                 width: 1.0,
                 radius: RADIUS_MD.into(),
             },
@@ -98,7 +98,7 @@ pub fn view_overlay<'a, Message: 'a>(
         .width(Length::Fill)
         .height(Length::Fill)
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(BACKDROP)),
+            background: Some(iced::Background::Color(BACKDROP())),
             ..container::Style::default()
         })
         .into()

--- a/src-tauri/native/iced-shell/src/settings_dialog.rs
+++ b/src-tauri/native/iced-shell/src/settings_dialog.rs
@@ -46,11 +46,11 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
             .style(move |_theme, status| {
                 let (bg, border_color, text_color, shadow) = if is_active {
                     (
-                        tint(ACCENT, 0.22),
-                        ACCENT_HOVER,
-                        TEXT_ACTIVE,
+                        tint(ACCENT(), 0.22),
+                        ACCENT_HOVER(),
+                        TEXT_ACTIVE(),
                         Shadow {
-                            color: tint(ACCENT, 0.30),
+                            color: tint(ACCENT(), 0.30),
                             offset: Vector::new(0.0, 1.0),
                             blur_radius: 8.0,
                         },
@@ -58,21 +58,21 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
                 } else {
                     match status {
                         button::Status::Hovered => (
-                            tint(BG_TERTIARY, 0.95),
-                            tint(ACCENT, 0.45),
-                            TEXT_PRIMARY,
+                            tint(BG_TERTIARY(), 0.95),
+                            tint(ACCENT(), 0.45),
+                            TEXT_PRIMARY(),
                             Shadow::default(),
                         ),
                         button::Status::Pressed => (
-                            tint(ACCENT, 0.16),
-                            tint(ACCENT, 0.60),
-                            TEXT_ACTIVE,
+                            tint(ACCENT(), 0.16),
+                            tint(ACCENT(), 0.60),
+                            TEXT_ACTIVE(),
                             Shadow::default(),
                         ),
                         _ => (
-                            tint(BG_PRIMARY, 0.18),
-                            tint(BORDER, 0.85),
-                            TEXT_SECONDARY,
+                            tint(BG_PRIMARY(), 0.18),
+                            tint(BORDER(), 0.85),
+                            TEXT_SECONDARY(),
                             Shadow::default(),
                         ),
                     }
@@ -100,10 +100,10 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
         .style(|_theme, status| {
             let (bg, border_color, text_color) = match status {
                 button::Status::Hovered => {
-                    (tint(BG_TERTIARY, 0.95), tint(BORDER, 0.9), TEXT_ACTIVE)
+                    (tint(BG_TERTIARY(), 0.95), tint(BORDER(), 0.9), TEXT_ACTIVE())
                 }
-                button::Status::Pressed => (tint(ACCENT, 0.18), tint(ACCENT, 0.6), TEXT_ACTIVE),
-                _ => (tint(BG_PRIMARY, 0.35), tint(BORDER, 0.7), TEXT_PRIMARY),
+                button::Status::Pressed => (tint(ACCENT(), 0.18), tint(ACCENT(), 0.6), TEXT_ACTIVE()),
+                _ => (tint(BG_PRIMARY(), 0.35), tint(BORDER(), 0.7), TEXT_PRIMARY()),
             };
 
             button::Style {
@@ -120,7 +120,7 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
 
     let header = container(
         row![
-            text("Settings").size(18).color(TEXT_ACTIVE),
+            text("Settings").size(18).color(TEXT_ACTIVE()),
             Space::new().width(Length::Fill),
             close_btn,
         ]
@@ -128,7 +128,7 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
         .padding(Padding::from([10, 16])),
     )
     .style(|_theme| container::Style {
-        background: Some(Background::Color(tint(BG_PRIMARY, 0.97))),
+        background: Some(Background::Color(tint(BG_PRIMARY(), 0.97))),
         ..container::Style::default()
     })
     .width(Length::Fill);
@@ -138,10 +138,10 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
         "Godly Terminal (Native) \u{2014} v{}",
         godly_protocol::FRONTEND_CONTRACT_VERSION
     );
-    let footer = container(text(version).size(11).color(TEXT_SECONDARY))
+    let footer = container(text(version).size(11).color(TEXT_SECONDARY()))
         .padding(Padding::from([8, 16]))
         .style(|_theme| container::Style {
-            background: Some(Background::Color(tint(BG_PRIMARY, 0.68))),
+            background: Some(Background::Color(tint(BG_PRIMARY(), 0.68))),
             ..container::Style::default()
         })
         .width(Length::Fill);
@@ -156,14 +156,14 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
     .padding(Padding::from([8, 10]))
     .width(Length::Fill)
     .style(|_theme| container::Style {
-        background: Some(Background::Color(tint(BG_PRIMARY, 0.72))),
+        background: Some(Background::Color(tint(BG_PRIMARY(), 0.72))),
         border: Border {
-            color: tint(BORDER, 0.9),
+            color: tint(BORDER(), 0.9),
             width: 1.0,
             radius: TAB_STRIP_RADIUS.into(),
         },
         shadow: Shadow {
-            color: tint(BACKDROP, 0.28),
+            color: tint(BACKDROP(), 0.28),
             offset: Vector::new(0.0, 1.0),
             blur_radius: 6.0,
         },
@@ -183,9 +183,9 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
     .width(Length::Fill)
     .height(Length::Fill)
     .style(|_theme| container::Style {
-        background: Some(Background::Color(BG_SECONDARY)),
+        background: Some(Background::Color(BG_SECONDARY())),
         border: Border {
-            color: tint(BG_PRIMARY, 0.88),
+            color: tint(BG_PRIMARY(), 0.88),
             width: 1.0,
             radius: DIALOG_RADIUS.into(),
         },
@@ -197,14 +197,14 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
         .width(Length::FillPortion(80))
         .height(Length::FillPortion(70))
         .style(|_theme| container::Style {
-            background: Some(Background::Color(tint(BG_PRIMARY, 0.84))),
+            background: Some(Background::Color(tint(BG_PRIMARY(), 0.84))),
             border: Border {
-                color: tint(ACCENT, 0.26),
+                color: tint(ACCENT(), 0.26),
                 width: 1.0,
                 radius: DIALOG_OUTER_RADIUS.into(),
             },
             shadow: Shadow {
-                color: tint(BACKDROP, 0.65),
+                color: tint(BACKDROP(), 0.65),
                 offset: Vector::new(0.0, 14.0),
                 blur_radius: 34.0,
             },
@@ -216,7 +216,7 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
         .width(Length::Fill)
         .height(Length::Fill)
         .style(|_theme| container::Style {
-            background: Some(Background::Color(tint(BACKDROP, 0.84))),
+            background: Some(Background::Color(tint(BACKDROP(), 0.84))),
             ..container::Style::default()
         })
         .into()

--- a/src-tauri/native/iced-shell/src/shortcuts_tab.rs
+++ b/src-tauri/native/iced-shell/src/shortcuts_tab.rs
@@ -187,12 +187,12 @@ pub fn view_shortcuts_tab<'a, M: 'a>() -> Element<'a, M> {
         let mut entries = column![].spacing(ENTRY_SPACING).width(Length::Fill);
 
         for entry in cat.entries {
-            let key_badge = container(text(entry.keys).size(12).color(ACCENT))
+            let key_badge = container(text(entry.keys).size(12).color(ACCENT()))
                 .padding(Padding::from([3, 8]))
                 .style(|_theme| container::Style {
-                    background: Some(Background::Color(tint(BG_PRIMARY, 0.7))),
+                    background: Some(Background::Color(tint(BG_PRIMARY(), 0.7))),
                     border: Border {
-                        color: BORDER,
+                        color: BORDER(),
                         width: 1.0,
                         radius: KEY_BADGE_RADIUS.into(),
                     },
@@ -202,7 +202,7 @@ pub fn view_shortcuts_tab<'a, M: 'a>() -> Element<'a, M> {
             let entry_row = row![
                 text(entry.action)
                     .size(13)
-                    .color(TEXT_PRIMARY)
+                    .color(TEXT_PRIMARY())
                     .width(Length::Fill),
                 key_badge
             ]
@@ -215,16 +215,16 @@ pub fn view_shortcuts_tab<'a, M: 'a>() -> Element<'a, M> {
         }
 
         let section = container(
-            column![text(cat.name).size(14).color(TEXT_ACTIVE), entries]
+            column![text(cat.name).size(14).color(TEXT_ACTIVE()), entries]
                 .spacing(8)
                 .width(Length::Fill),
         )
         .padding(Padding::from([10, 12]))
         .width(Length::Fill)
         .style(|_theme| container::Style {
-            background: Some(Background::Color(tint(BG_PRIMARY, 0.4))),
+            background: Some(Background::Color(tint(BG_PRIMARY(), 0.4))),
             border: Border {
-                color: BORDER,
+                color: BORDER(),
                 width: 1.0,
                 radius: SECTION_RADIUS.into(),
             },

--- a/src-tauri/native/iced-shell/src/sidebar.rs
+++ b/src-tauri/native/iced-shell/src/sidebar.rs
@@ -129,15 +129,15 @@ impl<Message> canvas::Program<Message> for SidebarHeaderIcon {
 
 fn header_action_button_style(status: button::Status) -> button::Style {
     let bg = match status {
-        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
         _ => Color::TRANSPARENT,
     };
 
     button::Style {
         background: Some(iced::Background::Color(bg)),
-        text_color: TEXT_ACTIVE,
+        text_color: TEXT_ACTIVE(),
         border: Border {
-            color: BORDER,
+            color: BORDER(),
             width: 1.0,
             radius: 4.0.into(),
         },
@@ -170,6 +170,11 @@ pub trait SidebarWorkspaceSignals {
     fn has_workspace_notification(&self, _workspace_id: &str) -> bool {
         false
     }
+
+    /// Returns an icon string for the workspace's AI tool mode (if any).
+    fn workspace_ai_mode_icon(&self, _workspace_id: &str) -> Option<&'static str> {
+        None
+    }
 }
 
 impl<'a> SidebarWorkspaceSignals for Option<&'a str> {
@@ -188,6 +193,24 @@ where
 
     fn has_workspace_notification(&self, workspace_id: &str) -> bool {
         (self.1)(workspace_id)
+    }
+}
+
+impl<'a, F, G> SidebarWorkspaceSignals for (Option<&'a str>, F, G)
+where
+    F: for<'b> Fn(&'b str) -> bool,
+    G: for<'b> Fn(&'b str) -> Option<&'static str>,
+{
+    fn context_menu_workspace_id(&self) -> Option<&str> {
+        self.0
+    }
+
+    fn has_workspace_notification(&self, workspace_id: &str) -> bool {
+        (self.1)(workspace_id)
+    }
+
+    fn workspace_ai_mode_icon(&self, workspace_id: &str) -> Option<&'static str> {
+        (self.2)(workspace_id)
     }
 }
 
@@ -217,19 +240,19 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             workspace_signals.has_workspace_notification(ws.id.as_str());
 
         let row_text = if is_active {
-            ACCENT_HOVER
+            ACCENT_HOVER()
         } else {
-            TEXT_PRIMARY
+            TEXT_PRIMARY()
         };
 
         let name_label = text(&ws.name).size(13).color(row_text);
 
         let terminal_count = ws.layout.leaf_count();
-        let badge_bg = if is_active { ACCENT } else { BG_TERTIARY };
+        let badge_bg = if is_active { ACCENT() } else { BG_TERTIARY() };
         let badge_text = if is_active {
-            BG_SECONDARY
+            BG_SECONDARY()
         } else {
-            TEXT_SECONDARY
+            TEXT_SECONDARY()
         };
 
         let badge = container(
@@ -249,9 +272,9 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
         });
 
         let worktree_indicator_bg = if ws.worktree_mode {
-            ACCENT_HOVER
+            ACCENT_HOVER()
         } else {
-            Color::from_rgba(TEXT_SECONDARY.r, TEXT_SECONDARY.g, TEXT_SECONDARY.b, 0.25)
+            Color::from_rgba(TEXT_SECONDARY().r, TEXT_SECONDARY().g, TEXT_SECONDARY().b, 0.25)
         };
         let worktree_indicator = container(
             Space::new()
@@ -268,8 +291,8 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             ..container::Style::default()
         });
 
-        let notification_indicator_bg = if is_active { ACCENT_HOVER } else { DANGER };
-        let notification_indicator_border = if is_active { BORDER } else { BG_SECONDARY };
+        let notification_indicator_bg = if is_active { ACCENT_HOVER() } else { DANGER() };
+        let notification_indicator_border = if is_active { BORDER() } else { BG_SECONDARY() };
         let notification_indicator = container(
             Space::new()
                 .width(Length::Fixed(8.0))
@@ -285,11 +308,15 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             ..container::Style::default()
         });
 
+        let ai_mode_icon = workspace_signals.workspace_ai_mode_icon(ws.id.as_str());
         let mut item_content = row![
             worktree_indicator,
             name_label,
-            Space::new().width(Length::Fill)
         ];
+        if let Some(icon) = ai_mode_icon {
+            item_content = item_content.push(text(icon).size(11));
+        }
+        item_content = item_content.push(Space::new().width(Length::Fill));
         if has_workspace_notification {
             item_content = item_content.push(notification_indicator);
         }
@@ -306,17 +333,17 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             .width(Length::Fill)
             .style(move |_theme, status| {
                 let bg = if is_active {
-                    Color::from_rgba(ACCENT_HOVER.r, ACCENT_HOVER.g, ACCENT_HOVER.b, 0.08)
+                    Color::from_rgba(ACCENT_HOVER().r, ACCENT_HOVER().g, ACCENT_HOVER().b, 0.08)
                 } else {
                     match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => Color::TRANSPARENT,
                     }
                 };
 
                 let border = if is_active {
                     Border {
-                        color: ACCENT_HOVER,
+                        color: ACCENT_HOVER(),
                         width: 1.0,
                         radius: 4.0.into(),
                     }
@@ -353,35 +380,35 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             let move_down_id = ws.id.clone();
             let delete_id = ws.id.clone();
 
-            let rename_btn = button(text("Rename").size(12).color(TEXT_PRIMARY))
+            let rename_btn = button(text("Rename").size(12).color(TEXT_PRIMARY()))
                 .on_press(on_action(SidebarAction::RenameWorkspace(rename_id)))
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
                 .style(|_theme, status| {
                     let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => Color::TRANSPARENT,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(bg)),
-                        text_color: TEXT_PRIMARY,
+                        text_color: TEXT_PRIMARY(),
                         border: Border::default(),
                         ..button::Style::default()
                     }
                 });
 
-            let open_btn = button(text("Open in Explorer").size(12).color(TEXT_PRIMARY))
+            let open_btn = button(text("Open in Explorer").size(12).color(TEXT_PRIMARY()))
                 .on_press(on_action(SidebarAction::OpenWorkspaceInExplorer(open_id)))
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
                 .style(|_theme, status| {
                     let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => Color::TRANSPARENT,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(bg)),
-                        text_color: TEXT_PRIMARY,
+                        text_color: TEXT_PRIMARY(),
                         border: Border::default(),
                         ..button::Style::default()
                     }
@@ -392,7 +419,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             } else {
                 "Enable Worktree Mode"
             };
-            let worktree_btn = button(text(worktree_label).size(12).color(TEXT_PRIMARY))
+            let worktree_btn = button(text(worktree_label).size(12).color(TEXT_PRIMARY()))
                 .on_press(on_action(SidebarAction::ToggleWorkspaceWorktreeMode(
                     worktree_id,
                 )))
@@ -400,79 +427,79 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
                 .width(Length::Fill)
                 .style(|_theme, status| {
                     let bg = match status {
-                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                        button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                         _ => Color::TRANSPARENT,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(bg)),
-                        text_color: TEXT_PRIMARY,
+                        text_color: TEXT_PRIMARY(),
                         border: Border::default(),
                         ..button::Style::default()
                     }
                 });
 
             let move_up_btn = if idx > 0 {
-                button(text("Move Up").size(12).color(TEXT_PRIMARY))
+                button(text("Move Up").size(12).color(TEXT_PRIMARY()))
                     .on_press(on_action(SidebarAction::MoveWorkspaceUp(move_up_id)))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
                     .style(|_theme, status| {
                         let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                             _ => Color::TRANSPARENT,
                         };
                         button::Style {
                             background: Some(iced::Background::Color(bg)),
-                            text_color: TEXT_PRIMARY,
+                            text_color: TEXT_PRIMARY(),
                             border: Border::default(),
                             ..button::Style::default()
                         }
                     })
             } else {
-                button(text("Move Up").size(12).color(TEXT_SECONDARY))
+                button(text("Move Up").size(12).color(TEXT_SECONDARY()))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
                     .style(|_theme, _status| button::Style::default())
             };
 
             let move_down_btn = if idx + 1 < workspaces.len() {
-                button(text("Move Down").size(12).color(TEXT_PRIMARY))
+                button(text("Move Down").size(12).color(TEXT_PRIMARY()))
                     .on_press(on_action(SidebarAction::MoveWorkspaceDown(move_down_id)))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
                     .style(|_theme, status| {
                         let bg = match status {
-                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY,
+                            button::Status::Hovered | button::Status::Pressed => BG_TERTIARY(),
                             _ => Color::TRANSPARENT,
                         };
                         button::Style {
                             background: Some(iced::Background::Color(bg)),
-                            text_color: TEXT_PRIMARY,
+                            text_color: TEXT_PRIMARY(),
                             border: Border::default(),
                             ..button::Style::default()
                         }
                     })
             } else {
-                button(text("Move Down").size(12).color(TEXT_SECONDARY))
+                button(text("Move Down").size(12).color(TEXT_SECONDARY()))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
                     .style(|_theme, _status| button::Style::default())
             };
 
-            let delete_btn = button(text("Delete").size(12).color(DANGER))
+            let delete_btn = button(text("Delete").size(12).color(DANGER()))
                 .on_press(on_action(SidebarAction::DeleteWorkspace(delete_id)))
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
                 .style(|_theme, status| {
                     let bg = match status {
                         button::Status::Hovered | button::Status::Pressed => {
-                            Color::from_rgba(DANGER.r, DANGER.g, DANGER.b, 0.20)
+                            Color::from_rgba(DANGER().r, DANGER().g, DANGER().b, 0.20)
                         }
                         _ => Color::TRANSPARENT,
                     };
                     button::Style {
                         background: Some(iced::Background::Color(bg)),
-                        text_color: DANGER,
+                        text_color: DANGER(),
                         border: Border::default(),
                         ..button::Style::default()
                     }
@@ -488,9 +515,9 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             ])
             .padding(Padding::from([4, 4]))
             .style(|_theme| container::Style {
-                background: Some(iced::Background::Color(BG_SECONDARY)),
+                background: Some(iced::Background::Color(BG_SECONDARY())),
                 border: Border {
-                    color: BORDER,
+                    color: BORDER(),
                     width: 1.0,
                     radius: 4.0.into(),
                 },
@@ -504,11 +531,11 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
     let workspaces_badge = container(
         text(format!("{}", workspaces.len()))
             .size(10)
-            .color(TEXT_SECONDARY),
+            .color(TEXT_SECONDARY()),
     )
     .padding(Padding::from([1, 7]))
     .style(|_theme| container::Style {
-        background: Some(iced::Background::Color(BG_TERTIARY)),
+        background: Some(iced::Background::Color(BG_TERTIARY())),
         border: Border {
             color: Color::TRANSPARENT,
             width: 0.0,
@@ -518,7 +545,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
     });
 
     let settings_btn = button(
-        canvas(SidebarHeaderIcon::settings(TEXT_PRIMARY))
+        canvas(SidebarHeaderIcon::settings(TEXT_PRIMARY()))
             .width(Length::Fixed(HEADER_ICON_SIZE))
             .height(Length::Fixed(HEADER_ICON_SIZE)),
     )
@@ -527,7 +554,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
     .style(|_theme, status| header_action_button_style(status));
 
     let new_btn = button(
-        canvas(SidebarHeaderIcon::new_workspace(TEXT_PRIMARY))
+        canvas(SidebarHeaderIcon::new_workspace(TEXT_PRIMARY()))
             .width(Length::Fixed(HEADER_ICON_SIZE))
             .height(Length::Fixed(HEADER_ICON_SIZE)),
     )
@@ -537,7 +564,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
 
     let header = container(
         row![
-            text("WORKSPACES").size(11).color(TEXT_SECONDARY),
+            text("WORKSPACES").size(11).color(TEXT_SECONDARY()),
             Space::new().width(Length::Fill),
             workspaces_badge,
             settings_btn,
@@ -548,9 +575,9 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
     )
     .padding(Padding::from([10, 10]))
     .style(|_theme| container::Style {
-        background: Some(iced::Background::Color(BG_SECONDARY)),
+        background: Some(iced::Background::Color(BG_SECONDARY())),
         border: Border {
-            color: BORDER,
+            color: BORDER(),
             width: 1.0,
             radius: 0.0.into(),
         },
@@ -570,12 +597,12 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
         .height(Length::Fill)
         .clip(true)
         .style(|_theme| container::Style {
-            background: Some(iced::Background::Color(BG_SECONDARY)),
+            background: Some(iced::Background::Color(BG_SECONDARY())),
             ..container::Style::default()
         });
 
     let divider = rule::vertical(1).style(move |_theme| rule::Style {
-        color: BORDER,
+        color: BORDER(),
         radius: 0.0.into(),
         fill_mode: rule::FillMode::Full,
         snap: true,

--- a/src-tauri/native/iced-shell/src/theme.rs
+++ b/src-tauri/native/iced-shell/src/theme.rs
@@ -1,38 +1,227 @@
 use iced::Color;
+use std::sync::RwLock;
 
-// Dusk palette ported from the legacy web theme (src/themes/builtin.ts).
-pub const BG_PRIMARY: Color = Color::from_rgb(0.1137, 0.1216, 0.1294); // #1d1f21
-pub const BG_SECONDARY: Color = Color::from_rgb(0.0941, 0.1020, 0.1059); // #181a1b
-pub const BG_TERTIARY: Color = Color::from_rgb(0.1804, 0.1686, 0.1569); // #2e2b28
-pub const BG_ACTIVE: Color = Color::from_rgb(0.2392, 0.2157, 0.2000); // #3d3733
+// ---------------------------------------------------------------------------
+// Terminal-specific color palette (16 ANSI colors + extras).
+// ---------------------------------------------------------------------------
 
-pub const TEXT_PRIMARY: Color = Color::from_rgb(0.6902, 0.6706, 0.6235); // #b0ab9f
-pub const TEXT_SECONDARY: Color = Color::from_rgb(0.4196, 0.4000, 0.3608); // #6b665c
-pub const TEXT_ACTIVE: Color = Color::from_rgb(0.7725, 0.7529, 0.7137); // #c5c0b6
+#[derive(Debug, Clone)]
+pub struct TerminalPalette {
+    pub black: Color,
+    pub red: Color,
+    pub green: Color,
+    pub yellow: Color,
+    pub blue: Color,
+    pub magenta: Color,
+    pub cyan: Color,
+    pub white: Color,
+    pub bright_black: Color,
+    pub bright_red: Color,
+    pub bright_green: Color,
+    pub bright_yellow: Color,
+    pub bright_blue: Color,
+    pub bright_magenta: Color,
+    pub bright_cyan: Color,
+    pub bright_white: Color,
+    pub foreground: Color,
+    pub background: Color,
+    pub cursor: Color,
+    pub selection: Color,
+}
 
-pub const ACCENT: Color = Color::from_rgb(0.8314, 0.6627, 0.4157); // #d4a96a
-pub const ACCENT_HOVER: Color = Color::from_rgb(0.8784, 0.7451, 0.5333); // #e0be88
-pub const BORDER: Color = Color::from_rgb(0.1804, 0.1686, 0.1569); // #2e2b28
-pub const DANGER: Color = Color::from_rgb(0.7608, 0.4392, 0.4392); // #c27070
+// ---------------------------------------------------------------------------
+// Full UI + terminal theme palette.
+// ---------------------------------------------------------------------------
 
-pub const PANE_BG: Color = Color::from_rgb(0.0745, 0.0784, 0.0863); // #131416
-pub const PANE_BORDER: Color = Color::from_rgb(0.2471, 0.2235, 0.2039); // #3f3934
-pub const PANE_FOCUSED_BORDER: Color = Color::from_rgb(0.8784, 0.7451, 0.5333); // #e0be88
-pub const EMPTY_STATE_BG: Color = Color::from_rgb(0.1294, 0.1333, 0.1451); // #212225
+#[derive(Debug, Clone)]
+pub struct ThemePalette {
+    pub bg_primary: Color,
+    pub bg_secondary: Color,
+    pub bg_tertiary: Color,
+    pub bg_active: Color,
+    pub text_primary: Color,
+    pub text_secondary: Color,
+    pub text_active: Color,
+    pub accent: Color,
+    pub accent_hover: Color,
+    pub border: Color,
+    pub danger: Color,
+    pub pane_bg: Color,
+    pub pane_border: Color,
+    pub pane_focused_border: Color,
+    pub empty_state_bg: Color,
+    pub backdrop: Color,
+    pub terminal: TerminalPalette,
+}
 
-pub const BACKDROP: Color = Color::from_rgba(0.0, 0.0, 0.0, 0.58);
+// ---------------------------------------------------------------------------
+// Theme identifiers.
+// ---------------------------------------------------------------------------
 
-// --- Design system tokens (L27-L32) ---
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ThemeId {
+    Dusk,
+    TokyoNight,
+    Dracula,
+    Nord,
+    GruvboxDark,
+    OneDark,
+    Catppuccin,
+    SolarizedDark,
+    Monokai,
+    AyuDark,
+    RosePine,
+}
 
-// L27: Font families.
-// Iced uses the system default sans-serif for UI chrome text.
-// Terminal cells use the configured monospace font via the renderer.
-// These constants document the intent for downstream usage.
+impl ThemeId {
+    pub fn all() -> &'static [ThemeId] {
+        &[
+            ThemeId::Dusk,
+            ThemeId::TokyoNight,
+            ThemeId::Dracula,
+            ThemeId::Nord,
+            ThemeId::GruvboxDark,
+            ThemeId::OneDark,
+            ThemeId::Catppuccin,
+            ThemeId::SolarizedDark,
+            ThemeId::Monokai,
+            ThemeId::AyuDark,
+            ThemeId::RosePine,
+        ]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ThemeId::Dusk => "Dusk",
+            ThemeId::TokyoNight => "Tokyo Night",
+            ThemeId::Dracula => "Dracula",
+            ThemeId::Nord => "Nord",
+            ThemeId::GruvboxDark => "Gruvbox Dark",
+            ThemeId::OneDark => "One Dark",
+            ThemeId::Catppuccin => "Catppuccin",
+            ThemeId::SolarizedDark => "Solarized Dark",
+            ThemeId::Monokai => "Monokai",
+            ThemeId::AyuDark => "Ayu Dark",
+            ThemeId::RosePine => "Rosé Pine",
+        }
+    }
+
+    /// Preview swatch colors for theme picker UI: [bg, accent, fg, border, terminal_bg].
+    pub fn preview_colors(self) -> [Color; 5] {
+        let p = palette(self);
+        [
+            p.bg_primary,
+            p.accent,
+            p.text_primary,
+            p.border,
+            p.terminal.background,
+        ]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global active palette (RwLock).
+// ---------------------------------------------------------------------------
+
+static ACTIVE_PALETTE: RwLock<Option<ThemePalette>> = RwLock::new(None);
+
+pub fn set_active_theme(id: ThemeId) {
+    let p = palette(id);
+    *ACTIVE_PALETTE.write().unwrap() = Some(p);
+}
+
+fn active() -> ThemePalette {
+    ACTIVE_PALETTE
+        .read()
+        .unwrap()
+        .clone()
+        .unwrap_or_else(|| palette(ThemeId::Dusk))
+}
+
+/// Returns the active theme's terminal palette.
+pub fn active_terminal_palette() -> TerminalPalette {
+    active().terminal
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compatible accessors (previously pub const, now pub fn).
+// Import sites stay identical: `use crate::theme::{BG_PRIMARY, ACCENT, ...};`
+// Usage sites must append `()`: `BG_PRIMARY` → `BG_PRIMARY()`.
+// ---------------------------------------------------------------------------
+
+#[allow(non_snake_case)]
+pub fn BG_PRIMARY() -> Color {
+    active().bg_primary
+}
+#[allow(non_snake_case)]
+pub fn BG_SECONDARY() -> Color {
+    active().bg_secondary
+}
+#[allow(non_snake_case)]
+pub fn BG_TERTIARY() -> Color {
+    active().bg_tertiary
+}
+#[allow(non_snake_case)]
+pub fn BG_ACTIVE() -> Color {
+    active().bg_active
+}
+#[allow(non_snake_case)]
+pub fn TEXT_PRIMARY() -> Color {
+    active().text_primary
+}
+#[allow(non_snake_case)]
+pub fn TEXT_SECONDARY() -> Color {
+    active().text_secondary
+}
+#[allow(non_snake_case)]
+pub fn TEXT_ACTIVE() -> Color {
+    active().text_active
+}
+#[allow(non_snake_case)]
+pub fn ACCENT() -> Color {
+    active().accent
+}
+#[allow(non_snake_case)]
+pub fn ACCENT_HOVER() -> Color {
+    active().accent_hover
+}
+#[allow(non_snake_case)]
+pub fn BORDER() -> Color {
+    active().border
+}
+#[allow(non_snake_case)]
+pub fn DANGER() -> Color {
+    active().danger
+}
+#[allow(non_snake_case)]
+pub fn PANE_BG() -> Color {
+    active().pane_bg
+}
+#[allow(non_snake_case)]
+pub fn PANE_BORDER() -> Color {
+    active().pane_border
+}
+#[allow(non_snake_case)]
+pub fn PANE_FOCUSED_BORDER() -> Color {
+    active().pane_focused_border
+}
+#[allow(non_snake_case)]
+pub fn EMPTY_STATE_BG() -> Color {
+    active().empty_state_bg
+}
+#[allow(non_snake_case)]
+pub fn BACKDROP() -> Color {
+    active().backdrop
+}
+
+// ---------------------------------------------------------------------------
+// Design system tokens (theme-independent, stay as pub const).
+// ---------------------------------------------------------------------------
+
 pub const UI_FONT_SIZE_SM: f32 = 11.0;
 pub const UI_FONT_SIZE: f32 = 13.0;
 pub const UI_FONT_SIZE_LG: f32 = 15.0;
 
-// L29: Spacing scale (4px increments).
 pub const SPACE_XXS: f32 = 2.0;
 pub const SPACE_XS: f32 = 4.0;
 pub const SPACE_SM: f32 = 8.0;
@@ -41,16 +230,572 @@ pub const SPACE_LG: f32 = 16.0;
 pub const SPACE_XL: f32 = 24.0;
 pub const SPACE_XXL: f32 = 32.0;
 
-// L30: Border radius scale.
 pub const RADIUS_SM: f32 = 4.0;
 pub const RADIUS_MD: f32 = 6.0;
 pub const RADIUS_LG: f32 = 8.0;
 pub const RADIUS_XL: f32 = 12.0;
 
-// L31: Shadow/elevation for floating elements.
 pub const SHADOW_COLOR: Color = Color::from_rgba(0.0, 0.0, 0.0, 0.40);
 pub const SHADOW_LIGHT: Color = Color::from_rgba(0.0, 0.0, 0.0, 0.20);
 
-// L32: Transition/animation timing (in milliseconds).
 pub const TRANSITION_HOVER_MS: u64 = 150;
 pub const TRANSITION_STATE_MS: u64 = 200;
+
+// ---------------------------------------------------------------------------
+// Palette definitions.
+// ---------------------------------------------------------------------------
+
+pub fn palette(id: ThemeId) -> ThemePalette {
+    match id {
+        ThemeId::Dusk => dusk(),
+        ThemeId::TokyoNight => tokyo_night(),
+        ThemeId::Dracula => dracula(),
+        ThemeId::Nord => nord(),
+        ThemeId::GruvboxDark => gruvbox_dark(),
+        ThemeId::OneDark => one_dark(),
+        ThemeId::Catppuccin => catppuccin(),
+        ThemeId::SolarizedDark => solarized_dark(),
+        ThemeId::Monokai => monokai(),
+        ThemeId::AyuDark => ayu_dark(),
+        ThemeId::RosePine => rose_pine(),
+    }
+}
+
+fn dusk() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb(0.1137, 0.1216, 0.1294),
+        bg_secondary: Color::from_rgb(0.0941, 0.1020, 0.1059),
+        bg_tertiary: Color::from_rgb(0.1804, 0.1686, 0.1569),
+        bg_active: Color::from_rgb(0.2392, 0.2157, 0.2000),
+        text_primary: Color::from_rgb(0.6902, 0.6706, 0.6235),
+        text_secondary: Color::from_rgb(0.4196, 0.4000, 0.3608),
+        text_active: Color::from_rgb(0.7725, 0.7529, 0.7137),
+        accent: Color::from_rgb(0.8314, 0.6627, 0.4157),
+        accent_hover: Color::from_rgb(0.8784, 0.7451, 0.5333),
+        border: Color::from_rgb(0.1804, 0.1686, 0.1569),
+        danger: Color::from_rgb(0.7608, 0.4392, 0.4392),
+        pane_bg: Color::from_rgb(0.0745, 0.0784, 0.0863),
+        pane_border: Color::from_rgb(0.2471, 0.2235, 0.2039),
+        pane_focused_border: Color::from_rgb(0.8784, 0.7451, 0.5333),
+        empty_state_bg: Color::from_rgb(0.1294, 0.1333, 0.1451),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x1d, 0x1f, 0x21),
+            red: Color::from_rgb8(0xcc, 0x66, 0x66),
+            green: Color::from_rgb8(0xb5, 0xbd, 0x68),
+            yellow: Color::from_rgb8(0xf0, 0xc6, 0x74),
+            blue: Color::from_rgb8(0x81, 0xa2, 0xbe),
+            magenta: Color::from_rgb8(0xb2, 0x94, 0xbb),
+            cyan: Color::from_rgb8(0x8a, 0xbe, 0xb7),
+            white: Color::from_rgb8(0xc5, 0xc8, 0xc6),
+            bright_black: Color::from_rgb8(0x96, 0x98, 0x96),
+            bright_red: Color::from_rgb8(0xde, 0x93, 0x5f),
+            bright_green: Color::from_rgb8(0xb5, 0xbd, 0x68),
+            bright_yellow: Color::from_rgb8(0xf0, 0xc6, 0x74),
+            bright_blue: Color::from_rgb8(0x81, 0xa2, 0xbe),
+            bright_magenta: Color::from_rgb8(0xb2, 0x94, 0xbb),
+            bright_cyan: Color::from_rgb8(0x8a, 0xbe, 0xb7),
+            bright_white: Color::from_rgb8(0xff, 0xff, 0xff),
+            foreground: Color::from_rgb8(0xc5, 0xc8, 0xc6),
+            background: Color::from_rgb8(0x13, 0x14, 0x16),
+            cursor: Color::from_rgb8(0xd4, 0xa9, 0x6a),
+            selection: Color::from_rgba(0.83, 0.66, 0.42, 0.30),
+        },
+    }
+}
+
+fn tokyo_night() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x1a, 0x1b, 0x26),
+        bg_secondary: Color::from_rgb8(0x16, 0x16, 0x1e),
+        bg_tertiary: Color::from_rgb8(0x24, 0x28, 0x3b),
+        bg_active: Color::from_rgb8(0x33, 0x46, 0x7c),
+        text_primary: Color::from_rgb8(0xa9, 0xb1, 0xd6),
+        text_secondary: Color::from_rgb8(0x56, 0x5f, 0x89),
+        text_active: Color::from_rgb8(0xc0, 0xca, 0xf5),
+        accent: Color::from_rgb8(0x7a, 0xa2, 0xf7),
+        accent_hover: Color::from_rgb8(0x89, 0xdd, 0xff),
+        border: Color::from_rgb8(0x29, 0x2e, 0x42),
+        danger: Color::from_rgb8(0xf7, 0x76, 0x8e),
+        pane_bg: Color::from_rgb8(0x16, 0x16, 0x1e),
+        pane_border: Color::from_rgb8(0x29, 0x2e, 0x42),
+        pane_focused_border: Color::from_rgb8(0x7a, 0xa2, 0xf7),
+        empty_state_bg: Color::from_rgb8(0x1e, 0x20, 0x30),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x15, 0x16, 0x1e),
+            red: Color::from_rgb8(0xf7, 0x76, 0x8e),
+            green: Color::from_rgb8(0x9e, 0xce, 0x6a),
+            yellow: Color::from_rgb8(0xe0, 0xaf, 0x68),
+            blue: Color::from_rgb8(0x7a, 0xa2, 0xf7),
+            magenta: Color::from_rgb8(0xbb, 0x9a, 0xf7),
+            cyan: Color::from_rgb8(0x7d, 0xcf, 0xff),
+            white: Color::from_rgb8(0xa9, 0xb1, 0xd6),
+            bright_black: Color::from_rgb8(0x41, 0x48, 0x68),
+            bright_red: Color::from_rgb8(0xf7, 0x76, 0x8e),
+            bright_green: Color::from_rgb8(0x9e, 0xce, 0x6a),
+            bright_yellow: Color::from_rgb8(0xe0, 0xaf, 0x68),
+            bright_blue: Color::from_rgb8(0x7a, 0xa2, 0xf7),
+            bright_magenta: Color::from_rgb8(0xbb, 0x9a, 0xf7),
+            bright_cyan: Color::from_rgb8(0x7d, 0xcf, 0xff),
+            bright_white: Color::from_rgb8(0xc0, 0xca, 0xf5),
+            foreground: Color::from_rgb8(0xa9, 0xb1, 0xd6),
+            background: Color::from_rgb8(0x1a, 0x1b, 0x26),
+            cursor: Color::from_rgb8(0xc0, 0xca, 0xf5),
+            selection: Color::from_rgba8(0x33, 0x46, 0x7c, 0.4),
+        },
+    }
+}
+
+fn dracula() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x28, 0x2a, 0x36),
+        bg_secondary: Color::from_rgb8(0x21, 0x22, 0x2c),
+        bg_tertiary: Color::from_rgb8(0x34, 0x35, 0x46),
+        bg_active: Color::from_rgb8(0x44, 0x47, 0x5a),
+        text_primary: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+        text_secondary: Color::from_rgb8(0x62, 0x72, 0xa4),
+        text_active: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+        accent: Color::from_rgb8(0xbd, 0x93, 0xf9),
+        accent_hover: Color::from_rgb8(0xcf, 0xa9, 0xff),
+        border: Color::from_rgb8(0x34, 0x35, 0x46),
+        danger: Color::from_rgb8(0xff, 0x55, 0x55),
+        pane_bg: Color::from_rgb8(0x21, 0x22, 0x2c),
+        pane_border: Color::from_rgb8(0x44, 0x47, 0x5a),
+        pane_focused_border: Color::from_rgb8(0xbd, 0x93, 0xf9),
+        empty_state_bg: Color::from_rgb8(0x28, 0x2a, 0x36),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x21, 0x22, 0x2c),
+            red: Color::from_rgb8(0xff, 0x55, 0x55),
+            green: Color::from_rgb8(0x50, 0xfa, 0x7b),
+            yellow: Color::from_rgb8(0xf1, 0xfa, 0x8c),
+            blue: Color::from_rgb8(0xbd, 0x93, 0xf9),
+            magenta: Color::from_rgb8(0xff, 0x79, 0xc6),
+            cyan: Color::from_rgb8(0x8b, 0xe9, 0xfd),
+            white: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+            bright_black: Color::from_rgb8(0x62, 0x72, 0xa4),
+            bright_red: Color::from_rgb8(0xff, 0x6e, 0x6e),
+            bright_green: Color::from_rgb8(0x69, 0xff, 0x94),
+            bright_yellow: Color::from_rgb8(0xff, 0xff, 0xa5),
+            bright_blue: Color::from_rgb8(0xd6, 0xac, 0xff),
+            bright_magenta: Color::from_rgb8(0xff, 0x92, 0xdf),
+            bright_cyan: Color::from_rgb8(0xa4, 0xff, 0xff),
+            bright_white: Color::from_rgb8(0xff, 0xff, 0xff),
+            foreground: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+            background: Color::from_rgb8(0x28, 0x2a, 0x36),
+            cursor: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+            selection: Color::from_rgba8(0x44, 0x47, 0x5a, 0.5),
+        },
+    }
+}
+
+fn nord() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x2e, 0x34, 0x40),
+        bg_secondary: Color::from_rgb8(0x29, 0x2e, 0x39),
+        bg_tertiary: Color::from_rgb8(0x3b, 0x42, 0x52),
+        bg_active: Color::from_rgb8(0x43, 0x4c, 0x5e),
+        text_primary: Color::from_rgb8(0xd8, 0xde, 0xe9),
+        text_secondary: Color::from_rgb8(0x7b, 0x88, 0xa1),
+        text_active: Color::from_rgb8(0xec, 0xef, 0xf4),
+        accent: Color::from_rgb8(0x88, 0xc0, 0xd0),
+        accent_hover: Color::from_rgb8(0x8f, 0xbc, 0xbb),
+        border: Color::from_rgb8(0x3b, 0x42, 0x52),
+        danger: Color::from_rgb8(0xbf, 0x61, 0x6a),
+        pane_bg: Color::from_rgb8(0x29, 0x2e, 0x39),
+        pane_border: Color::from_rgb8(0x3b, 0x42, 0x52),
+        pane_focused_border: Color::from_rgb8(0x88, 0xc0, 0xd0),
+        empty_state_bg: Color::from_rgb8(0x2e, 0x34, 0x40),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x3b, 0x42, 0x52),
+            red: Color::from_rgb8(0xbf, 0x61, 0x6a),
+            green: Color::from_rgb8(0xa3, 0xbe, 0x8c),
+            yellow: Color::from_rgb8(0xeb, 0xcb, 0x8b),
+            blue: Color::from_rgb8(0x81, 0xa1, 0xc1),
+            magenta: Color::from_rgb8(0xb4, 0x8e, 0xad),
+            cyan: Color::from_rgb8(0x88, 0xc0, 0xd0),
+            white: Color::from_rgb8(0xe5, 0xe9, 0xf0),
+            bright_black: Color::from_rgb8(0x4c, 0x56, 0x6a),
+            bright_red: Color::from_rgb8(0xbf, 0x61, 0x6a),
+            bright_green: Color::from_rgb8(0xa3, 0xbe, 0x8c),
+            bright_yellow: Color::from_rgb8(0xeb, 0xcb, 0x8b),
+            bright_blue: Color::from_rgb8(0x81, 0xa1, 0xc1),
+            bright_magenta: Color::from_rgb8(0xb4, 0x8e, 0xad),
+            bright_cyan: Color::from_rgb8(0x8f, 0xbc, 0xbb),
+            bright_white: Color::from_rgb8(0xec, 0xef, 0xf4),
+            foreground: Color::from_rgb8(0xd8, 0xde, 0xe9),
+            background: Color::from_rgb8(0x2e, 0x34, 0x40),
+            cursor: Color::from_rgb8(0xd8, 0xde, 0xe9),
+            selection: Color::from_rgba8(0x43, 0x4c, 0x5e, 0.5),
+        },
+    }
+}
+
+fn gruvbox_dark() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x28, 0x28, 0x28),
+        bg_secondary: Color::from_rgb8(0x1d, 0x20, 0x21),
+        bg_tertiary: Color::from_rgb8(0x3c, 0x38, 0x36),
+        bg_active: Color::from_rgb8(0x50, 0x49, 0x45),
+        text_primary: Color::from_rgb8(0xeb, 0xdb, 0xb2),
+        text_secondary: Color::from_rgb8(0x92, 0x83, 0x74),
+        text_active: Color::from_rgb8(0xfb, 0xf1, 0xc7),
+        accent: Color::from_rgb8(0xfe, 0x80, 0x19),
+        accent_hover: Color::from_rgb8(0xfa, 0xbd, 0x2f),
+        border: Color::from_rgb8(0x3c, 0x38, 0x36),
+        danger: Color::from_rgb8(0xfb, 0x49, 0x34),
+        pane_bg: Color::from_rgb8(0x1d, 0x20, 0x21),
+        pane_border: Color::from_rgb8(0x50, 0x49, 0x45),
+        pane_focused_border: Color::from_rgb8(0xfe, 0x80, 0x19),
+        empty_state_bg: Color::from_rgb8(0x28, 0x28, 0x28),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x28, 0x28, 0x28),
+            red: Color::from_rgb8(0xcc, 0x24, 0x1d),
+            green: Color::from_rgb8(0x98, 0x97, 0x1a),
+            yellow: Color::from_rgb8(0xd7, 0x99, 0x21),
+            blue: Color::from_rgb8(0x45, 0x85, 0x88),
+            magenta: Color::from_rgb8(0xb1, 0x62, 0x86),
+            cyan: Color::from_rgb8(0x68, 0x9d, 0x6a),
+            white: Color::from_rgb8(0xa8, 0x99, 0x84),
+            bright_black: Color::from_rgb8(0x92, 0x83, 0x74),
+            bright_red: Color::from_rgb8(0xfb, 0x49, 0x34),
+            bright_green: Color::from_rgb8(0xb8, 0xbb, 0x26),
+            bright_yellow: Color::from_rgb8(0xfa, 0xbd, 0x2f),
+            bright_blue: Color::from_rgb8(0x83, 0xa5, 0x98),
+            bright_magenta: Color::from_rgb8(0xd3, 0x86, 0x9b),
+            bright_cyan: Color::from_rgb8(0x8e, 0xc0, 0x7c),
+            bright_white: Color::from_rgb8(0xeb, 0xdb, 0xb2),
+            foreground: Color::from_rgb8(0xeb, 0xdb, 0xb2),
+            background: Color::from_rgb8(0x28, 0x28, 0x28),
+            cursor: Color::from_rgb8(0xeb, 0xdb, 0xb2),
+            selection: Color::from_rgba8(0x50, 0x49, 0x45, 0.5),
+        },
+    }
+}
+
+fn one_dark() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x28, 0x2c, 0x34),
+        bg_secondary: Color::from_rgb8(0x21, 0x25, 0x2b),
+        bg_tertiary: Color::from_rgb8(0x2c, 0x31, 0x3c),
+        bg_active: Color::from_rgb8(0x3e, 0x44, 0x51),
+        text_primary: Color::from_rgb8(0xab, 0xb2, 0xbf),
+        text_secondary: Color::from_rgb8(0x5c, 0x63, 0x70),
+        text_active: Color::from_rgb8(0xd7, 0xda, 0xe0),
+        accent: Color::from_rgb8(0x61, 0xaf, 0xef),
+        accent_hover: Color::from_rgb8(0x74, 0xbf, 0xf5),
+        border: Color::from_rgb8(0x3e, 0x44, 0x51),
+        danger: Color::from_rgb8(0xe0, 0x6c, 0x75),
+        pane_bg: Color::from_rgb8(0x21, 0x25, 0x2b),
+        pane_border: Color::from_rgb8(0x3e, 0x44, 0x51),
+        pane_focused_border: Color::from_rgb8(0x61, 0xaf, 0xef),
+        empty_state_bg: Color::from_rgb8(0x28, 0x2c, 0x34),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x28, 0x2c, 0x34),
+            red: Color::from_rgb8(0xe0, 0x6c, 0x75),
+            green: Color::from_rgb8(0x98, 0xc3, 0x79),
+            yellow: Color::from_rgb8(0xe5, 0xc0, 0x7b),
+            blue: Color::from_rgb8(0x61, 0xaf, 0xef),
+            magenta: Color::from_rgb8(0xc6, 0x78, 0xdd),
+            cyan: Color::from_rgb8(0x56, 0xb6, 0xc2),
+            white: Color::from_rgb8(0xab, 0xb2, 0xbf),
+            bright_black: Color::from_rgb8(0x5c, 0x63, 0x70),
+            bright_red: Color::from_rgb8(0xe0, 0x6c, 0x75),
+            bright_green: Color::from_rgb8(0x98, 0xc3, 0x79),
+            bright_yellow: Color::from_rgb8(0xe5, 0xc0, 0x7b),
+            bright_blue: Color::from_rgb8(0x61, 0xaf, 0xef),
+            bright_magenta: Color::from_rgb8(0xc6, 0x78, 0xdd),
+            bright_cyan: Color::from_rgb8(0x56, 0xb6, 0xc2),
+            bright_white: Color::from_rgb8(0xd7, 0xda, 0xe0),
+            foreground: Color::from_rgb8(0xab, 0xb2, 0xbf),
+            background: Color::from_rgb8(0x28, 0x2c, 0x34),
+            cursor: Color::from_rgb8(0x52, 0x8b, 0xff),
+            selection: Color::from_rgba8(0x3e, 0x44, 0x51, 0.5),
+        },
+    }
+}
+
+fn catppuccin() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x1e, 0x1e, 0x2e),
+        bg_secondary: Color::from_rgb8(0x18, 0x18, 0x25),
+        bg_tertiary: Color::from_rgb8(0x31, 0x32, 0x44),
+        bg_active: Color::from_rgb8(0x45, 0x47, 0x5a),
+        text_primary: Color::from_rgb8(0xcd, 0xd6, 0xf4),
+        text_secondary: Color::from_rgb8(0x6c, 0x70, 0x86),
+        text_active: Color::from_rgb8(0xcd, 0xd6, 0xf4),
+        accent: Color::from_rgb8(0xcb, 0xa6, 0xf7),
+        accent_hover: Color::from_rgb8(0xd4, 0xb7, 0xf9),
+        border: Color::from_rgb8(0x31, 0x32, 0x44),
+        danger: Color::from_rgb8(0xf3, 0x8b, 0xa8),
+        pane_bg: Color::from_rgb8(0x18, 0x18, 0x25),
+        pane_border: Color::from_rgb8(0x45, 0x47, 0x5a),
+        pane_focused_border: Color::from_rgb8(0xcb, 0xa6, 0xf7),
+        empty_state_bg: Color::from_rgb8(0x1e, 0x1e, 0x2e),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x45, 0x47, 0x5a),
+            red: Color::from_rgb8(0xf3, 0x8b, 0xa8),
+            green: Color::from_rgb8(0xa6, 0xe3, 0xa1),
+            yellow: Color::from_rgb8(0xf9, 0xe2, 0xaf),
+            blue: Color::from_rgb8(0x89, 0xb4, 0xfa),
+            magenta: Color::from_rgb8(0xcb, 0xa6, 0xf7),
+            cyan: Color::from_rgb8(0x94, 0xe2, 0xd5),
+            white: Color::from_rgb8(0xba, 0xc2, 0xde),
+            bright_black: Color::from_rgb8(0x58, 0x5b, 0x70),
+            bright_red: Color::from_rgb8(0xf3, 0x8b, 0xa8),
+            bright_green: Color::from_rgb8(0xa6, 0xe3, 0xa1),
+            bright_yellow: Color::from_rgb8(0xf9, 0xe2, 0xaf),
+            bright_blue: Color::from_rgb8(0x89, 0xb4, 0xfa),
+            bright_magenta: Color::from_rgb8(0xcb, 0xa6, 0xf7),
+            bright_cyan: Color::from_rgb8(0x94, 0xe2, 0xd5),
+            bright_white: Color::from_rgb8(0xa6, 0xad, 0xc8),
+            foreground: Color::from_rgb8(0xcd, 0xd6, 0xf4),
+            background: Color::from_rgb8(0x1e, 0x1e, 0x2e),
+            cursor: Color::from_rgb8(0xf5, 0xe0, 0xdc),
+            selection: Color::from_rgba8(0x45, 0x47, 0x5a, 0.5),
+        },
+    }
+}
+
+fn solarized_dark() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x00, 0x2b, 0x36),
+        bg_secondary: Color::from_rgb8(0x00, 0x21, 0x2b),
+        bg_tertiary: Color::from_rgb8(0x07, 0x36, 0x42),
+        bg_active: Color::from_rgb8(0x09, 0x40, 0x4f),
+        text_primary: Color::from_rgb8(0x83, 0x94, 0x96),
+        text_secondary: Color::from_rgb8(0x58, 0x6e, 0x75),
+        text_active: Color::from_rgb8(0x93, 0xa1, 0xa1),
+        accent: Color::from_rgb8(0xb5, 0x89, 0x00),
+        accent_hover: Color::from_rgb8(0xcb, 0x4b, 0x16),
+        border: Color::from_rgb8(0x07, 0x36, 0x42),
+        danger: Color::from_rgb8(0xdc, 0x32, 0x2f),
+        pane_bg: Color::from_rgb8(0x00, 0x21, 0x2b),
+        pane_border: Color::from_rgb8(0x07, 0x36, 0x42),
+        pane_focused_border: Color::from_rgb8(0xb5, 0x89, 0x00),
+        empty_state_bg: Color::from_rgb8(0x00, 0x2b, 0x36),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x07, 0x36, 0x42),
+            red: Color::from_rgb8(0xdc, 0x32, 0x2f),
+            green: Color::from_rgb8(0x85, 0x99, 0x00),
+            yellow: Color::from_rgb8(0xb5, 0x89, 0x00),
+            blue: Color::from_rgb8(0x26, 0x8b, 0xd2),
+            magenta: Color::from_rgb8(0xd3, 0x36, 0x82),
+            cyan: Color::from_rgb8(0x2a, 0xa1, 0x98),
+            white: Color::from_rgb8(0xee, 0xe8, 0xd5),
+            bright_black: Color::from_rgb8(0x00, 0x2b, 0x36),
+            bright_red: Color::from_rgb8(0xcb, 0x4b, 0x16),
+            bright_green: Color::from_rgb8(0x58, 0x6e, 0x75),
+            bright_yellow: Color::from_rgb8(0x65, 0x7b, 0x83),
+            bright_blue: Color::from_rgb8(0x83, 0x94, 0x96),
+            bright_magenta: Color::from_rgb8(0x6c, 0x71, 0xc4),
+            bright_cyan: Color::from_rgb8(0x93, 0xa1, 0xa1),
+            bright_white: Color::from_rgb8(0xfd, 0xf6, 0xe3),
+            foreground: Color::from_rgb8(0x83, 0x94, 0x96),
+            background: Color::from_rgb8(0x00, 0x2b, 0x36),
+            cursor: Color::from_rgb8(0x83, 0x94, 0x96),
+            selection: Color::from_rgba8(0x07, 0x36, 0x42, 0.5),
+        },
+    }
+}
+
+fn monokai() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x27, 0x28, 0x22),
+        bg_secondary: Color::from_rgb8(0x1e, 0x1f, 0x1a),
+        bg_tertiary: Color::from_rgb8(0x3e, 0x3d, 0x32),
+        bg_active: Color::from_rgb8(0x49, 0x48, 0x3e),
+        text_primary: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+        text_secondary: Color::from_rgb8(0x75, 0x71, 0x5e),
+        text_active: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+        accent: Color::from_rgb8(0xf4, 0xbf, 0x75),
+        accent_hover: Color::from_rgb8(0xe6, 0xdb, 0x74),
+        border: Color::from_rgb8(0x3e, 0x3d, 0x32),
+        danger: Color::from_rgb8(0xf9, 0x26, 0x72),
+        pane_bg: Color::from_rgb8(0x1e, 0x1f, 0x1a),
+        pane_border: Color::from_rgb8(0x49, 0x48, 0x3e),
+        pane_focused_border: Color::from_rgb8(0xf4, 0xbf, 0x75),
+        empty_state_bg: Color::from_rgb8(0x27, 0x28, 0x22),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x27, 0x28, 0x22),
+            red: Color::from_rgb8(0xf9, 0x26, 0x72),
+            green: Color::from_rgb8(0xa6, 0xe2, 0x2e),
+            yellow: Color::from_rgb8(0xf4, 0xbf, 0x75),
+            blue: Color::from_rgb8(0x66, 0xd9, 0xef),
+            magenta: Color::from_rgb8(0xae, 0x81, 0xff),
+            cyan: Color::from_rgb8(0xa1, 0xef, 0xe4),
+            white: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+            bright_black: Color::from_rgb8(0x75, 0x71, 0x5e),
+            bright_red: Color::from_rgb8(0xf9, 0x26, 0x72),
+            bright_green: Color::from_rgb8(0xa6, 0xe2, 0x2e),
+            bright_yellow: Color::from_rgb8(0xf4, 0xbf, 0x75),
+            bright_blue: Color::from_rgb8(0x66, 0xd9, 0xef),
+            bright_magenta: Color::from_rgb8(0xae, 0x81, 0xff),
+            bright_cyan: Color::from_rgb8(0xa1, 0xef, 0xe4),
+            bright_white: Color::from_rgb8(0xf9, 0xf8, 0xf5),
+            foreground: Color::from_rgb8(0xf8, 0xf8, 0xf2),
+            background: Color::from_rgb8(0x27, 0x28, 0x22),
+            cursor: Color::from_rgb8(0xf8, 0xf8, 0xf0),
+            selection: Color::from_rgba8(0x49, 0x48, 0x3e, 0.5),
+        },
+    }
+}
+
+fn ayu_dark() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x0a, 0x0e, 0x14),
+        bg_secondary: Color::from_rgb8(0x07, 0x0a, 0x0f),
+        bg_tertiary: Color::from_rgb8(0x1a, 0x1f, 0x29),
+        bg_active: Color::from_rgb8(0x27, 0x2d, 0x38),
+        text_primary: Color::from_rgb8(0xb3, 0xb1, 0xad),
+        text_secondary: Color::from_rgb8(0x5c, 0x67, 0x73),
+        text_active: Color::from_rgb8(0xe6, 0xe1, 0xcf),
+        accent: Color::from_rgb8(0xff, 0xb4, 0x54),
+        accent_hover: Color::from_rgb8(0xf2, 0x9e, 0x74),
+        border: Color::from_rgb8(0x1a, 0x1f, 0x29),
+        danger: Color::from_rgb8(0xff, 0x33, 0x33),
+        pane_bg: Color::from_rgb8(0x07, 0x0a, 0x0f),
+        pane_border: Color::from_rgb8(0x27, 0x2d, 0x38),
+        pane_focused_border: Color::from_rgb8(0xff, 0xb4, 0x54),
+        empty_state_bg: Color::from_rgb8(0x0a, 0x0e, 0x14),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x01, 0x06, 0x0e),
+            red: Color::from_rgb8(0xea, 0x6c, 0x73),
+            green: Color::from_rgb8(0x91, 0xb3, 0x62),
+            yellow: Color::from_rgb8(0xf9, 0xaf, 0x4f),
+            blue: Color::from_rgb8(0x53, 0xbd, 0xfa),
+            magenta: Color::from_rgb8(0xfa, 0xe9, 0x94),
+            cyan: Color::from_rgb8(0x90, 0xe1, 0xc6),
+            white: Color::from_rgb8(0xc7, 0xc7, 0xc7),
+            bright_black: Color::from_rgb8(0x68, 0x68, 0x68),
+            bright_red: Color::from_rgb8(0xf0, 0x71, 0x78),
+            bright_green: Color::from_rgb8(0xc2, 0xd9, 0x4c),
+            bright_yellow: Color::from_rgb8(0xff, 0xb4, 0x54),
+            bright_blue: Color::from_rgb8(0x59, 0xc2, 0xff),
+            bright_magenta: Color::from_rgb8(0xff, 0xee, 0x99),
+            bright_cyan: Color::from_rgb8(0x95, 0xe6, 0xcb),
+            bright_white: Color::from_rgb8(0xff, 0xff, 0xff),
+            foreground: Color::from_rgb8(0xb3, 0xb1, 0xad),
+            background: Color::from_rgb8(0x0a, 0x0e, 0x14),
+            cursor: Color::from_rgb8(0xe6, 0xb4, 0x50),
+            selection: Color::from_rgba8(0x27, 0x2d, 0x38, 0.5),
+        },
+    }
+}
+
+fn rose_pine() -> ThemePalette {
+    ThemePalette {
+        bg_primary: Color::from_rgb8(0x19, 0x17, 0x24),
+        bg_secondary: Color::from_rgb8(0x13, 0x11, 0x1b),
+        bg_tertiary: Color::from_rgb8(0x26, 0x23, 0x3a),
+        bg_active: Color::from_rgb8(0x39, 0x35, 0x52),
+        text_primary: Color::from_rgb8(0xe0, 0xde, 0xf4),
+        text_secondary: Color::from_rgb8(0x6e, 0x6a, 0x86),
+        text_active: Color::from_rgb8(0xe0, 0xde, 0xf4),
+        accent: Color::from_rgb8(0xeb, 0xbc, 0xba),
+        accent_hover: Color::from_rgb8(0xf2, 0xce, 0xcd),
+        border: Color::from_rgb8(0x26, 0x23, 0x3a),
+        danger: Color::from_rgb8(0xeb, 0x6f, 0x92),
+        pane_bg: Color::from_rgb8(0x13, 0x11, 0x1b),
+        pane_border: Color::from_rgb8(0x39, 0x35, 0x52),
+        pane_focused_border: Color::from_rgb8(0xeb, 0xbc, 0xba),
+        empty_state_bg: Color::from_rgb8(0x19, 0x17, 0x24),
+        backdrop: Color::from_rgba(0.0, 0.0, 0.0, 0.58),
+        terminal: TerminalPalette {
+            black: Color::from_rgb8(0x26, 0x23, 0x3a),
+            red: Color::from_rgb8(0xeb, 0x6f, 0x92),
+            green: Color::from_rgb8(0x31, 0x74, 0x8f),
+            yellow: Color::from_rgb8(0xf6, 0xc1, 0x77),
+            blue: Color::from_rgb8(0x9c, 0xcf, 0xd8),
+            magenta: Color::from_rgb8(0xc4, 0xa7, 0xe7),
+            cyan: Color::from_rgb8(0xea, 0x9a, 0x97),
+            white: Color::from_rgb8(0xe0, 0xde, 0xf4),
+            bright_black: Color::from_rgb8(0x6e, 0x6a, 0x86),
+            bright_red: Color::from_rgb8(0xeb, 0x6f, 0x92),
+            bright_green: Color::from_rgb8(0x31, 0x74, 0x8f),
+            bright_yellow: Color::from_rgb8(0xf6, 0xc1, 0x77),
+            bright_blue: Color::from_rgb8(0x9c, 0xcf, 0xd8),
+            bright_magenta: Color::from_rgb8(0xc4, 0xa7, 0xe7),
+            bright_cyan: Color::from_rgb8(0xea, 0x9a, 0x97),
+            bright_white: Color::from_rgb8(0xe0, 0xde, 0xf4),
+            foreground: Color::from_rgb8(0xe0, 0xde, 0xf4),
+            background: Color::from_rgb8(0x19, 0x17, 0x24),
+            cursor: Color::from_rgb8(0x52, 0x4f, 0x67),
+            selection: Color::from_rgba8(0x39, 0x35, 0x52, 0.5),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_themes_returns_11() {
+        assert_eq!(ThemeId::all().len(), 11);
+    }
+
+    #[test]
+    fn dusk_matches_legacy_constants() {
+        let p = palette(ThemeId::Dusk);
+        assert_eq!(
+            format!("{:?}", p.bg_primary),
+            format!("{:?}", Color::from_rgb(0.1137, 0.1216, 0.1294))
+        );
+        assert_eq!(
+            format!("{:?}", p.accent),
+            format!("{:?}", Color::from_rgb(0.8314, 0.6627, 0.4157))
+        );
+    }
+
+    #[test]
+    fn set_active_theme_updates_accessors() {
+        set_active_theme(ThemeId::Dusk);
+        let dusk_accent = ACCENT();
+        set_active_theme(ThemeId::Dracula);
+        let dracula_accent = ACCENT();
+        assert_ne!(
+            format!("{:?}", dusk_accent),
+            format!("{:?}", dracula_accent)
+        );
+        // Restore
+        set_active_theme(ThemeId::Dusk);
+    }
+
+    #[test]
+    fn each_theme_has_unique_label() {
+        let labels: Vec<&str> = ThemeId::all().iter().map(|t| t.label()).collect();
+        let unique: std::collections::HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(labels.len(), unique.len());
+    }
+
+    #[test]
+    fn palette_returns_valid_colors_for_all_themes() {
+        for &id in ThemeId::all() {
+            let p = palette(id);
+            assert!(p.bg_primary.a > 0.0);
+            assert!(p.accent.a > 0.0);
+            assert!(p.text_primary.a > 0.0);
+        }
+    }
+
+    #[test]
+    fn preview_colors_returns_five_for_all_themes() {
+        for &id in ThemeId::all() {
+            let colors = id.preview_colors();
+            assert_eq!(colors.len(), 5);
+        }
+    }
+}

--- a/src-tauri/native/iced-shell/src/title_bar.rs
+++ b/src-tauri/native/iced-shell/src/title_bar.rs
@@ -21,7 +21,7 @@ pub fn view_title_bar<'a, M: Clone + 'a>(
 ) -> Element<'a, M> {
     let title_text = text(title)
         .size(12)
-        .color(TEXT_SECONDARY);
+        .color(TEXT_SECONDARY());
 
     let drag_area = mouse_area(
         container(title_text)

--- a/src-tauri/native/terminal-surface/src/surface.rs
+++ b/src-tauri/native/terminal-surface/src/surface.rs
@@ -51,6 +51,10 @@ pub struct TerminalCanvas<'a> {
     /// Optional selection range (start, end) in reading order.
     /// When set, draws a semi-transparent blue overlay on selected cells.
     pub selection: Option<(GridPos, GridPos)>,
+    /// Default foreground color (overridable by theme).
+    pub default_fg: Color,
+    /// Default background color (overridable by theme).
+    pub default_bg: Color,
 }
 
 impl Default for TerminalCanvas<'_> {
@@ -59,6 +63,8 @@ impl Default for TerminalCanvas<'_> {
             grid: None,
             metrics: FontMetrics::default(),
             selection: None,
+            default_fg: DEFAULT_FG,
+            default_bg: DEFAULT_BG,
         }
     }
 }
@@ -70,6 +76,8 @@ impl<'a> TerminalCanvas<'a> {
             grid: None,
             metrics,
             selection: None,
+            default_fg: DEFAULT_FG,
+            default_bg: DEFAULT_BG,
         }
     }
 }
@@ -88,7 +96,7 @@ impl<Message> canvas::Program<Message> for TerminalCanvas<'_> {
         let mut frame = canvas::Frame::new(renderer, bounds.size());
 
         // Fill background
-        frame.fill_rectangle(Point::ORIGIN, bounds.size(), DEFAULT_BG);
+        frame.fill_rectangle(Point::ORIGIN, bounds.size(), self.default_bg);
 
         let grid = match &self.grid {
             Some(g) => g,
@@ -116,13 +124,13 @@ impl<Message> canvas::Program<Message> for TerminalCanvas<'_> {
                 // Resolve colors, handling inverse attribute
                 let (mut fg, bg) = if cell.inverse {
                     (
-                        parse_color(&cell.bg, DEFAULT_BG),
-                        parse_color(&cell.fg, DEFAULT_FG),
+                        parse_color(&cell.bg, self.default_bg),
+                        parse_color(&cell.fg, self.default_fg),
                     )
                 } else {
                     (
-                        parse_color(&cell.fg, DEFAULT_FG),
-                        parse_color(&cell.bg, DEFAULT_BG),
+                        parse_color(&cell.fg, self.default_fg),
+                        parse_color(&cell.bg, self.default_bg),
                     )
                 };
 
@@ -136,7 +144,7 @@ impl<Message> canvas::Program<Message> for TerminalCanvas<'_> {
                 }
 
                 // Draw background (only if non-default to avoid overdraw)
-                if bg.r != DEFAULT_BG.r || bg.g != DEFAULT_BG.g || bg.b != DEFAULT_BG.b {
+                if bg.r != self.default_bg.r || bg.g != self.default_bg.g || bg.b != self.default_bg.b {
                     frame.fill_rectangle(
                         Point::new(x, y),
                         Size::new(cell_w * char_width, cell_h),


### PR DESCRIPTION
## Summary
- Adds ThemePalette + TerminalPalette structs with complete UI and terminal color definitions
- 11 built-in themes: Dusk (default), Tokyo Night, Dracula, Nord, Gruvbox Dark, One Dark, Catppuccin, Solarized Dark, Monokai, Ayu Dark, Rose Pine
- Dynamic theme switching via global RwLock with backward-compatible accessor functions (const -> fn migration)
- Appearance tab in Settings dialog with 2-column theme grid and 5-color preview swatches
- Terminal surface updated to accept theme-provided default_fg/default_bg colors

## Changed Files
- `theme.rs` — Full rewrite: ThemeId enum, ThemePalette, TerminalPalette, 11 palettes, RwLock-based switching, backward-compat accessors
- `surface.rs` — Added default_fg/default_bg fields to TerminalCanvas
- `app.rs` — ThemeChanged message + handler, Appearance tab, TerminalCanvas theme color wiring, const-to-fn migration
- `sidebar.rs`, `settings_dialog.rs`, `shortcuts_tab.rs`, `title_bar.rs`, `mru_switcher.rs` — const-to-fn migration

## Test plan
- [ ] `cargo check -p godly-terminal-surface` passes
- [ ] `cargo check -p godly-iced-shell` passes (once other agents' modules land)
- [ ] Theme switching updates all UI chrome colors
- [ ] Terminal ANSI colors change with theme
- [ ] Appearance tab shows all 11 themes with correct preview swatches