### PR TITLE
fix: use OSC window title for tab labels when set by programs

### DIFF
--- a/changelog/unreleased/osc-tab-title.md
+++ b/changelog/unreleased/osc-tab-title.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Tab title not reflecting OSC window title** — programs like Claude Code that set the window title via OSC 2 sequences now have their title shown in the tab bar instead of the generic process name

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -89,12 +89,19 @@ impl TerminalInfo {
 
     /// Returns the display label for this terminal's tab.
     ///
-    /// Priority: custom_name > display_name (from process_name) > "Terminal"
+    /// Priority: custom_name > OSC title (if not a bare path) > display_name > "Terminal"
     pub fn tab_label(&self) -> String {
         if let Some(ref name) = self.custom_name {
             if !name.is_empty() {
                 return name.clone();
             }
+        }
+        // Use the OSC window title when the running program has set one,
+        // unless it looks like a bare filesystem path (shells often set
+        // the title to the CWD, which is not a useful tab label).
+        let t = self.title.trim();
+        if !t.is_empty() && self.extract_cwd().is_none() {
+            return t.to_string();
         }
         self.display_name()
     }
@@ -482,8 +489,16 @@ mod tests {
         info.process_name = "pwsh".into();
         assert_eq!(info.tab_label(), "PowerShell");
 
-        // title set -> still uses display_name (title is for CWD extraction)
+        // title set to a CWD path -> still uses display_name
         info.title = "C:\\Users\\test".into();
+        assert_eq!(info.tab_label(), "PowerShell");
+
+        // title set to a non-path string -> uses OSC title
+        info.title = "claude: fixing bug #42".into();
+        assert_eq!(info.tab_label(), "claude: fixing bug #42");
+
+        // Unix-style CWD path -> still uses display_name
+        info.title = "/home/user/project".into();
         assert_eq!(info.tab_label(), "PowerShell");
     }
 
@@ -692,6 +707,10 @@ mod tests {
         info.custom_name = Some(String::new());
         info.process_name = "bash".into();
         assert_eq!(info.tab_label(), "Bash");
+
+        // With a non-path OSC title, empty custom_name falls through to title
+        info.title = "vim main.rs".into();
+        assert_eq!(info.tab_label(), "vim main.rs");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The OSC window title pipeline was working end-to-end, but `tab_label()` was ignoring the title field and always using `display_name()` from process_name. This meant tab labels never reflected the OSC 2 window title set by programs like Claude Code.

Now the priority is:
1. Custom name (if set by user)
2. OSC title (if not a bare filesystem path — shells often set this to CWD)
3. Display name from process name

## Changes
- Modified `tab_label()` in `terminal_state.rs` to check the OSC title before falling back to process name
- Added tests for the priority chain, including Claude Code's custom titles
- Updated existing tests to verify filesystem paths are still filtered out

## Test Plan
- Existing tests pass (custom name priority, empty custom name fallthrough)
- New tests verify OSC title is used when set
- Tests confirm filesystem paths (bare CWD) are still skipped