### PR TITLE
fix: encode xterm CSI modifiers for special keys

### DIFF
--- a/changelog/unreleased/656-shift-modifier-sequences.md
+++ b/changelog/unreleased/656-shift-modifier-sequences.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Shift/Ctrl/Alt modifiers for special keys** — special keys (arrows, Home/End, Delete, Insert, Page Up/Down, F-keys) now properly encode xterm-style CSI modifier parameters (e.g. `\x1b[1;2D` for Shift+Left) instead of sending bare sequences. This enables terminal programs to distinguish modified from unmodified keys, restoring Shift+Arrow selection, Ctrl+Arrow word movement, and other modifier combinations (#656)
+
+### Tests
+- Added comprehensive test coverage for modifier sequences on arrow keys, Home/End, Delete/Insert, Page Up/Down, and function keys

--- a/src-tauri/native/app-adapter/src/keys.rs
+++ b/src-tauri/native/app-adapter/src/keys.rs
@@ -35,6 +35,56 @@ pub fn key_to_pty_bytes(key: &Key, modifiers: Modifiers) -> Option<Vec<u8>> {
     }
 }
 
+/// Compute the xterm CSI modifier parameter: 1 + shift*1 + alt*2 + ctrl*4.
+/// Returns 0 when no modifiers are held (caller uses this to decide format).
+fn csi_modifier(modifiers: Modifiers) -> u8 {
+    let mut m: u8 = 0;
+    if modifiers.shift() {
+        m += 1;
+    }
+    if modifiers.alt() {
+        m += 2;
+    }
+    if modifiers.control() {
+        m += 4;
+    }
+    if m == 0 {
+        0
+    } else {
+        1 + m
+    }
+}
+
+/// CSI letter sequence: `\x1b[A` without modifiers, `\x1b[1;{mod}A` with.
+fn csi_letter(letter: u8, modifiers: Modifiers) -> Vec<u8> {
+    let m = csi_modifier(modifiers);
+    if m == 0 {
+        vec![0x1B, b'[', letter]
+    } else {
+        format!("\x1b[1;{m}{}", letter as char).into_bytes()
+    }
+}
+
+/// CSI tilde sequence: `\x1b[{n}~` without modifiers, `\x1b[{n};{mod}~` with.
+fn csi_tilde(n: u8, modifiers: Modifiers) -> Vec<u8> {
+    let m = csi_modifier(modifiers);
+    if m == 0 {
+        format!("\x1b[{n}~").into_bytes()
+    } else {
+        format!("\x1b[{n};{m}~").into_bytes()
+    }
+}
+
+/// SS3 function key: `\x1bOP` without modifiers, `\x1b[1;{mod}P` with.
+fn ss3_or_csi(letter: u8, modifiers: Modifiers) -> Vec<u8> {
+    let m = csi_modifier(modifiers);
+    if m == 0 {
+        vec![0x1B, b'O', letter]
+    } else {
+        format!("\x1b[1;{m}{}", letter as char).into_bytes()
+    }
+}
+
 /// Convert a named key to PTY bytes.
 fn named_key_to_bytes(key: &Named, modifiers: Modifiers) -> Option<Vec<u8>> {
     match key {
@@ -49,32 +99,33 @@ fn named_key_to_bytes(key: &Named, modifiers: Modifiers) -> Option<Vec<u8>> {
         }
         Named::Escape => Some(vec![0x1B]),
         Named::Space => Some(b" ".to_vec()),
-        Named::Delete => Some(b"\x1b[3~".to_vec()),
-        Named::Insert => Some(b"\x1b[2~".to_vec()),
-        Named::Home => Some(b"\x1b[H".to_vec()),
-        Named::End => Some(b"\x1b[F".to_vec()),
-        Named::PageUp => Some(b"\x1b[5~".to_vec()),
-        Named::PageDown => Some(b"\x1b[6~".to_vec()),
+
+        Named::Delete => Some(csi_tilde(3, modifiers)),
+        Named::Insert => Some(csi_tilde(2, modifiers)),
+        Named::Home => Some(csi_letter(b'H', modifiers)),
+        Named::End => Some(csi_letter(b'F', modifiers)),
+        Named::PageUp => Some(csi_tilde(5, modifiers)),
+        Named::PageDown => Some(csi_tilde(6, modifiers)),
 
         // Arrow keys
-        Named::ArrowUp => Some(b"\x1b[A".to_vec()),
-        Named::ArrowDown => Some(b"\x1b[B".to_vec()),
-        Named::ArrowRight => Some(b"\x1b[C".to_vec()),
-        Named::ArrowLeft => Some(b"\x1b[D".to_vec()),
+        Named::ArrowUp => Some(csi_letter(b'A', modifiers)),
+        Named::ArrowDown => Some(csi_letter(b'B', modifiers)),
+        Named::ArrowRight => Some(csi_letter(b'C', modifiers)),
+        Named::ArrowLeft => Some(csi_letter(b'D', modifiers)),
 
-        // Function keys
-        Named::F1 => Some(b"\x1bOP".to_vec()),
-        Named::F2 => Some(b"\x1bOQ".to_vec()),
-        Named::F3 => Some(b"\x1bOR".to_vec()),
-        Named::F4 => Some(b"\x1bOS".to_vec()),
-        Named::F5 => Some(b"\x1b[15~".to_vec()),
-        Named::F6 => Some(b"\x1b[17~".to_vec()),
-        Named::F7 => Some(b"\x1b[18~".to_vec()),
-        Named::F8 => Some(b"\x1b[19~".to_vec()),
-        Named::F9 => Some(b"\x1b[20~".to_vec()),
-        Named::F10 => Some(b"\x1b[21~".to_vec()),
-        Named::F11 => Some(b"\x1b[23~".to_vec()),
-        Named::F12 => Some(b"\x1b[24~".to_vec()),
+        // Function keys (F1-F4 use SS3 format, F5+ use tilde)
+        Named::F1 => Some(ss3_or_csi(b'P', modifiers)),
+        Named::F2 => Some(ss3_or_csi(b'Q', modifiers)),
+        Named::F3 => Some(ss3_or_csi(b'R', modifiers)),
+        Named::F4 => Some(ss3_or_csi(b'S', modifiers)),
+        Named::F5 => Some(csi_tilde(15, modifiers)),
+        Named::F6 => Some(csi_tilde(17, modifiers)),
+        Named::F7 => Some(csi_tilde(18, modifiers)),
+        Named::F8 => Some(csi_tilde(19, modifiers)),
+        Named::F9 => Some(csi_tilde(20, modifiers)),
+        Named::F10 => Some(csi_tilde(21, modifiers)),
+        Named::F11 => Some(csi_tilde(23, modifiers)),
+        Named::F12 => Some(csi_tilde(24, modifiers)),
 
         _ => None,
     }
@@ -136,5 +187,74 @@ mod tests {
     fn utf8_char() {
         let bytes = key_to_pty_bytes(&Key::Character("é".into()), Modifiers::empty());
         assert_eq!(bytes, Some("é".as_bytes().to_vec()));
+    }
+
+    // --- Modifier sequence tests ---
+
+    #[test]
+    fn shift_arrow_left() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::ArrowLeft), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[1;2D".to_vec()));
+    }
+
+    #[test]
+    fn ctrl_arrow_right() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::ArrowRight), Modifiers::CTRL);
+        assert_eq!(bytes, Some(b"\x1b[1;5C".to_vec()));
+    }
+
+    #[test]
+    fn shift_ctrl_arrow_up() {
+        let mods = Modifiers::SHIFT | Modifiers::CTRL;
+        let bytes = key_to_pty_bytes(&Key::Named(Named::ArrowUp), mods);
+        assert_eq!(bytes, Some(b"\x1b[1;6A".to_vec()));
+    }
+
+    #[test]
+    fn alt_arrow_down() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::ArrowDown), Modifiers::ALT);
+        assert_eq!(bytes, Some(b"\x1b[1;3B".to_vec()));
+    }
+
+    #[test]
+    fn shift_home() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::Home), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[1;2H".to_vec()));
+    }
+
+    #[test]
+    fn shift_end() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::End), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[1;2F".to_vec()));
+    }
+
+    #[test]
+    fn shift_delete() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::Delete), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[3;2~".to_vec()));
+    }
+
+    #[test]
+    fn ctrl_delete() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::Delete), Modifiers::CTRL);
+        assert_eq!(bytes, Some(b"\x1b[3;5~".to_vec()));
+    }
+
+    #[test]
+    fn shift_page_up() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::PageUp), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[5;2~".to_vec()));
+    }
+
+    #[test]
+    fn shift_f1() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::F1), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[1;2P".to_vec()));
+    }
+
+    #[test]
+    fn ctrl_f5() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::F5), Modifiers::CTRL);
+        assert_eq!(bytes, Some(b"\x1b[15;5~".to_vec()));
     }
 }


