### PR TITLE
refactor: remove dead code from daemon crate

### DIFF
--- a/src-tauri/daemon/src/pid.rs
+++ b/src-tauri/daemon/src/pid.rs
@@ -27,61 +27,6 @@ pub fn remove_pid_file() {
     let _ = fs::remove_file(path);
 }
 
-/// Check if the daemon is already running by attempting to connect to its named pipe.
-/// This is more reliable than checking a PID file since the pipe only exists if
-/// the daemon is actively listening.
-///
-/// NOTE: This has a race window between daemon startup and pipe creation.
-/// For singleton enforcement, prefer `DaemonLock::try_acquire()` which uses
-/// a named mutex and is race-free.
-#[allow(dead_code)]
-pub fn is_daemon_running() -> bool {
-    #[cfg(windows)]
-    {
-        use std::ffi::OsStr;
-        use std::os::windows::ffi::OsStrExt;
-        use winapi::um::errhandlingapi::GetLastError;
-        use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
-        use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
-        use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
-
-        const ERROR_PIPE_BUSY: u32 = 231;
-
-        let pipe_name_str = godly_protocol::pipe_name();
-        let pipe_name: Vec<u16> = OsStr::new(&pipe_name_str)
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
-
-        unsafe {
-            let handle = CreateFileW(
-                pipe_name.as_ptr(),
-                GENERIC_READ | GENERIC_WRITE,
-                FILE_SHARE_READ | FILE_SHARE_WRITE,
-                std::ptr::null_mut(),
-                OPEN_EXISTING,
-                0,
-                std::ptr::null_mut(),
-            );
-
-            if handle == INVALID_HANDLE_VALUE {
-                // ERROR_PIPE_BUSY means the pipe exists but all instances are in use
-                // — the daemon IS running, just busy serving another client
-                let err = GetLastError();
-                err == ERROR_PIPE_BUSY
-            } else {
-                CloseHandle(handle);
-                true
-            }
-        }
-    }
-
-    #[cfg(not(windows))]
-    {
-        false
-    }
-}
-
 /// RAII guard that holds a Windows named mutex to enforce only one daemon
 /// instance per GODLY_INSTANCE. The mutex is released automatically when
 /// the process exits (normally or via crash), so no stale locks can occur.
@@ -142,10 +87,7 @@ impl DaemonLock {
 
     #[cfg(not(windows))]
     pub fn try_acquire() -> Result<Self, String> {
-        // On non-Windows, fall back to pipe check
-        if is_daemon_running() {
-            return Err("Another daemon instance is already running".to_string());
-        }
+        // Non-Windows stub — no singleton enforcement
         Ok(Self {})
     }
 }

--- a/src-tauri/daemon/src/scrollback_budget.rs
+++ b/src-tauri/daemon/src/scrollback_budget.rs
@@ -38,25 +38,6 @@ impl ScrollbackBudget {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn register_session(&mut self, id: String, cols: u16) {
-        self.sessions.insert(
-            id,
-            SessionInfo {
-                scrollback_rows: 0,
-                cols,
-                is_paused: false,
-                last_output_epoch_ms: 0,
-                current_scrollback_len: DEFAULT_SCROLLBACK_LEN,
-            },
-        );
-    }
-
-    #[allow(dead_code)]
-    pub fn remove_session(&mut self, id: &str) {
-        self.sessions.remove(id);
-    }
-
     /// Remove entries for sessions that no longer exist.
     pub fn retain_sessions(&mut self, active_ids: &[String]) {
         self.sessions.retain(|id, _| active_ids.contains(id));

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -361,10 +361,6 @@ impl DaemonServer {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn stop(&self) {
-        self.running.store(false, Ordering::Relaxed);
-    }
 }
 
 /// Get the raw handle from a File for use with PeekNamedPipe

--- a/src-tauri/daemon/src/session.rs
+++ b/src-tauri/daemon/src/session.rs
@@ -198,11 +198,7 @@ pub struct DaemonSession {
     #[cfg(windows)]
     pub pid: u32,
     /// PID of the pty-shim process
-    #[allow(dead_code)]
     shim_pid: u32,
-    /// Named pipe name for shim communication
-    #[allow(dead_code)]
-    shim_pipe_name: String,
     /// Writer to the shim pipe for user input (sends TAG_SHIM_WRITE binary frames).
     /// Uses a channel-based writer that routes through the I/O thread to avoid
     /// the DuplicateHandle deadlock (see ShimIoMessage doc comment).
@@ -357,7 +353,6 @@ impl DaemonSession {
             #[cfg(windows)]
             pid: shell_pid,
             shim_pid: meta.shim_pid,
-            shim_pipe_name: meta.shim_pipe_name,
             shim_writer,
             shim_io_tx,
             running,
@@ -545,7 +540,6 @@ impl DaemonSession {
             #[cfg(windows)]
             pid: shell_pid,
             shim_pid: meta.shim_pid,
-            shim_pipe_name: meta.shim_pipe_name,
             shim_writer,
             shim_io_tx,
             running,
@@ -1266,15 +1260,6 @@ impl DaemonSession {
         self.last_output_epoch_ms.load(Ordering::Relaxed)
     }
 
-    /// Get the current epoch ms (helper for callers computing idle time).
-    #[allow(dead_code)]
-    pub fn current_epoch_ms() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64
-    }
-
     /// Read the godly-vt grid state as a GridData snapshot.
     /// Returns plain-text rows (no ANSI escapes) plus cursor position.
     pub fn read_grid(&self) -> godly_protocol::GridData {
@@ -1495,16 +1480,6 @@ impl DaemonSession {
         self.ring_buffer.lock().len()
     }
 
-    #[cfg(windows)]
-    #[allow(dead_code)]
-    pub fn get_pid(&self) -> u32 {
-        self.pid
-    }
-
-    #[allow(dead_code)]
-    pub fn get_shell_type(&self) -> &ShellType {
-        &self.shell_type
-    }
 }
 
 impl Drop for DaemonSession {


### PR DESCRIPTION
## Summary
- Remove 5 unused functions/methods across `session.rs`, `server.rs`, `pid.rs`, and `scrollback_budget.rs`
- Remove unused `shim_pipe_name` field from `DaemonSession` (stored but never read)
- Remove incorrect `#[allow(dead_code)]` from `shim_pid` field which has 10+ active references
- Update non-Windows `DaemonLock::try_acquire()` stub to not depend on removed `is_daemon_running()`

## Test plan
- [x] `cargo check -p godly-daemon` passes with no new warnings
- [x] `cargo test -p godly-daemon` — all 43 unit/integration tests pass (3 pre-existing arrow-up latency benchmark failures unchanged)
- [x] Grepped all removed symbols to confirm zero callers