### PR TITLE
feat: implement directional pane focus navigation with Alt+Arrow keys

### DIFF
--- a/changelog/unreleased/642-directional-pane-focus.md
+++ b/changelog/unreleased/642-directional-pane-focus.md
@@ -1,0 +1,2 @@
+### Added
+- **Directional pane focus navigation** — navigate between split panes using Alt+Arrow keys. Press Alt+Left/Right/Up/Down to move focus to the adjacent pane in that direction (#642)

--- a/src-tauri/native/app-adapter/src/shortcuts.rs
+++ b/src-tauri/native/app-adapter/src/shortcuts.rs
@@ -22,6 +22,10 @@ pub enum AppAction {
     SplitDown,
     Unsplit,
     FocusNextPane,
+    FocusLeft,
+    FocusRight,
+    FocusUp,
+    FocusDown,
     SelectAll,
     NextWorkspace,
     PrevWorkspace,
@@ -36,11 +40,12 @@ pub enum AppAction {
 /// Flat index order matching the categories in `shortcuts_tab.rs`.
 ///
 /// Tabs:       0=NewTab, 1=CloseTab, 2=NextTab, 3=PreviousTab, 4=RenameTab
-/// Split:      5=SplitRight, 6=SplitDown, 7=Unsplit, 8=FocusNextPane
-/// Clipboard:  9=Copy, 10=Paste, 11=SelectAll
-/// Scrollback: 12=ScrollPageUp, 13=ScrollPageDown, 14=ScrollToTop, 15=ScrollToBottom
-/// Zoom:       16=ZoomIn, 17=ZoomOut, 18=ZoomReset
-/// Workspaces: 19=NextWorkspace, 20=PrevWorkspace, 21=ToggleSidebar, 22=OpenSettings
+/// Split:      5=SplitRight, 6=SplitDown, 7=Unsplit, 8=FocusNextPane,
+///             9=FocusLeft, 10=FocusRight, 11=FocusUp, 12=FocusDown
+/// Clipboard:  13=Copy, 14=Paste, 15=SelectAll
+/// Scrollback: 16=ScrollPageUp, 17=ScrollPageDown, 18=ScrollToTop, 19=ScrollToBottom
+/// Zoom:       20=ZoomIn, 21=ZoomOut, 22=ZoomReset
+/// Workspaces: 23=NextWorkspace, 24=PrevWorkspace, 25=ToggleSidebar, 26=OpenSettings
 const FLAT_ACTION_ORDER: &[AppAction] = &[
     // Tabs
     AppAction::NewTab,
@@ -53,6 +58,10 @@ const FLAT_ACTION_ORDER: &[AppAction] = &[
     AppAction::SplitDown,
     AppAction::Unsplit,
     AppAction::FocusNextPane,
+    AppAction::FocusLeft,
+    AppAction::FocusRight,
+    AppAction::FocusUp,
+    AppAction::FocusDown,
     // Clipboard
     AppAction::Copy,
     AppAction::Paste,
@@ -339,6 +348,16 @@ fn check_named_shortcut(named: &Named, ctrl: bool, shift: bool, alt: bool) -> Op
     if !ctrl && !shift && !alt {
         return match named {
             Named::F2 => Some(AppAction::RenameTab),
+            _ => None,
+        };
+    }
+    // Alt (no Ctrl, no Shift) — directional pane focus.
+    if alt && !ctrl && !shift {
+        return match named {
+            Named::ArrowLeft => Some(AppAction::FocusLeft),
+            Named::ArrowRight => Some(AppAction::FocusRight),
+            Named::ArrowUp => Some(AppAction::FocusUp),
+            Named::ArrowDown => Some(AppAction::FocusDown),
             _ => None,
         };
     }
@@ -769,10 +788,10 @@ mod tests {
         );
     }
     #[test]
-    fn alt_right_alone_is_not_shortcut() {
+    fn alt_right_is_focus_right() {
         assert_eq!(
             check_app_shortcut(&named_key(Named::ArrowRight), alt()),
-            None
+            Some(AppAction::FocusRight)
         );
     }
     #[test]
@@ -859,6 +878,21 @@ mod tests {
     #[test]
     fn flat_index_7_is_unsplit() {
         assert_eq!(flat_index_to_action(7), Some(AppAction::Unsplit));
+    }
+
+    #[test]
+    fn flat_index_9_is_focus_left() {
+        assert_eq!(flat_index_to_action(9), Some(AppAction::FocusLeft));
+    }
+
+    #[test]
+    fn flat_index_12_is_focus_down() {
+        assert_eq!(flat_index_to_action(12), Some(AppAction::FocusDown));
+    }
+
+    #[test]
+    fn flat_index_13_is_copy() {
+        assert_eq!(flat_index_to_action(13), Some(AppAction::Copy));
     }
 
     #[test]
@@ -1111,6 +1145,42 @@ mod tests {
         assert_eq!(
             check_app_shortcut(&char_key("\x1c"), alt()),
             Some(AppAction::FocusNextPane),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Directional focus shortcut tests (#642)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn alt_left_is_focus_left() {
+        assert_eq!(
+            check_app_shortcut(&named_key(Named::ArrowLeft), alt()),
+            Some(AppAction::FocusLeft)
+        );
+    }
+
+    #[test]
+    fn alt_up_is_focus_up() {
+        assert_eq!(
+            check_app_shortcut(&named_key(Named::ArrowUp), alt()),
+            Some(AppAction::FocusUp)
+        );
+    }
+
+    #[test]
+    fn alt_down_is_focus_down() {
+        assert_eq!(
+            check_app_shortcut(&named_key(Named::ArrowDown), alt()),
+            Some(AppAction::FocusDown)
+        );
+    }
+
+    #[test]
+    fn alt_shift_arrow_is_not_shortcut() {
+        assert_eq!(
+            check_app_shortcut(&named_key(Named::ArrowRight), alt_shift()),
+            None
         );
     }
 }

--- a/src-tauri/native/features-shell/src/layout.rs
+++ b/src-tauri/native/features-shell/src/layout.rs
@@ -1,4 +1,4 @@
-use godly_layout_core::{LayoutNode, SplitDirection, SplitPlacement};
+use godly_layout_core::{FocusDirection, LayoutNode, SplitDirection, SplitPlacement};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SplitFocusedInput {
@@ -59,6 +59,18 @@ pub fn reduce_cycle_focus(
     let layout = layout?;
     let focused_terminal_id = focused_terminal_id?;
     layout.next_leaf_id(focused_terminal_id).map(str::to_string)
+}
+
+pub fn reduce_directional_focus(
+    layout: Option<&LayoutNode>,
+    focused_terminal_id: Option<&str>,
+    direction: FocusDirection,
+) -> Option<String> {
+    let layout = layout?;
+    let focused_terminal_id = focused_terminal_id?;
+    layout
+        .neighbor_in_direction(focused_terminal_id, direction)
+        .map(str::to_string)
 }
 
 /// Returns the terminal ID to focus when a pane is clicked,

--- a/src-tauri/native/features-shell/tests/directional_focus.rs
+++ b/src-tauri/native/features-shell/tests/directional_focus.rs
@@ -1,0 +1,143 @@
+use godly_features_shell::layout::reduce_directional_focus;
+use godly_layout_core::{FocusDirection, LayoutNode, SplitDirection};
+
+fn h_split(first: &str, second: &str) -> LayoutNode {
+    LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Leaf {
+            terminal_id: first.into(),
+        }),
+        second: Box::new(LayoutNode::Leaf {
+            terminal_id: second.into(),
+        }),
+    }
+}
+
+fn v_split(first: &str, second: &str) -> LayoutNode {
+    LayoutNode::Split {
+        direction: SplitDirection::Vertical,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Leaf {
+            terminal_id: first.into(),
+        }),
+        second: Box::new(LayoutNode::Leaf {
+            terminal_id: second.into(),
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Basic directional focus via reducer
+// ---------------------------------------------------------------------------
+
+#[test]
+fn h_split_focus_right() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-left"), FocusDirection::Right),
+        Some("t-right".into())
+    );
+}
+
+#[test]
+fn h_split_focus_left() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-right"), FocusDirection::Left),
+        Some("t-left".into())
+    );
+}
+
+#[test]
+fn v_split_focus_down() {
+    let layout = v_split("t-top", "t-bottom");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-top"), FocusDirection::Down),
+        Some("t-bottom".into())
+    );
+}
+
+#[test]
+fn v_split_focus_up() {
+    let layout = v_split("t-top", "t-bottom");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-bottom"), FocusDirection::Up),
+        Some("t-top".into())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-axis returns None
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v_split_focus_right_returns_none() {
+    let layout = v_split("t-top", "t-bottom");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-top"), FocusDirection::Right),
+        None
+    );
+}
+
+#[test]
+fn h_split_focus_down_returns_none() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-left"), FocusDirection::Down),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2x2 grid: directional navigation matches spatial positions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn grid_focus_right_from_top_left_goes_to_top_right() {
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(v_split("t-tl", "t-bl")),
+        second: Box::new(v_split("t-tr", "t-br")),
+    };
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-tl"), FocusDirection::Right),
+        Some("t-tr".into())
+    );
+}
+
+#[test]
+fn grid_focus_up_from_bottom_right_goes_to_top_right() {
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(v_split("t-tl", "t-bl")),
+        second: Box::new(v_split("t-tr", "t-br")),
+    };
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), Some("t-br"), FocusDirection::Up),
+        Some("t-tr".into())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases: None inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_layout_returns_none() {
+    assert_eq!(
+        reduce_directional_focus(None, Some("t-1"), FocusDirection::Right),
+        None
+    );
+}
+
+#[test]
+fn no_focused_returns_none() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        reduce_directional_focus(Some(&layout), None, FocusDirection::Right),
+        None
+    );
+}

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -23,7 +23,7 @@ use godly_app_adapter::sound::{self, NotificationSoundPreset};
 use godly_features_shell::layout as layout_reducer;
 use godly_features_shell::tabs as tab_reducer;
 use godly_features_shell::workspaces as workspace_reducer;
