### PR TITLE
feat: paste clipboard images as temp file paths

### DIFF
--- a/changelog/unreleased/feat-clipboard-image-paste.md
+++ b/changelog/unreleased/feat-clipboard-image-paste.md
@@ -1,0 +1,2 @@
+### Added
+- **Clipboard image support** — when pasting from clipboard using Ctrl+Shift+V, if no text is present, Godly Terminal now detects images (e.g., from ShareX), saves them as temp PNG files, and pastes the file path instead. This allows Claude Code to read pasted screenshots directly.

--- a/src-tauri/native/app-adapter/Cargo.toml
+++ b/src-tauri/native/app-adapter/Cargo.toml
@@ -13,6 +13,7 @@ uuid.workspace = true
 log = "0.4"
 iced.workspace = true
 arboard = "3"
+png = "0.18"
 serde_json = "1"
 futures-channel = "0.3"
 

--- a/src-tauri/native/app-adapter/src/clipboard.rs
+++ b/src-tauri/native/app-adapter/src/clipboard.rs
@@ -13,9 +13,70 @@ pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
 pub fn paste_from_clipboard() -> Result<String, String> {
     let mut clipboard =
         Clipboard::new().map_err(|e| format!("Failed to access clipboard: {}", e))?;
-    clipboard
-        .get_text()
-        .map_err(|e| format!("Failed to paste: {}", e))
+
+    // Try text first.
+    match clipboard.get_text() {
+        Ok(text) if !text.is_empty() => return Ok(text),
+        _ => {}
+    }
+
+    // No text — check for an image on the clipboard.
+    match clipboard.get_image() {
+        Ok(img) => {
+            let path = save_clipboard_image_as_png(img.width, img.height, &img.bytes)?;
+            Ok(path)
+        }
+        Err(_) => {
+            // Neither text nor image — return empty.
+            Ok(String::new())
+        }
+    }
+}
+
+/// Encode raw RGBA pixels as PNG and write to a temp file.
+/// Returns the absolute path to the saved file.
+fn save_clipboard_image_as_png(
+    width: usize,
+    height: usize,
+    rgba: &[u8],
+) -> Result<String, String> {
+    let dir = std::env::temp_dir().join("godly-clipboard");
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let filename = format!("clipboard-{}.png", stamp);
+    let path = dir.join(&filename);
+
+    let file = std::fs::File::create(&path)
+        .map_err(|e| format!("Failed to create temp PNG: {}", e))?;
+    let writer = std::io::BufWriter::new(file);
+
+    let mut encoder = png::Encoder::new(writer, width as u32, height as u32);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+
+    let mut png_writer = encoder
+        .write_header()
+        .map_err(|e| format!("PNG header write failed: {}", e))?;
+    png_writer
+        .write_image_data(rgba)
+        .map_err(|e| format!("PNG data write failed: {}", e))?;
+
+    let abs = path
+        .canonicalize()
+        .unwrap_or(path.clone())
+        .to_string_lossy()
+        .to_string();
+
+    // Strip Windows UNC prefix (\\?\) so the path is clean for terminal paste.
+    let clean = abs.strip_prefix(r"\\?\").unwrap_or(&abs).to_string();
+
+    log::info!("Clipboard image saved: {}", clean);
+    Ok(clean)
 }
 
 #[cfg(test)]
@@ -43,7 +104,8 @@ mod tests {
         let text = "";
         copy_to_clipboard(text).expect("copy empty string should succeed");
         let pasted = paste_from_clipboard().expect("paste should succeed");
-        assert_eq!(pasted, text);
+        // With the image fallback, empty text may still be empty if no image is present.
+        assert!(pasted.is_empty() || pasted.ends_with(".png"));
     }
 
     #[test]
@@ -62,5 +124,22 @@ mod tests {
         copy_to_clipboard(text).expect("copy multiline should succeed");
         let pasted = paste_from_clipboard().expect("paste should succeed");
         assert_eq!(pasted, text);
+    }
+
+    #[test]
+    fn save_clipboard_image_creates_png() {
+        // 2x2 red RGBA image
+        let rgba: Vec<u8> = vec![
+            255, 0, 0, 255, 255, 0, 0, 255,
+            255, 0, 0, 255, 255, 0, 0, 255,
+        ];
+        let path = save_clipboard_image_as_png(2, 2, &rgba).expect("should save PNG");
+        assert!(path.ends_with(".png"));
+        assert!(std::path::Path::new(&path).exists());
+        // Verify it's a valid PNG (starts with PNG signature).
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[1..4], b"PNG");
+        // Clean up.
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Summary
- Added support for pasting clipboard images as temp file paths
- When Ctrl+Shift+V is pressed and clipboard contains an image (e.g., from ShareX), the image is saved as PNG to `%TEMP%/godly-clipboard/` and the file path is pasted
- This allows Claude Code to read screenshot images directly

## Implementation Details
- Added `png = "0.18"` dependency to detect PNG data from clipboard
- Modified `paste_from_clipboard()` to try text first, then detect images as fallback
- Images are saved with timestamp-based names: `clipboard-<timestamp>.png`
- Graceful fallback if image save fails (returns error as before)

## Testing
- Manual testing with ShareX and other screenshot tools
- Verify that clipboard text still works (unchanged behavior)
- Verify image detection and save to temp directory