### PR TITLE
fix: disk leak — add runtime log rotation and screenshot cleanup

### DIFF
--- a/changelog/unreleased/fix-disk-leaks-log-rotation-screenshot-cleanup.md
+++ b/changelog/unreleased/fix-disk-leaks-log-rotation-screenshot-cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+- **Daemon and MCP debug log disk leaks** — Added runtime log rotation at 2MB with `.prev.log` backup, preventing unbounded log file growth. Previously logs only rotated at startup. Both daemon and MCP processes now track bytes written and rotate proactively.
+- **Screenshot temp file accumulation** — Added cleanup of screenshot temp files older than 1 hour at the start of screenshot encoding. Temp directory (`%TEMP%/godly-screenshots/`) is now cleaned best-effort, preventing disk space exhaustion from long-running instances.

--- a/src-tauri/daemon/src/debug_log.rs
+++ b/src-tauri/daemon/src/debug_log.rs
@@ -1,9 +1,17 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-static LOG_FILE: OnceLock<Mutex<File>> = OnceLock::new();
+struct LogState {
+    file: File,
+    path: PathBuf,
+    prev_path: PathBuf,
+    bytes_written: u64,
+}
+
+static LOG_FILE: OnceLock<Mutex<LogState>> = OnceLock::new();
 static START_TIME: OnceLock<Instant> = OnceLock::new();
 
 /// Maximum log file size before rotation (2MB).
@@ -41,6 +49,9 @@ pub fn init() {
         }
     }
 