-use godly_layout_core::SplitPlacement;
+use godly_layout_core::{FocusDirection, SplitPlacement};
 use godly_protocol::types::RichGridData;
 use godly_protocol::McpResponse;
 
@@ -578,6 +578,11 @@ pub enum Message {
     UnsplitPane,
     /// Cycle focus to the next pane in the layout tree.
     FocusNextPane,
+    /// Move focus to the pane in a specific direction.
+    FocusLeft,
+    FocusRight,
+    FocusUp,
+    FocusDown,
     /// User clicked on a specific pane in the split layout.
     PaneClicked(String),
     /// User clicked a workspace in the sidebar.
@@ -1735,6 +1740,10 @@ impl GodlyApp {
             Message::FocusNextPane => {
                 self.cycle_focus();
             }
+            Message::FocusLeft => self.focus_in_direction(FocusDirection::Left),
+            Message::FocusRight => self.focus_in_direction(FocusDirection::Right),
+            Message::FocusUp => self.focus_in_direction(FocusDirection::Up),
+            Message::FocusDown => self.focus_in_direction(FocusDirection::Down),
             Message::PaneClicked(terminal_id) => {
                 if let Some(new_focus) =
                     layout_reducer::reduce_pane_clicked(self.active_layout(), &terminal_id)
@@ -4459,6 +4468,22 @@ impl GodlyApp {
                 self.cycle_focus();
                 Task::none()
             }
+            AppAction::FocusLeft => {
+                self.focus_in_direction(FocusDirection::Left);
+                Task::none()
+            }
+            AppAction::FocusRight => {
+                self.focus_in_direction(FocusDirection::Right);
+                Task::none()
+            }
+            AppAction::FocusUp => {
+                self.focus_in_direction(FocusDirection::Up);
+                Task::none()
+            }
+            AppAction::FocusDown => {
+                self.focus_in_direction(FocusDirection::Down);
+                Task::none()
+            }
             AppAction::SelectAll => {
                 self.select_all();
                 Task::none()
@@ -5662,6 +5687,20 @@ impl GodlyApp {
     fn cycle_focus(&mut self) {
         let next_id =
             layout_reducer::reduce_cycle_focus(self.active_layout(), self.active_focused());
+        if let Some(next_id) = next_id {
+            self.notifications.mark_read(&next_id);
+            if let Some(ws) = self.workspaces.active_mut() {
+                ws.focused_terminal = next_id;
+            }
+        }
+    }
+
+    fn focus_in_direction(&mut self, direction: FocusDirection) {
+        let next_id = layout_reducer::reduce_directional_focus(
+            self.active_layout(),
+            self.active_focused(),
+            direction,
+        );
         if let Some(next_id) = next_id {
             self.notifications.mark_read(&next_id);
             if let Some(ws) = self.workspaces.active_mut() {

--- a/src-tauri/native/iced-shell/src/shortcuts_tab.rs
+++ b/src-tauri/native/iced-shell/src/shortcuts_tab.rs
@@ -63,6 +63,22 @@ const SPLIT_PANES: &[ShortcutEntry] = &[
         action: "Focus Next Pane",
         keys: "Alt+\\",
     },
+    ShortcutEntry {
+        action: "Focus Left",
+        keys: "Alt+Left",
+    },
+    ShortcutEntry {
+        action: "Focus Right",
+        keys: "Alt+Right",
+    },
+    ShortcutEntry {
+        action: "Focus Up",
+        keys: "Alt+Up",
+    },
+    ShortcutEntry {
+        action: "Focus Down",
+        keys: "Alt+Down",
+    },
 ];
 
 const CLIPBOARD: &[ShortcutEntry] = &[

--- a/src-tauri/native/layout-core/src/lib.rs
+++ b/src-tauri/native/layout-core/src/lib.rs
@@ -40,6 +40,30 @@ pub enum SplitDirection {
     Vertical,
 }
 
+/// Direction for spatial pane focus navigation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl FocusDirection {
+    /// The split axis that this direction moves along.
+    pub fn split_direction(self) -> SplitDirection {
+        match self {
+            FocusDirection::Left | FocusDirection::Right => SplitDirection::Horizontal,
+            FocusDirection::Up | FocusDirection::Down => SplitDirection::Vertical,
+        }
+    }
+
+    /// Whether this direction moves toward the second child of a matching split.
+    pub fn moves_to_second(self) -> bool {
+        matches!(self, FocusDirection::Right | FocusDirection::Down)
+    }
+}
+
 /// A binary tree of terminal panes.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LayoutNode {
@@ -208,6 +232,48 @@ impl LayoutNode {
         let pos = ids.iter().position(|&id| id == current_id)?;
         let next_pos = (pos + 1) % ids.len();
         Some(ids[next_pos])
+    }
+
+    /// Returns the leftmost/topmost leaf ID (first in depth-first order).
+    pub fn first_leaf_id(&self) -> &str {
+        match self {
+            LayoutNode::Leaf { terminal_id } => terminal_id,
+            LayoutNode::Split { first, .. } => first.first_leaf_id(),
+        }
+    }
+
+    /// Returns the rightmost/bottommost leaf ID (last in depth-first order).
+    pub fn last_leaf_id(&self) -> &str {
+        match self {
+            LayoutNode::Leaf { terminal_id } => terminal_id,
+            LayoutNode::Split { second, .. } => second.last_leaf_id(),
+        }
+    }
+
+    /// Returns the spatial neighbor of `current_id` in the given direction,
+    /// or `None` if there is no neighbor in that direction.
+    pub fn neighbor_in_direction(&self, current_id: &str, direction: FocusDirection) -> Option<&str> {
+        match self {
+            LayoutNode::Leaf { .. } => None,
+            LayoutNode::Split {
+                direction: split_dir,
+                first,
+                second,
+                ..
+            } => {
+                if *split_dir == direction.split_direction() {
+                    if direction.moves_to_second() && first.find_leaf(current_id) {
+                        return Some(second.first_leaf_id());
+                    }
+                    if !direction.moves_to_second() && second.find_leaf(current_id) {
+                        return Some(first.last_leaf_id());
+                    }
+                }
+                first
+                    .neighbor_in_direction(current_id, direction)
+                    .or_else(|| second.neighbor_in_direction(current_id, direction))
+            }
+        }
     }
 }
 

--- a/src-tauri/native/layout-core/tests/directional_focus.rs
+++ b/src-tauri/native/layout-core/tests/directional_focus.rs
@@ -1,0 +1,284 @@
+use godly_layout_core::{FocusDirection, LayoutNode, SplitDirection};
+
+fn h_split(first: &str, second: &str) -> LayoutNode {
+    LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Leaf {
+            terminal_id: first.into(),
+        }),
+        second: Box::new(LayoutNode::Leaf {
+            terminal_id: second.into(),
+        }),
+    }
+}
+
+fn v_split(first: &str, second: &str) -> LayoutNode {
+    LayoutNode::Split {
+        direction: SplitDirection::Vertical,
+        ratio: 0.5,
+        first: Box::new(LayoutNode::Leaf {
+            terminal_id: first.into(),
+        }),
+        second: Box::new(LayoutNode::Leaf {
+            terminal_id: second.into(),
+        }),
+    }
+}
+
+fn leaf(id: &str) -> LayoutNode {
+    LayoutNode::Leaf {
+        terminal_id: id.into(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Horizontal split: [t-left | t-right]
+// ---------------------------------------------------------------------------
+
+#[test]
+fn h_split_focus_right_from_left() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        layout.neighbor_in_direction("t-left", FocusDirection::Right),
+        Some("t-right")
+    );
+}
+
+#[test]
+fn h_split_focus_left_from_right() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        layout.neighbor_in_direction("t-right", FocusDirection::Left),
+        Some("t-left")
+    );
+}
+
+#[test]
+fn h_split_focus_right_from_right_is_none() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        layout.neighbor_in_direction("t-right", FocusDirection::Right),
+        None
+    );
+}
+
+#[test]
+fn h_split_focus_left_from_left_is_none() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        layout.neighbor_in_direction("t-left", FocusDirection::Left),
+        None
+    );
+}
+
+#[test]
+fn h_split_no_vertical_neighbors() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        layout.neighbor_in_direction("t-left", FocusDirection::Up),
+        None
+    );
+    assert_eq!(
+        layout.neighbor_in_direction("t-left", FocusDirection::Down),
+        None
+    );
+    assert_eq!(
+        layout.neighbor_in_direction("t-right", FocusDirection::Up),
+        None
+    );
+    assert_eq!(
+        layout.neighbor_in_direction("t-right", FocusDirection::Down),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Vertical split: [t-top / t-bottom]
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v_split_focus_down_from_top() {
+    let layout = v_split("t-top", "t-bottom");
+    assert_eq!(
+        layout.neighbor_in_direction("t-top", FocusDirection::Down),
+        Some("t-bottom")
+    );
+}
+
+#[test]
+fn v_split_focus_up_from_bottom() {
+    let layout = v_split("t-top", "t-bottom");
+    assert_eq!(
+        layout.neighbor_in_direction("t-bottom", FocusDirection::Up),
+        Some("t-top")
+    );
+}
+
+#[test]
+fn v_split_no_horizontal_neighbors() {
+    let layout = v_split("t-top", "t-bottom");
+    assert_eq!(
+        layout.neighbor_in_direction("t-top", FocusDirection::Left),
+        None
+    );
+    assert_eq!(
+        layout.neighbor_in_direction("t-top", FocusDirection::Right),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Nested: [t-left | (V) [t-top-right / t-bottom-right]]
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_focus_right_enters_first_leaf_of_subtree() {
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(leaf("t-left")),
+        second: Box::new(v_split("t-top-right", "t-bottom-right")),
+    };
+    assert_eq!(
+        layout.neighbor_in_direction("t-left", FocusDirection::Right),
+        Some("t-top-right")
+    );
+}
+
+#[test]
+fn nested_focus_left_from_subtree_returns_left_pane() {
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(leaf("t-left")),
+        second: Box::new(v_split("t-top-right", "t-bottom-right")),
+    };
+    assert_eq!(
+        layout.neighbor_in_direction("t-top-right", FocusDirection::Left),
+        Some("t-left")
+    );
+    assert_eq!(
+        layout.neighbor_in_direction("t-bottom-right", FocusDirection::Left),
+        Some("t-left")
+    );
+}
+
+#[test]
+fn nested_focus_down_within_subtree() {
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(leaf("t-left")),
+        second: Box::new(v_split("t-top-right", "t-bottom-right")),
+    };
+    assert_eq!(
+        layout.neighbor_in_direction("t-top-right", FocusDirection::Down),
+        Some("t-bottom-right")
+    );
+}
+
+#[test]
+fn nested_focus_up_from_left_is_none() {
+    let layout = LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(leaf("t-left")),
+        second: Box::new(v_split("t-top-right", "t-bottom-right")),
+    };
+    assert_eq!(
+        layout.neighbor_in_direction("t-left", FocusDirection::Up),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2x2 grid: (H) [(V) [t-tl / t-bl], (V) [t-tr / t-br]]
+//
+// Visual:  t-tl | t-tr
+//          -----+-----
+//          t-bl | t-br
+// ---------------------------------------------------------------------------
+
+fn grid_layout() -> LayoutNode {
+    LayoutNode::Split {
+        direction: SplitDirection::Horizontal,
+        ratio: 0.5,
+        first: Box::new(v_split("t-tl", "t-bl")),
+        second: Box::new(v_split("t-tr", "t-br")),
+    }
+}
+
+#[test]
+fn grid_focus_right_from_top_left() {
+    assert_eq!(
+        grid_layout().neighbor_in_direction("t-tl", FocusDirection::Right),
+        Some("t-tr")
+    );
+}
+
+#[test]
+fn grid_focus_down_from_top_left() {
+    assert_eq!(
+        grid_layout().neighbor_in_direction("t-tl", FocusDirection::Down),
+        Some("t-bl")
+    );
+}
+
+#[test]
+fn grid_focus_left_from_top_right() {
+    assert_eq!(
+        grid_layout().neighbor_in_direction("t-tr", FocusDirection::Left),
+        Some("t-bl")
+    );
+}
+
+#[test]
+fn grid_focus_up_from_bottom_right() {
+    assert_eq!(
+        grid_layout().neighbor_in_direction("t-br", FocusDirection::Up),
+        Some("t-tr")
+    );
+}
+
+#[test]
+fn grid_focus_left_from_bottom_left_is_none() {
+    assert_eq!(
+        grid_layout().neighbor_in_direction("t-bl", FocusDirection::Left),
+        None
+    );
+}
+
+#[test]
+fn grid_focus_down_from_bottom_left_is_none() {
+    assert_eq!(
+        grid_layout().neighbor_in_direction("t-bl", FocusDirection::Down),
+        None
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Single leaf — all directions return None
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_leaf_all_directions_none() {
+    let layout = leaf("t-only");
+    assert_eq!(layout.neighbor_in_direction("t-only", FocusDirection::Left), None);
+    assert_eq!(layout.neighbor_in_direction("t-only", FocusDirection::Right), None);
+    assert_eq!(layout.neighbor_in_direction("t-only", FocusDirection::Up), None);
+    assert_eq!(layout.neighbor_in_direction("t-only", FocusDirection::Down), None);
+}
+
+// ---------------------------------------------------------------------------
+// Missing ID returns None
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_id_returns_none() {
+    let layout = h_split("t-left", "t-right");
+    assert_eq!(
+        layout.neighbor_in_direction("missing", FocusDirection::Right),
+        None
+    );
+}


### PR DESCRIPTION
## Summary

Implement Alt+Left/Right/Up/Down keybindings to navigate focus between adjacent panes in split layouts.

## Changes

- **layout-core**: Add `FocusDirection` enum and neighbor finding algorithm to traverse split layout trees
- **app-adapter**: Add `FocusLeft/Right/Up/Down` action variants and Alt+Arrow key bindings
- **features-shell**: Add `reduce_directional_focus()` reducer for focus state updates
- **iced-shell**: Add focus navigation message handlers and message dispatch
- **shortcuts_tab**: Add UI entries for 4 new directional focus actions
- **tests**: Comprehensive test suites for layout traversal and focus behavior

## Testing

- 29 layout-core tests covering tree traversal and neighbor detection
- 10 features-shell tests covering reducer state updates
- 63 features-shell integration tests
- 140 app-adapter tests
- iced-shell compiles successfully

fixes #642