### PR TITLE
feat(native): quit confirmation + copy preview dialogs (K2+K3)

### DIFF
--- a/changelog/unreleased/k2-k3-quit-copy-dialogs.md
+++ b/changelog/unreleased/k2-k3-quit-copy-dialogs.md
@@ -1,0 +1,4 @@
+### Added
+- **Quit confirmation dialog** - Shows active session count when closing with terminals running; sessions continue in daemon
+- **Copy preview dialog** - Previews large selections (>500 chars) before copying to clipboard
+- **Reusable confirm_dialog module** - Generic centered modal dialog with backdrop, title, body, confirm/cancel buttons, and danger mode styling

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -338,6 +338,9 @@ pub struct GodlyApp {
     dragging_tab_id: Option<String>,
     /// Ctrl+Tab MRU switcher popup state while modifier is held.
     mru_switcher: Option<MruSwitcherState>,
+    // --- K2/K3: Quit Confirmation + Copy Preview ---
+    quit_confirm_pending: bool,
+    copy_preview_text: Option<String>,
 }
 
 impl Default for GodlyApp {
@@ -408,6 +411,8 @@ impl Default for GodlyApp {
             next_toast_id: 1,
             dragging_tab_id: None,
             mru_switcher: None,
+            quit_confirm_pending: false,
+            copy_preview_text: None,
         }
     }
 }
@@ -627,6 +632,13 @@ pub enum Message {
     ClipboardPasteFailed(String),
     /// File path dropped on window.
     FileDropped(PathBuf),
+    // --- K2/K3: Quit Confirmation + Copy Preview ---
+    QuitConfirmShow,
+    QuitConfirmed,
+    QuitCancelled,
+    CopyPreviewShow(String),
+    CopyPreviewConfirmed,
+    CopyPreviewDismissed,
 }
 
 /// Result of initialization — either a fresh terminal or recovered sessions.
@@ -1324,7 +1336,10 @@ impl GodlyApp {
                 }
             }
             Message::TitleBarClose => {
-                if let Some(id) = self.window_id {
+                let terminal_count = self.terminals.count();
+                if terminal_count > 0 {
+                    self.quit_confirm_pending = true;
+                } else if let Some(id) = self.window_id {
                     return window::close(id);
                 }
             }
@@ -1946,6 +1961,33 @@ impl GodlyApp {
             Message::SettingsTabClicked(tab_id) => {
                 self.settings_tab = tab_id;
             }
+            // --- K2/K3: Quit Confirmation + Copy Preview ---
+            Message::QuitConfirmShow => {
+                self.quit_confirm_pending = true;
+            }
+            Message::QuitConfirmed => {
+                self.quit_confirm_pending = false;
+                if let Some(id) = self.window_id {
+                    return window::close(id);
+                }
+            }
+            Message::QuitCancelled => {
+                self.quit_confirm_pending = false;
+            }
+            Message::CopyPreviewShow(preview_text) => {
+                self.copy_preview_text = Some(preview_text);
+            }
+            Message::CopyPreviewConfirmed => {
+                if let Some(ref text) = self.copy_preview_text {
+                    if let Err(e) = clipboard::copy_to_clipboard(text) {
+                        log::error!("Clipboard copy failed: {}", e);
+                    }
+                }
+                self.copy_preview_text = None;
+            }
+            Message::CopyPreviewDismissed => {
+                self.copy_preview_text = None;
+            }
         }
         Task::none()
     }
@@ -2114,10 +2156,41 @@ impl GodlyApp {
             with_mru_switcher
         };
 
-        if self.rename_tab_id.is_some() {
+        let with_tab_rename: Element<'_, Message> = if self.rename_tab_id.is_some() {
             stack![with_workspace_rename, self.view_tab_rename_dialog()].into()
         } else {
             with_workspace_rename
+        };
+
+        // --- K2/K3: Quit Confirmation + Copy Preview ---
+        let with_quit: Element<'_, Message> = if self.quit_confirm_pending {
+            let terminal_count = self.terminals.count();
+            stack![
+                with_tab_rename,
+                crate::confirm_dialog::view_quit_confirm(
+                    terminal_count,
+                    Message::QuitConfirmed,
+                    Message::QuitCancelled,
+                )
+            ]
+            .into()
+        } else {
+            with_tab_rename
+        };
+
+        if let Some(ref preview_text) = self.copy_preview_text {
+            stack![
+                with_quit,
+                crate::confirm_dialog::view_copy_preview(
+                    preview_text,
+                    preview_text.len(),
+                    Message::CopyPreviewConfirmed,
+                    Message::CopyPreviewDismissed,
+                )
+            ]
+            .into()
+        } else {
+            with_quit
         }
     }
 