+    // Read current file size so bytes_written starts correct (we append)
+    let initial_size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
     let file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -48,16 +59,32 @@ pub fn init() {
 
     match file {
         Ok(f) => {
-            LOG_FILE.get_or_init(|| Mutex::new(f));
+            LOG_FILE.get_or_init(|| {
+                Mutex::new(LogState {
+                    file: f,
+                    path: path.clone(),
+                    prev_path: prev_path.clone(),
+                    bytes_written: initial_size,
+                })
+            });
         }
         Err(e) => {
-            let fallback = std::env::temp_dir().join("godly-daemon-debug.log");
+            let fallback_path = std::env::temp_dir().join("godly-daemon-debug.log");
+            let fallback_prev = std::env::temp_dir().join("godly-daemon-debug.prev.log");
             if let Ok(f) = OpenOptions::new()
                 .create(true)
                 .append(true)
-                .open(&fallback)
+                .open(&fallback_path)
             {
-                LOG_FILE.get_or_init(|| Mutex::new(f));
+                let initial = fs::metadata(&fallback_path).map(|m| m.len()).unwrap_or(0);
+                LOG_FILE.get_or_init(|| {
+                    Mutex::new(LogState {
+                        file: f,
+                        path: fallback_path,
+                        prev_path: fallback_prev,
+                        bytes_written: initial,
+                    })
+                });
             } else {
                 eprintln!("[daemon] Failed to open debug log: {}", e);
             }
@@ -102,7 +129,7 @@ pub fn install_panic_hook() {
 /// Write a log line with timestamp (wall clock + monotonic elapsed).
 pub fn log(msg: &str) {
     if let Some(mutex) = LOG_FILE.get() {
-        if let Ok(mut file) = mutex.lock() {
+        if let Ok(mut state) = mutex.lock() {
             let ts = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default();
@@ -110,16 +137,35 @@ pub fn log(msg: &str) {
                 .get()
                 .map(|s| s.elapsed())
                 .unwrap_or_default();
-            let _ = writeln!(
-                file,
-                "[{}.{:03}] [{:>8.3}s] {}",
+            let line = format!(
+                "[{}.{:03}] [{:>8.3}s] {}\n",
                 ts.as_secs(),
                 ts.subsec_millis(),
                 elapsed.as_secs_f64(),
                 msg
             );
-            let _ = file.flush();
+            let _ = state.file.write_all(line.as_bytes());
+            let _ = state.file.flush();
+            state.bytes_written += line.len() as u64;
+
+            if state.bytes_written > MAX_LOG_SIZE {
+                rotate(&mut state);
+            }
         }
+    }
+}
+
+/// Rotate: copy current → .prev.log, truncate current, reset counter.
+fn rotate(state: &mut LogState) {
+    let _ = fs::copy(&state.path, &state.prev_path);
+    let _ = fs::remove_file(&state.path);
+    if let Ok(f) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&state.path)
+    {
+        state.file = f;
+        state.bytes_written = 0;
     }
 }
 
@@ -155,12 +201,12 @@ pub fn install_exception_handler() {
 
         // Use try_lock to avoid deadlock if exception occurs during logging
         if let Some(mutex) = LOG_FILE.get() {
-            if let Ok(mut file) = mutex.try_lock() {
+            if let Ok(mut state) = mutex.try_lock() {
                 let ts = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default();
                 let _ = writeln!(
-                    file,
+                    state.file,
                     "[{}.{:03}] FATAL EXCEPTION: code=0x{:08X} ({}) address=0x{:X}",
                     ts.as_secs(),
                     ts.subsec_millis(),
@@ -168,7 +214,7 @@ pub fn install_exception_handler() {
                     code_name,
                     address
                 );
-                let _ = file.flush();
+                let _ = state.file.flush();
             }
         }
 

--- a/src-tauri/mcp/src/log.rs
+++ b/src-tauri/mcp/src/log.rs
@@ -1,9 +1,20 @@
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-static LOG_FILE: OnceLock<Mutex<File>> = OnceLock::new();
+struct LogState {
+    file: File,
+    path: PathBuf,
+    prev_path: PathBuf,
+    bytes_written: u64,
+}
+
+static LOG_FILE: OnceLock<Mutex<LogState>> = OnceLock::new();
+
+/// Maximum log file size before rotation (2MB).
+const MAX_LOG_SIZE: u64 = 2 * 1024 * 1024;
 
 /// Initialize the file logger. Logs to `godly-mcp.log` next to the binary,
 /// falling back to the system temp directory.
@@ -13,6 +24,18 @@ pub fn init() {
         .and_then(|p| p.parent().map(|d| d.join("godly-mcp.log")))
         .unwrap_or_else(|| std::env::temp_dir().join("godly-mcp.log"));
 
+    let prev_path = path.with_extension("prev.log");
+
+    // Rotate if the log file is too large
+    if let Ok(meta) = fs::metadata(&path) {
+        if meta.len() > MAX_LOG_SIZE {
+            let _ = fs::copy(&path, &prev_path);
+            let _ = fs::remove_file(&path);
+        }
+    }
+
+    let initial_size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
     let file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -20,13 +43,29 @@ pub fn init() {
 
     match file {
         Ok(f) => {
-            LOG_FILE.get_or_init(|| Mutex::new(f));
+            LOG_FILE.get_or_init(|| {
+                Mutex::new(LogState {
+                    file: f,
+                    path: path.clone(),
+                    prev_path: prev_path.clone(),
+                    bytes_written: initial_size,
+                })
+            });
         }
         Err(e) => {
             // Last resort: try temp dir if we haven't already
-            let fallback = std::env::temp_dir().join("godly-mcp.log");
-            if let Ok(f) = OpenOptions::new().create(true).append(true).open(&fallback) {
-                LOG_FILE.get_or_init(|| Mutex::new(f));
+            let fallback_path = std::env::temp_dir().join("godly-mcp.log");
+            let fallback_prev = fallback_path.with_extension("prev.log");
+            if let Ok(f) = OpenOptions::new().create(true).append(true).open(&fallback_path) {
+                let initial = fs::metadata(&fallback_path).map(|m| m.len()).unwrap_or(0);
+                LOG_FILE.get_or_init(|| {
+                    Mutex::new(LogState {
+                        file: f,
+                        path: fallback_path,
+                        prev_path: fallback_prev,
+                        bytes_written: initial,
+                    })
+                });
             } else {
                 eprintln!("[godly-mcp] Failed to open log file: {}", e);
             }
@@ -37,15 +76,38 @@ pub fn init() {
 /// Write a log line with a timestamp.
 pub fn log(msg: &str) {
     if let Some(mutex) = LOG_FILE.get() {
-        if let Ok(mut file) = mutex.lock() {
+        if let Ok(mut state) = mutex.lock() {
             let ts = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default();
-            let secs = ts.as_secs();
-            let millis = ts.subsec_millis();
-            let _ = writeln!(file, "[{}.{:03}] {}", secs, millis, msg);
-            let _ = file.flush();
+            let line = format!(
+                "[{}.{:03}] {}\n",
+                ts.as_secs(),
+                ts.subsec_millis(),
+                msg
+            );
+            let _ = state.file.write_all(line.as_bytes());
+            let _ = state.file.flush();
+            state.bytes_written += line.len() as u64;
+
+            if state.bytes_written > MAX_LOG_SIZE {
+                rotate(&mut state);
+            }
         }
+    }
+}
+
+/// Rotate: copy current → .prev.log, truncate current, reset counter.
+fn rotate(state: &mut LogState) {
+    let _ = fs::copy(&state.path, &state.prev_path);
+    let _ = fs::remove_file(&state.path);
+    if let Ok(f) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&state.path)
+    {
+        state.file = f;
+        state.bytes_written = 0;
     }
 }
 

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -2738,6 +2738,21 @@ impl GodlyApp {
             };
         }
 
+        // Clean up screenshots older than 1 hour (best-effort)
+        let one_hour = std::time::Duration::from_secs(3600);
+        if let Ok(entries) = std::fs::read_dir(&temp_dir) {
+            let now = std::time::SystemTime::now();
+            for entry in entries.flatten() {
+                if let Ok(meta) = entry.metadata() {
+                    if let Ok(modified) = meta.modified() {
+                        if now.duration_since(modified).unwrap_or_default() > one_hour {
+                            let _ = std::fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+        }
+
         let id = uuid::Uuid::new_v4();
         let path = temp_dir.join(format!("screenshot-{}.png", &id.to_string()[..8]));
 


### PR DESCRIPTION
## Summary

Fixed three sources of disk space leaks in long-running instances:

1. **Daemon debug log rotation** — `src-tauri/daemon/src/debug_log.rs`
   - Changed from `OnceLock<Mutex<File>>` to `OnceLock<Mutex<LogState>>` tracking file handle, paths, and bytes_written
   - `log()` function now rotates (copy → .prev.log, reopen fresh) when exceeding 2MB
   - Previously rotation only ran at startup; now proactive runtime rotation prevents unbounded growth

2. **MCP log rotation** — `src-tauri/mcp/src/log.rs`
   - Added identical LogState + rotation pattern
   - Previously had zero rotation—pure append with no size check
   - Now rotates at 2MB threshold with .prev.log backup

3. **Screenshot temp file cleanup** — `src-tauri/native/iced-shell/src/app.rs`
   - Added cleanup of files older than 1 hour at the start of `encode_screenshot_to_file`
   - Iterates `%TEMP%/godly-screenshots/`, checks modified time, deletes old files
   - Best-effort (errors silently ignored) to prevent disk space exhaustion

All 3 crates compile successfully: godly-daemon, godly-mcp, godly-iced-shell.

## Testing

- Verify daemon/MCP logs rotate at 2MB and .prev.log backup is created
- Run long-term instance and confirm old screenshots are cleaned up
- Monitor disk usage of long-running staging instance