### PR TITLE
fix: prevent keybinding shadow bindings and respect custom tab shortcuts

### DIFF
--- a/changelog/unreleased/fix-custom-keybinding-shadow-bindings.md
+++ b/changelog/unreleased/fix-custom-keybinding-shadow-bindings.md
@@ -1,0 +1,3 @@
+### Fixed
+- **Keybinding conflict shadow bindings** — custom keybindings that conflicted with other actions now swap bindings instead of resetting, preventing unreachable actions
+- **RecencySwitcher hardcoded keybindings** — tab cycling and commit now respect user's custom tab-switching shortcuts instead of assuming Ctrl+Tab

--- a/src/components/RecencySwitcher.ts
+++ b/src/components/RecencySwitcher.ts
@@ -1,4 +1,5 @@
 import { store, type Terminal } from '../state/store';
+import { keybindingStore, chordToString, eventToChord } from '../state/keybinding-store';
 
 export interface RecencySwitcherEntry {
   terminalId: string;
@@ -9,8 +10,9 @@ export interface RecencySwitcherEntry {
 
 /**
  * Modal overlay that shows tabs ordered by most-recently-used.
- * Opens on Ctrl+Tab, cycles with repeated Tab presses while Ctrl is held,
- * and commits the selection when Ctrl is released.
+ * Opens on the tab-switching shortcut, cycles with repeated presses while
+ * the primary modifier is held, and commits the selection when the modifier
+ * is released. Dynamically reads keybindings so custom shortcuts work.
  */
 export class RecencySwitcher {
   private overlay: HTMLElement;
@@ -20,6 +22,8 @@ export class RecencySwitcher {
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
   private keyupHandler: ((e: KeyboardEvent) => void) | null = null;
   private visible = false;
+  /** The modifier key whose release commits the selection. */
+  private commitModifier: string = 'Control';
 
   constructor() {
     this.overlay = document.createElement('div');
@@ -56,7 +60,7 @@ export class RecencySwitcher {
 
   /**
    * Show the switcher with MRU-ordered entries.
-   * @param reverse If true, start selection at the end (Ctrl+Shift+Tab).
+   * @param reverse If true, start selection at the end (Shift+Tab direction).
    */
   show(reverse = false): void {
     const state = store.getState();
@@ -68,6 +72,15 @@ export class RecencySwitcher {
     const workspace = state.workspaces.find(w => w.id === wsId);
 
     if (wsTerminals.length < 2) return;
+
+    // Determine the commit modifier from the actual keybinding
+    const chord = reverse
+      ? keybindingStore.getBinding('tabs.previousTab')
+      : keybindingStore.getBinding('tabs.nextTab');
+    this.commitModifier = chord.ctrlKey ? 'Control'
+      : chord.altKey ? 'Alt'
+      : chord.shiftKey ? 'Shift'
+      : 'Control'; // fallback
 
     // Build entries in MRU order, falling back to tab order for terminals not in history
     const ordered = this.buildMruList(accessHistory, wsTerminals);
@@ -170,7 +183,13 @@ export class RecencySwitcher {
   }
 
   private attachListeners(): void {
-    // Capture keydown to intercept Tab while Ctrl is held
+    // Read the actual chords for tab cycling
+    const nextChord = keybindingStore.getBinding('tabs.nextTab');
+    const prevChord = keybindingStore.getBinding('tabs.previousTab');
+    const nextStr = chordToString(nextChord);
+    const prevStr = chordToString(prevChord);
+
+    // Capture keydown to intercept cycle keys
     this.keydownHandler = (e: KeyboardEvent) => {
       if (!this.visible) return;
 
@@ -181,22 +200,24 @@ export class RecencySwitcher {
         return;
       }
 
-      // Tab while Ctrl held = cycle
-      if (e.key === 'Tab' && e.ctrlKey) {
+      // Match against the actual keybindings for cycling
+      const chord = eventToChord(e);
+      const str = chordToString(chord);
+      if (str === nextStr) {
         e.preventDefault();
         e.stopImmediatePropagation();
-        if (e.shiftKey) {
-          this.cyclePrev();
-        } else {
-          this.cycleNext();
-        }
+        this.cycleNext();
+      } else if (str === prevStr) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        this.cyclePrev();
       }
     };
 
-    // keyup on Control = commit selection
+    // Commit selection when the primary modifier key is released
     this.keyupHandler = (e: KeyboardEvent) => {
       if (!this.visible) return;
-      if (e.key === 'Control') {
+      if (e.key === this.commitModifier) {
         e.preventDefault();
         this.commit();
       }

--- a/src/components/settings/shortcuts-tab.ts
+++ b/src/components/settings/shortcuts-tab.ts
@@ -116,14 +116,17 @@ export class ShortcutsTab implements SettingsTabProvider {
       if (conflict) {
         const conflictDef = DEFAULT_SHORTCUTS.find((d) => d.id === conflict);
         const conflictLabel = conflictDef?.label ?? conflict;
+        const currentChord = keybindingStore.getBinding(actionId);
         const proceed = confirm(
-          `"${formatChord(chord)}" is already bound to "${conflictLabel}".\n\nOverwrite? The conflicting shortcut will be reset to its default.`
+          `"${formatChord(chord)}" is already bound to "${conflictLabel}".\n\nSwap? "${conflictLabel}" will be reassigned to "${formatChord(currentChord)}".`
         );
         if (!proceed) {
           this.stopCapture();
           return;
         }
-        keybindingStore.resetBinding(conflict);
+        // Swap: give the conflicting action the current chord of the action being edited.
+        // This avoids shadow bindings where both actions claim the same chord.
+        keybindingStore.swapBinding(actionId, conflict);
       }
 
       keybindingStore.setBinding(actionId, chord);

--- a/src/state/keybinding-store.test.ts
+++ b/src/state/keybinding-store.test.ts
@@ -323,6 +323,50 @@ describe('KeybindingStore', () => {
     });
   });
 
+  describe('shadow binding detection', () => {
+    it('hasShadowBindings returns true when two actions share the same chord', () => {
+      const store = new KeybindingStore();
+      // Give split.splitRight the same chord as tabs.previousTab (Ctrl+Shift+Tab)
+      const prevTabChord = store.getBinding('tabs.previousTab');
+      store.setBinding('split.splitRight', prevTabChord);
+
+      // tabs.previousTab has a binding but it's not reachable via matchAction
+      expect(store.hasShadowBindings()).toBe(true);
+    });
+
+    it('getShadowedActions returns actions whose chord is overridden by another', () => {
+      const store = new KeybindingStore();
+      const prevTabChord = store.getBinding('tabs.previousTab');
+      store.setBinding('split.splitRight', prevTabChord);
+
+      const shadowed = store.getShadowedActions();
+      expect(shadowed).toContain('tabs.previousTab');
+      expect(shadowed).not.toContain('split.splitRight');
+    });
+
+    it('no shadow bindings exist with default shortcuts', () => {
+      const store = new KeybindingStore();
+      expect(store.hasShadowBindings()).toBe(false);
+    });
+
+    it('swapBinding correctly exchanges two actions chords', () => {
+      const store = new KeybindingStore();
+      const splitChord = store.getBinding('split.splitRight');  // Ctrl+\
+      const prevTabChord = store.getBinding('tabs.previousTab'); // Ctrl+Shift+Tab
+
+      store.swapBinding('split.splitRight', 'tabs.previousTab');
+
+      // After swap: split gets Ctrl+Shift+Tab, previousTab gets Ctrl+\
+      expect(chordToString(store.getBinding('split.splitRight'))).toBe(chordToString(prevTabChord));
+      expect(chordToString(store.getBinding('tabs.previousTab'))).toBe(chordToString(splitChord));
+
+      // Both should be reachable
+      expect(store.matchAction({ ...prevTabChord, type: 'keydown' })).toBe('split.splitRight');
+      expect(store.matchAction({ ...splitChord, type: 'keydown' })).toBe('tabs.previousTab');
+      expect(store.hasShadowBindings()).toBe(false);
+    });
+  });
+
   describe('subscribe', () => {
     it('notifies on setBinding', () => {
       const store = new KeybindingStore();

--- a/src/state/keybinding-store.ts
+++ b/src/state/keybinding-store.ts
@@ -513,6 +513,18 @@ export class KeybindingStore {
     this.notify();
   }
 
+  /** Swap the chords of two actions (no shadow bindings). */
+  swapBinding(actionA: ActionId, actionB: ActionId): void {
+    const chordA = this.bindings.get(actionA);
+    const chordB = this.bindings.get(actionB);
+    if (!chordA || !chordB) return;
+    this.bindings.set(actionA, { ...chordB });
+    this.bindings.set(actionB, { ...chordA });
+    this.rebuildIndex();
+    this.saveToStorage();
+    this.notify();
+  }
+
   /** Reset a single action to its default. */
   resetBinding(actionId: ActionId): void {
     const def = DEFAULT_SHORTCUTS.find((d) => d.id === actionId);
@@ -530,6 +542,31 @@ export class KeybindingStore {
     this.rebuildIndex();
     this.saveToStorage();
     this.notify();
+  }
+
+  /**
+   * Returns true if any action has a binding that is shadowed by another
+   * action (same chord, later in iteration order wins in the chordIndex).
+   */
+  hasShadowBindings(): boolean {
+    return this.getShadowedActions().length > 0;
+  }
+
+  /**
+   * Returns action IDs whose chord is overridden by another action in the
+   * chordIndex (the action has a chord, but matchAction would return a
+   * different action for that chord).
+   */
+  getShadowedActions(): ActionId[] {
+    const shadowed: ActionId[] = [];
+    for (const [actionId, chord] of this.bindings) {
+      const str = chordToString(chord);
+      const winner = this.chordIndex.get(str);
+      if (winner && winner !== actionId) {
+        shadowed.push(actionId);
+      }
+    }
+    return shadowed;
   }
 
   // ── Subscriptions ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix keybinding conflict resolution creating shadow bindings (unreachable actions)
- Fix RecencySwitcher hardcoding Ctrl+Tab for cycling and Ctrl release for commit

Fixes #635

## Test plan
- [x] 4 new unit tests for shadow binding detection and swap behavior
- [ ] Set a custom split hotkey that conflicts with Previous Tab → verify swap dialog and both actions work
- [ ] Customize tabs.nextTab to Alt+N → verify RecencySwitcher cycles and commits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)