@@ -3980,6 +4053,11 @@ impl GodlyApp {
 
         let text = self.selection.selected_text(grid);
         if text.is_empty() {
+            return;
+        }
+
+        if text.len() > crate::confirm_dialog::COPY_PREVIEW_THRESHOLD {
+            self.copy_preview_text = Some(text);
             return;
         }
 

--- a/src-tauri/native/iced-shell/src/confirm_dialog.rs
+++ b/src-tauri/native/iced-shell/src/confirm_dialog.rs
@@ -1,0 +1,254 @@
+use iced::widget::{button, column, container, row, scrollable, text, Space};
+use iced::{Background, Border, Color, Element, Length, Padding, Shadow, Vector};
+
+use crate::theme::{
+    ACCENT, BACKDROP, BG_SECONDARY, BG_TERTIARY, BORDER, DANGER, RADIUS_LG, RADIUS_MD, RADIUS_SM,
+    TEXT_ACTIVE, TEXT_PRIMARY, TEXT_SECONDARY,
+};
+
+/// Render a centered modal confirmation dialog.
+///
+/// - Semi-transparent backdrop
+/// - Title, body text (or element), confirm/cancel buttons
+pub fn view_confirm_dialog<'a, M: Clone + 'a>(
+    title: &'a str,
+    body: Element<'a, M>,
+    confirm_label: &'a str,
+    cancel_label: &'a str,
+    on_confirm: M,
+    on_cancel: M,
+    danger: bool,
+) -> Element<'a, M> {
+    let title_text = text(title).size(16).color(TEXT_ACTIVE);
+
+    let confirm_color = if danger { DANGER } else { ACCENT };
+
+    let cancel_btn = button(text(cancel_label).size(13).color(TEXT_PRIMARY))
+        .on_press(on_cancel)
+        .padding(Padding::from([7, 18]))
+        .style(move |_theme, status| {
+            let bg = match status {
+                button::Status::Hovered => BG_TERTIARY,
+                _ => Color::TRANSPARENT,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color: TEXT_PRIMARY,
+                border: Border {
+                    color: BORDER,
+                    width: 1.0,
+                    radius: RADIUS_MD.into(),
+                },
+                ..button::Style::default()
+            }
+        });
+
+    let confirm_btn = button(text(confirm_label).size(13).color(Color::WHITE))
+        .on_press(on_confirm)
+        .padding(Padding::from([7, 18]))
+        .style(move |_theme, status| {
+            let bg = match status {
+                button::Status::Hovered => Color::from_rgba(
+                    (confirm_color.r * 1.1).min(1.0),
+                    (confirm_color.g * 1.1).min(1.0),
+                    (confirm_color.b * 1.1).min(1.0),
+                    1.0,
+                ),
+                _ => confirm_color,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color: Color::WHITE,
+                border: Border {
+                    color: Color::TRANSPARENT,
+                    width: 0.0,
+                    radius: RADIUS_MD.into(),
+                },
+                ..button::Style::default()
+            }
+        });
+
+    let footer = row![Space::new().width(Length::Fill), cancel_btn, confirm_btn].spacing(10);
+
+    let dialog_content = column![
+        title_text,
+        Space::new().height(12.0),
+        body,
+        Space::new().height(16.0),
+        footer,
+    ];
+
+    let dialog = container(dialog_content)
+        .padding(Padding::from([20, 24]))
+        .width(Length::Fixed(440.0))
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(BG_SECONDARY)),
+            border: Border {
+                color: BORDER,
+                width: 1.0,
+                radius: RADIUS_LG.into(),
+            },
+            shadow: Shadow {
+                color: Color::from_rgba(0.0, 0.0, 0.0, 0.5),
+                offset: Vector::new(0.0, 8.0),
+                blur_radius: 24.0,
+            },
+            ..container::Style::default()
+        });
+
+    container(iced::widget::center(dialog))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(BACKDROP)),
+            ..container::Style::default()
+        })
+        .into()
+}
+
+/// Render a quit confirmation dialog showing active terminal count.
+pub fn view_quit_confirm<'a, M: Clone + 'a>(
+    terminal_count: usize,
+    on_confirm: M,
+    on_cancel: M,
+) -> Element<'a, M> {
+    let body_text = format!(
+        "You have {} active terminal session{}. \
+         Quitting will detach all sessions (they continue running in the daemon).\n\n\
+         Are you sure you want to quit?",
+        terminal_count,
+        if terminal_count == 1 { "" } else { "s" }
+    );
+    let body = text(body_text).size(13).color(TEXT_PRIMARY).into();
+
+    view_confirm_dialog(
+        "Quit Godly Terminal?",
+        body,
+        "Quit",
+        "Cancel",
+        on_confirm,
+        on_cancel,
+        true,
+    )
+}
+
+/// Render a copy preview dialog for large selections.
+pub fn view_copy_preview<'a, M: Clone + 'a>(
+    preview_text: &str,
+    total_chars: usize,
+    on_confirm: M,
+    on_cancel: M,
+) -> Element<'a, M> {
+    let truncated = if preview_text.len() > 500 {
+        format!("{}...", &preview_text[..500])
+    } else {
+        preview_text.to_string()
+    };
+
+    let body = column![
+        text(format!("Selection contains {} characters.", total_chars))
+            .size(13)
+            .color(TEXT_SECONDARY),
+        Space::new().height(8.0),
+        container(
+            scrollable(text(truncated).size(12).color(TEXT_PRIMARY))
+                .height(Length::Fixed(200.0))
+        )
+        .padding(Padding::from([8, 10]))
+        .width(Length::Fill)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(BG_TERTIARY)),
+            border: Border {
+                color: BORDER,
+                width: 1.0,
+                radius: RADIUS_SM.into(),
+            },
+            ..container::Style::default()
+        }),
+    ]
+    .into();
+
+    view_confirm_dialog(
+        "Copy Large Selection?",
+        body,
+        "Copy",
+        "Cancel",
+        on_confirm,
+        on_cancel,
+        false,
+    )
+}
+
+/// Threshold in characters above which a copy preview is shown.
+pub const COPY_PREVIEW_THRESHOLD: usize = 500;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    enum TestMsg {
+        Confirm,
+        Cancel,
+    }
+
+    #[test]
+    fn quit_confirm_renders() {
+        let _el: Element<'_, TestMsg> = view_quit_confirm(3, TestMsg::Confirm, TestMsg::Cancel);
+    }
+
+    #[test]
+    fn quit_confirm_singular() {
+        let _el: Element<'_, TestMsg> = view_quit_confirm(1, TestMsg::Confirm, TestMsg::Cancel);
+    }
+
+    #[test]
+    fn copy_preview_renders() {
+        let _el: Element<'_, TestMsg> = view_copy_preview(
+            "hello world this is a test",
+            26,
+            TestMsg::Confirm,
+            TestMsg::Cancel,
+        );
+    }
+
+    #[test]
+    fn copy_preview_long_text() {
+        let long = "x".repeat(1000);
+        let _el: Element<'_, TestMsg> =
+            view_copy_preview(&long, 1000, TestMsg::Confirm, TestMsg::Cancel);
+    }
+
+    #[test]
+    fn copy_preview_threshold() {
+        assert_eq!(COPY_PREVIEW_THRESHOLD, 500);
+    }
+
+    #[test]
+    fn confirm_dialog_renders() {
+        let body: Element<'_, TestMsg> = text("Are you sure?").into();
+        let _el: Element<'_, TestMsg> = view_confirm_dialog(
+            "Confirm",
+            body,
+            "Yes",
+            "No",
+            TestMsg::Confirm,
+            TestMsg::Cancel,
+            false,
+        );
+    }
+
+    #[test]
+    fn confirm_dialog_danger_mode() {
+        let body: Element<'_, TestMsg> = text("This is dangerous!").into();
+        let _el: Element<'_, TestMsg> = view_confirm_dialog(
+            "Warning",
+            body,
+            "Delete",
+            "Cancel",
+            TestMsg::Confirm,
+            TestMsg::Cancel,
+            true,
+        );
+    }
+}

