### PR TITLE
fix: terminal viewport should not extend behind status bar

### DIFF
--- a/changelog/unreleased/fix-terminal-status-bar-viewport.md
+++ b/changelog/unreleased/fix-terminal-status-bar-viewport.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Terminal content area clipped behind status bar** — terminal viewport now correctly subtracts the 20px status bar height, preventing the last line of terminal output from being hidden behind the bottom status bar

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -6594,11 +6594,12 @@ fn resolve_terminal_empty_state(
 
 fn terminal_content_rect(window_width: f32, window_height: f32, sidebar_width: f32) -> PaneRect {
     let top = title_bar::TITLE_BAR_HEIGHT + TAB_BAR_HEIGHT;
+    let bottom = status_bar::STATUS_BAR_HEIGHT;
     PaneRect::new(
         sidebar_width.max(0.0),
         top,
         (window_width - sidebar_width).max(1.0),
-        (window_height - top).max(1.0),
+        (window_height - top - bottom).max(1.0),
     )
 }
 


### PR DESCRIPTION
## Summary
- Terminal viewport now correctly subtracts the 20px status bar height from the calculation
- Fixes terminal content area clipping behind the bottom status bar
- Prevents the last line of terminal output from being hidden

## Changes
- Modified `terminal_content_rect()` function to include status bar height in viewport height calculation
- Added changelog fragment documenting the fix