### PR TITLE
fix: send correct Shift+Tab escape sequence to PTY

### DIFF
--- a/changelog/unreleased/fix-shift-tab-pty-escape.md
+++ b/changelog/unreleased/fix-shift-tab-pty-escape.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Shift+Tab escape sequence** — Shift+Tab now correctly sends the reverse-tab escape sequence `ESC[Z` to the PTY instead of a bare tab character, fixing support in terminal applications like Claude Code that rely on backtab

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1579,15 +1579,18 @@ impl GodlyApp {
                 self.selection.clear();
 
                 // Forward to PTY — send to focused terminal, not just active tab.
-                // Use the platform-composed `text` for printable characters (handles
-                // Shift+key → uppercase/symbols correctly on all keyboard layouts).
-                // Fall back to key_to_pty_bytes for control chars and named keys.
-                let bytes = if !modifiers.control() {
-                    text.as_ref().map(|t| t.as_bytes().to_vec())
-                } else {
-                    None
-                }
-                .or_else(|| key_to_pty_bytes(&key, modifiers));
+                // Use the platform-composed `text` for printable Character keys
+                // (handles Shift+key → uppercase/symbols on all keyboard layouts).
+                // Named keys (Tab, Enter, arrows, etc.) always go through
+                // key_to_pty_bytes which encodes modifiers correctly
+                // (e.g. Shift+Tab → ESC[Z, not bare \t).
+                let bytes =
+                    if !modifiers.control() && matches!(key, keyboard::Key::Character(_)) {
+                        text.as_ref().map(|t| t.as_bytes().to_vec())
+                    } else {
+                        None
+                    }
+                    .or_else(|| key_to_pty_bytes(&key, modifiers));
 
                 if let Some(bytes) = bytes {
                     if let (Some(tid), Some(client)) = (self.target_terminal_id(), &self.client) {


### PR DESCRIPTION
## Summary
Fixes Shift+Tab sending wrong escape sequence to the PTY. When Shift+Tab was pressed, the code used a bare tab character instead of the correct reverse-tab escape sequence `\x1b[Z`, breaking terminal applications like Claude Code that rely on backtab.

The fix restricts the platform-composed text path to `Key::Character(_)` only, ensuring named keys like Tab always go through `key_to_pty_bytes` which correctly encodes modifiers.

## Changes
- **src-tauri/native/iced-shell/src/app.rs** — Add `matches!(key, keyboard::Key::Character(_))` check to restrict text-based PTY input to character keys only
- **changelog/unreleased/fix-shift-tab-pty-escape.md** — Added changelog fragment

## Test Plan
- Open a terminal application that uses Shift+Tab for reverse navigation (e.g., Claude Code, Vim)
- Press Shift+Tab and verify the application receives the backtab command
- Verify normal Tab still works as expected

## Related Issue
Fixes #684