### PR TITLE
fix: preserve diagnostic logs across restarts with rotation

### DIFF
--- a/changelog/unreleased/fix-diag-log-truncation.md
+++ b/changelog/unreleased/fix-diag-log-truncation.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Diagnostic log truncation** — Diagnostic logs now append instead of truncating on restart, preserving crash evidence. Logs rotate to `.prev.log` when exceeding 2MB.

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -14,17 +14,30 @@ pub mod diag {
     static LOG: Mutex<Option<std::fs::File>> = Mutex::new(None);
     static START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
 
+    /// Maximum log file size before rotation (2MB).
+    const MAX_LOG_SIZE: u64 = 2 * 1024 * 1024;
+
     pub fn init() {
         START.get_or_init(std::time::Instant::now);
         let base = match std::env::var("APPDATA") {
             Ok(v) => std::path::PathBuf::from(v),
             Err(_) => return,
         };
-        let path = base.join("com.godly.terminal").join("iced-diag.log");
+        let dir = base.join("com.godly.terminal");
+        let path = dir.join("iced-diag.log");
+        let prev_path = dir.join("iced-diag.prev.log");
+
+        // Rotate if the log file exceeds 2MB
+        if let Ok(meta) = std::fs::metadata(&path) {
+            if meta.len() > MAX_LOG_SIZE {
+                let _ = std::fs::copy(&path, &prev_path);
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+
         if let Ok(f) = std::fs::OpenOptions::new()
             .create(true)
-            .write(true)
-            .truncate(true)
+            .append(true)
             .open(&path)
         {
             *LOG.lock().unwrap() = Some(f);


### PR DESCRIPTION
## Summary
- Changed `diag::init()` in `iced-shell/src/app.rs` from `.truncate(true)` to `.append(true)` so diagnostic logs survive process restarts
- Added 2MB log rotation: when `iced-diag.log` exceeds 2MB, it is copied to `iced-diag.prev.log` before starting fresh
- Matches the rotation pattern already used by daemon (`debug_log.rs`) and MCP (`log.rs`) loggers

## Test plan
- [x] `cargo check -p godly-iced-shell` passes
- [ ] Launch app twice, verify `iced-diag.log` preserves entries from previous run
- [ ] Create a >2MB `iced-diag.log`, launch app, verify rotation to `.prev.log`