### PR TITLE
fix: use workspace folder_path as cwd when creating terminals

### DIFF
--- a/changelog/unreleased/fix-terminal-cwd-workspace-path.md
+++ b/changelog/unreleased/fix-terminal-cwd-workspace-path.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Terminal creation working directory** — new terminals now open in the workspace's `folder_path` instead of defaulting to the app process's cwd

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -5666,7 +5666,11 @@ impl GodlyApp {
     }
 
     fn create_terminal_task(&self, session_id: String) -> Task<Message> {
-        self.create_terminal_task_with_cwd(session_id, None)
+        let cwd = self
+            .workspaces
+            .active()
+            .map(|ws| ws.folder_path.clone());
+        self.create_terminal_task_with_cwd(session_id, cwd)
     }
 
     fn create_terminal_task_with_cwd(


### PR DESCRIPTION
## Summary

When creating a new terminal in a workspace, the terminal's working directory now defaults to the workspace's configured `folder_path` instead of the app process's working directory.

## Changes

- Updated `create_terminal_task()` in `src-tauri/native/iced-shell/src/app.rs` to look up the active workspace and pass its `folder_path` as the cwd when creating terminals
- Added changelog fragment documenting the fix

## Testing

Verify that new terminals open in the correct workspace directory.