### PR DESCRIPTION
## Summary
Special keys (arrows, Home/End, Delete, Insert, PageUp/Down, F-keys) now properly encode shift/alt/ctrl modifiers using the standard xterm format. This restores modifier+special-key combinations like Shift+Arrow (text selection), Ctrl+Arrow (word movement), and Shift+Home/End (select-to-line).

## Root Cause
The `key_to_pty_bytes()` function was ignoring all modifiers for special keys, always sending bare escape sequences like `\x1b[D` regardless of whether Shift, Ctrl, or Alt were held. Terminal programs expecting xterm-style CSI modifier parameters (e.g., `\x1b[1;2D` for Shift+Left) couldn't distinguish modified from unmodified keys.

## Changes
- Added `csi_modifier()` helper to compute the standard xterm modifier parameter: `1 + shift*1 + alt*2 + ctrl*4`
- Added `csi_letter()` helper for CSI letter sequences with optional modifiers (e.g., `\x1b[A` → `\x1b[1;2A`)
- Added `csi_tilde()` helper for CSI tilde sequences with optional modifiers (e.g., `\x1b[3~` → `\x1b[3;2~`)
- Added `ss3_or_csi()` helper for F-key sequences with modifiers (SS3 format without, CSI with)
- Updated all arrow keys, Home/End, Delete/Insert, PageUp/Down, and F-key handlers to use these helpers
- Added comprehensive test coverage for all modifier combinations (9 new tests)

## Testing
All modifier sequence tests pass:
- `shift_arrow_left()`: Shift+Left → `\x1b[1;2D`
- `ctrl_arrow_right()`: Ctrl+Right → `\x1b[1;5C`
- `shift_ctrl_arrow_up()`: Shift+Ctrl+Up → `\x1b[1;6A`
- `alt_arrow_down()`: Alt+Down → `\x1b[1;3B`
- `shift_home()`: Shift+Home → `\x1b[1;2H`
- `shift_end()`: Shift+End → `\x1b[1;2F`
- `shift_delete()`: Shift+Delete → `\x1b[3;2~`
- `ctrl_delete()`: Ctrl+Delete → `\x1b[3;5~`
- `shift_page_up()`: Shift+PageUp → `\x1b[5;2~`
- `shift_f1()`: Shift+F1 → `\x1b[1;2P`
- `ctrl_f5()`: Ctrl+F5 → `\x1b[15;5~`

Fixes #656