--- a/src-tauri/native/iced-shell/src/lib.rs
+++ b/src-tauri/native/iced-shell/src/lib.rs
@@ -13,3 +13,4 @@ pub mod terminal_state;
 pub mod title_bar;
 pub mod theme;
 pub mod workspace_state;
+pub mod confirm_dialog;

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -16,6 +16,8 @@ mod theme;
 mod title_bar;
 mod workspace_state;
 
+mod confirm_dialog;
+
 use app::{GodlyApp, Message};
 
 fn main() -> iced::Result {


### PR DESCRIPTION
## Summary

- **Quit confirmation dialog (K2)** — When closing with active terminal sessions, shows a centered modal with session count and confirm/cancel buttons. Sessions continue running in daemon after quit.
- **Copy preview dialog (K3)** — Large selections (>500 chars) show a scrollable preview before copying to clipboard.
- **Reusable `confirm_dialog` module** — Generic centered modal with backdrop, title, body element, confirm/cancel buttons, and danger mode styling. Used by both K2 and K3.

## Changes

- `confirm_dialog.rs` (new) — `view_confirm_dialog()`, `view_quit_confirm()`, `view_copy_preview()`, `COPY_PREVIEW_THRESHOLD`, 7 unit tests
- `app.rs` — Struct fields (`quit_confirm_pending`, `copy_preview_text`), Message variants, update handlers, `copy_selection` threshold gate, view overlay chain
- `lib.rs` / `main.rs` — Module registration

## Test plan

- [x] `cargo check -p godly-iced-shell` passes (0 errors)
- [x] `cargo nextest run -p godly-iced-shell` passes (364 tests, 0 failures)
- [ ] CI full build
- [ ] Manual: close app with active sessions → quit dialog appears
- [ ] Manual: select >500 chars → copy preview dialog appears
- [ ] Manual: close app with no sessions → closes immediately (no dialog)