### PR TITLE
fix: inject GODLY_SESSION_ID into PTY shell environment

### DIFF
--- a/changelog/unreleased/fix-godly-session-id-env.md
+++ b/changelog/unreleased/fix-godly-session-id-env.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Notification hooks now work** — daemon now injects `GODLY_SESSION_ID` into PTY shell environment, allowing `godly-notify` and other session-aware tools to identify the correct terminal tab

--- a/src-tauri/daemon/src/shim_client.rs
+++ b/src-tauri/daemon/src/shim_client.rs
@@ -40,6 +40,10 @@ pub fn spawn_shim(
         cmd.args(["--cwd", dir]);
     }
 
+    // Set GODLY_SESSION_ID so the shell (and tools like godly-notify) can
+    // identify which terminal tab they're running in.
+    cmd.env("GODLY_SESSION_ID", session_id);
+
     // Propagate GODLY_INSTANCE if set (for pipe name isolation in tests)
     if let Ok(instance) = std::env::var("GODLY_INSTANCE") {
         cmd.env("GODLY_INSTANCE", &instance);


### PR DESCRIPTION
Notifications and other session-aware tools rely on `GODLY_SESSION_ID` to identify which terminal tab they are running in. Without this env var in the PTY's environment, `godly-notify` (used by Claude Code hooks) and similar tools silently fail.

This fix injects `GODLY_SESSION_ID` into the PTY shell environment when spawning the shim process.