### PR TITLE
feat: Quick Claude model and permission mode dropdowns

### DIFF
--- a/changelog/unreleased/feat-quick-claude-cli-flags.md
+++ b/changelog/unreleased/feat-quick-claude-cli-flags.md
@@ -1,0 +1,2 @@
+### Added
+- **Claude Code CLI flags** — Quick Claude dialog now has Model (Opus/Sonnet/Haiku) and Permission Mode (Default/Plan/Auto) dropdowns, visible only when Claude Code is selected as the AI tool

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -730,6 +730,14 @@ pub enum Message {
     QuickClaudeDialogLaunch,
     /// Voice input from Quick Claude dialog.
     QuickClaudeDialogVoice,
+    /// Model selected in Quick Claude dialog.
+    QuickClaudeDialogModelSelected(String),
+    /// Toggle model dropdown in Quick Claude dialog.
+    QuickClaudeDialogModelDropdownToggle,
+    /// Permission mode selected in Quick Claude dialog.
+    QuickClaudeDialogModeSelected(String),
+    /// Toggle mode dropdown in Quick Claude dialog.
+    QuickClaudeDialogModeDropdownToggle,
     /// AI tool display name input changed.
     AiToolNameInputChanged(String),
     /// AI tool command input changed.
@@ -2187,7 +2195,7 @@ impl GodlyApp {
                     QuickClaudeLayout::VSplit | QuickClaudeLayout::HSplit => 2,
                     QuickClaudeLayout::Grid2x2 => 4,
                 };
-                let steps = crate::quick_claude::default_launch_steps(num_agents, &preset.prompt_template);
+                let steps = crate::quick_claude::default_launch_steps(num_agents, &preset.prompt_template, "sonnet", "default");
 
                 let ws_id = uuid::Uuid::new_v4().to_string();
                 let ws_name = format!("QC: {}", preset.name);
@@ -2283,6 +2291,28 @@ impl GodlyApp {
                     dlg.auto_suggest_branch = val;
                 }
             }
+            Message::QuickClaudeDialogModelSelected(model) => {
+                if let Some(ref mut dlg) = self.quick_claude_dialog {
+                    dlg.selected_model = model;
+                    dlg.model_dropdown_open = false;
+                }
+            }
+            Message::QuickClaudeDialogModelDropdownToggle => {
+                if let Some(ref mut dlg) = self.quick_claude_dialog {
+                    dlg.model_dropdown_open = !dlg.model_dropdown_open;
+                }
+            }
+            Message::QuickClaudeDialogModeSelected(mode) => {
+                if let Some(ref mut dlg) = self.quick_claude_dialog {
+                    dlg.selected_mode = mode;
+                    dlg.mode_dropdown_open = false;
+                }
+            }
+            Message::QuickClaudeDialogModeDropdownToggle => {
+                if let Some(ref mut dlg) = self.quick_claude_dialog {
+                    dlg.mode_dropdown_open = !dlg.mode_dropdown_open;
+                }
+            }
             Message::QuickClaudeDialogLaunch => {
                 if self.quick_claude_launch.is_some() {
                     return Task::none();
@@ -2292,8 +2322,10 @@ impl GodlyApp {
                 };
                 let prompt = dlg.prompt_text();
                 let prompt = prompt.trim();
+                let model = dlg.selected_model.clone();
+                let mode = dlg.selected_mode.clone();
                 let num_agents = 1;
-                let steps = crate::quick_claude::default_launch_steps(num_agents, prompt);
+                let steps = crate::quick_claude::default_launch_steps(num_agents, prompt, &model, &mode);
 
                 let ws_id = uuid::Uuid::new_v4().to_string();
                 let ws_name = "Quick Claude".to_string();
@@ -3466,6 +3498,10 @@ impl GodlyApp {
                 Message::QuickClaudeDialogBranchChanged,
                 Message::QuickClaudeDialogMainBranchToggled,
                 Message::QuickClaudeDialogAutoSuggestToggled,
+                Message::QuickClaudeDialogModelSelected,
+                Message::QuickClaudeDialogModelDropdownToggle,
+                Message::QuickClaudeDialogModeSelected,
+                Message::QuickClaudeDialogModeDropdownToggle,
                 Message::QuickClaudeDialogLaunch,
                 Message::QuickClaudeDialogVoice,
                 Message::QuickClaudeDialogClose,

--- a/src-tauri/native/iced-shell/src/quick_claude.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude.rs
@@ -28,7 +28,17 @@ pub enum LaunchStep {
 }
 
 /// Build the default launch sequence for a preset with N agents.
-pub fn default_launch_steps(num_agents: usize, prompt: &str) -> Vec<LaunchStep> {
+pub fn default_launch_steps(num_agents: usize, prompt: &str, model: &str, mode: &str) -> Vec<LaunchStep> {
+    let mut cmd = "claude".to_string();
+    // Add model flag (always, since we default to sonnet)
+    cmd.push_str(&format!(" --model {}", model));
+    // Add mode flag
+    match mode {
+        "plan" => cmd.push_str(" --plan"),
+        "auto" => cmd.push_str(" --dangerously-skip-permissions"),
+        _ => {} // "default" — no flag
+    }
+
     let mut steps = Vec::new();
     for i in 0..num_agents {
         steps.push(LaunchStep::CreateTerminal { agent_index: i });
@@ -38,7 +48,7 @@ pub fn default_launch_steps(num_agents: usize, prompt: &str) -> Vec<LaunchStep> 
         });
         steps.push(LaunchStep::RunCommand {
             agent_index: i,
-            command: "claude".to_string(),
+            command: cmd.clone(),
         });
         steps.push(LaunchStep::WaitReady {
             agent_index: i,
@@ -267,7 +277,7 @@ mod tests {
 
     #[test]
     fn default_steps_single_no_prompt() {
-        let steps = default_launch_steps(1, "");
+        let steps = default_launch_steps(1, "", "sonnet", "default");
         // CreateTerminal, WaitIdle, RunCommand, WaitReady(trust), SendEnter, WaitReady(>)
         assert_eq!(steps.len(), 6);
         assert!(matches!(steps[0], LaunchStep::CreateTerminal { agent_index: 0 }));
@@ -276,7 +286,7 @@ mod tests {
 
     #[test]
     fn default_steps_single_with_prompt() {
-        let steps = default_launch_steps(1, "build the app");
+        let steps = default_launch_steps(1, "build the app", "sonnet", "default");
         // 6 base steps + 1 SendPrompt
         assert_eq!(steps.len(), 7);
         assert!(matches!(steps[6], LaunchStep::SendPrompt { agent_index: 0, .. }));
@@ -284,9 +294,39 @@ mod tests {
 
     #[test]
     fn default_steps_grid_2x2() {
-        let steps = default_launch_steps(4, "test");
+        let steps = default_launch_steps(4, "test", "sonnet", "default");
         // Each agent: 7 steps (with prompt). 4 agents = 28
         assert_eq!(steps.len(), 28);
+    }
+
+    #[test]
+    fn default_steps_with_model_and_mode() {
+        let steps = default_launch_steps(1, "", "opus", "plan");
+        if let LaunchStep::RunCommand { command, .. } = &steps[2] {
+            assert_eq!(command, "claude --model opus --plan");
+        } else {
+            panic!("Expected RunCommand at index 2");
+        }
+    }
+
+    #[test]
+    fn default_steps_auto_mode() {
+        let steps = default_launch_steps(1, "", "haiku", "auto");
+        if let LaunchStep::RunCommand { command, .. } = &steps[2] {
+            assert_eq!(command, "claude --model haiku --dangerously-skip-permissions");
+        } else {
+            panic!("Expected RunCommand at index 2");
+        }
+    }
+
+    #[test]
+    fn default_steps_default_mode_no_extra_flag() {
+        let steps = default_launch_steps(1, "", "sonnet", "default");
+        if let LaunchStep::RunCommand { command, .. } = &steps[2] {
+            assert_eq!(command, "claude --model sonnet");
+        } else {
+            panic!("Expected RunCommand at index 2");
+        }
     }
 
     #[test]

--- a/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
@@ -20,6 +20,10 @@ pub struct QuickClaudeDialogState {
     pub auto_suggest_branch: bool,
     /// Snapshot of available workspaces (id, name) at dialog open time.
     pub workspaces: Vec<(String, String)>,
+    pub selected_model: String,
+    pub model_dropdown_open: bool,
+    pub selected_mode: String,
+    pub mode_dropdown_open: bool,
 }
 
 impl QuickClaudeDialogState {
@@ -34,6 +38,10 @@ impl QuickClaudeDialogState {
             main_branch_mode: false,
             auto_suggest_branch: true,
             workspaces,
+            selected_model: "sonnet".to_string(),
+            model_dropdown_open: false,
+            selected_mode: "default".to_string(),
+            mode_dropdown_open: false,
         }
     }
 
@@ -53,6 +61,10 @@ pub fn view_quick_claude_dialog<'a, M: Clone + 'a>(
     on_branch_changed: impl Fn(String) -> M + 'a,
     on_main_branch_toggled: impl Fn(bool) -> M + 'a,
     on_auto_suggest_toggled: impl Fn(bool) -> M + 'a,
+    on_model_selected: impl Fn(String) -> M + 'a,
+    on_model_dropdown_toggle: M,
+    on_mode_selected: impl Fn(String) -> M + 'a,
+    on_mode_dropdown_toggle: M,
     on_launch: M,
     on_voice: M,
     on_cancel: M,
@@ -230,6 +242,178 @@ pub fn view_quick_claude_dialog<'a, M: Clone + 'a>(
         );
     }
 
+    // ── Model & Mode dropdowns (Claude Code only) ──────────────────────
+    let model_mode_section: Option<Element<'a, M>> = if state.selected_ai_tool == "Claude Code" {
+        let models = [("Opus", "opus"), ("Sonnet", "sonnet"), ("Haiku", "haiku")];
+        let modes = [("Default", "default"), ("Plan", "plan"), ("Auto", "auto")];
+
+        // Model dropdown
+        let model_display = models
+            .iter()
+            .find(|(_, v)| *v == state.selected_model.as_str())
+            .map(|(d, _)| *d)
+            .unwrap_or("Sonnet");
+
+        let model_toggle = on_model_dropdown_toggle.clone();
+        let model_button = button(
+            row![
+                text(model_display).size(13).color(text_primary),
+                Space::new().width(Length::Fill),
+                text(if state.model_dropdown_open { "\u{25B2}" } else { "\u{25BC}" })
+                    .size(10)
+                    .color(text_secondary),
+            ]
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(model_toggle)
+        .padding(Padding::from([8, 12]))
+        .width(Length::Fill)
+        .style(move |_theme, _status| button::Style {
+            background: Some(Background::Color(bg_primary)),
+            text_color: text_primary,
+            border: Border {
+                color: border_color,
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..button::Style::default()
+        });
+
+        let mut model_col = column![
+            text("Model").size(11).color(text_secondary),
+            model_button,
+        ]
+        .spacing(4);
+
+        if state.model_dropdown_open {
+            let mut model_list = column![].spacing(2);
+            for (display, value) in models {
+                let is_selected = state.selected_model == value;
+                let val = value.to_string();
+                let item = button(
+                    text(display)
+                        .size(13)
+                        .color(if is_selected { text_active } else { text_primary }),
+                )
+                .on_press(on_model_selected(val))
+                .padding(Padding::from([5, 10]))
+                .width(Length::Fill)
+                .style(move |_theme, _status| button::Style {
+                    background: Some(Background::Color(if is_selected {
+                        tint(accent, 0.12)
+                    } else {
+                        Color::TRANSPARENT
+                    })),
+                    text_color: text_primary,
+                    border: Border::default(),
+                    ..button::Style::default()
+                });
+                model_list = model_list.push(item);
+            }
+            model_col = model_col.push(
+                container(model_list)
+                    .width(Length::Fill)
+                    .style(move |_theme| container::Style {
+                        background: Some(Background::Color(bg_primary)),
+                        border: Border {
+                            color: border_color,
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..container::Style::default()
+                    }),
+            );
+        }
+
+        // Mode dropdown
+        let mode_display = modes
+            .iter()
+            .find(|(_, v)| *v == state.selected_mode.as_str())
+            .map(|(d, _)| *d)
+            .unwrap_or("Default");
+
+        let mode_toggle = on_mode_dropdown_toggle.clone();
+        let mode_button = button(
+            row![
+                text(mode_display).size(13).color(text_primary),
+                Space::new().width(Length::Fill),
+                text(if state.mode_dropdown_open { "\u{25B2}" } else { "\u{25BC}" })
+                    .size(10)
+                    .color(text_secondary),
+            ]
+            .align_y(iced::Alignment::Center),
+        )
+        .on_press(mode_toggle)
+        .padding(Padding::from([8, 12]))
+        .width(Length::Fill)
+        .style(move |_theme, _status| button::Style {
+            background: Some(Background::Color(bg_primary)),
+            text_color: text_primary,
+            border: Border {
+                color: border_color,
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..button::Style::default()
+        });
+
+        let mut mode_col = column![
+            text("Permission Mode").size(11).color(text_secondary),
+            mode_button,
+        ]
+        .spacing(4);
+
+        if state.mode_dropdown_open {
+            let mut mode_list = column![].spacing(2);
+            for (display, value) in modes {
+                let is_selected = state.selected_mode == value;
+                let val = value.to_string();
+                let item = button(
+                    text(display)
+                        .size(13)
+                        .color(if is_selected { text_active } else { text_primary }),
+                )
+                .on_press(on_mode_selected(val))
+                .padding(Padding::from([5, 10]))
+                .width(Length::Fill)
+                .style(move |_theme, _status| button::Style {
+                    background: Some(Background::Color(if is_selected {
+                        tint(accent, 0.12)
+                    } else {
+                        Color::TRANSPARENT
+                    })),
+                    text_color: text_primary,
+                    border: Border::default(),
+                    ..button::Style::default()
+                });
+                mode_list = mode_list.push(item);
+            }
+            mode_col = mode_col.push(
+                container(mode_list)
+                    .width(Length::Fill)
+                    .style(move |_theme| container::Style {
+                        background: Some(Background::Color(bg_primary)),
+                        border: Border {
+                            color: border_color,
+                            width: 1.0,
+                            radius: 4.0.into(),
+                        },
+                        ..container::Style::default()
+                    }),
+            );
+        }
+
+        let model_mode_row = row![
+            container(model_col).width(Length::FillPortion(1)),
+            container(mode_col).width(Length::FillPortion(1)),
+        ]
+        .spacing(12);
+
+        Some(model_mode_row.into())
+    } else {
+        None
+    };
+
     // ── Prompt textarea ──────────────────────────────────────────────────
     let editor = text_editor(&state.prompt_content)
         .on_action(on_prompt_action)
@@ -349,22 +533,28 @@ pub fn view_quick_claude_dialog<'a, M: Clone + 'a>(
     .spacing(8);
 
     // ── Compose dialog ───────────────────────────────────────────────────
-    let dialog_content = column![
+    let mut dialog_content = column![
         title,
         subtitle,
         step_indicator,
         workspace_section,
         ai_tool_section,
-        prompt_section,
-        branch_section,
-        checkbox_row,
-        footer,
     ]
     .spacing(12);
 
+    if let Some(mm_section) = model_mode_section {
+        dialog_content = dialog_content.push(mm_section);
+    }
+
+    dialog_content = dialog_content
+        .push(prompt_section)
+        .push(branch_section)
+        .push(checkbox_row)
+        .push(footer);
+
     let dialog = container(dialog_content)
         .padding(Padding::from([20, 24]))
-        .width(Length::Fixed(520.0))
+        .width(Length::Fixed(600.0))
         .style(move |_theme| container::Style {
             background: Some(Background::Color(bg_secondary)),
             border: Border {
@@ -413,6 +603,10 @@ mod tests {
         assert!(!state.main_branch_mode);
         assert!(state.auto_suggest_branch);
         assert_eq!(state.workspaces.len(), 2);
+        assert_eq!(state.selected_model, "sonnet");
+        assert!(!state.model_dropdown_open);
+        assert_eq!(state.selected_mode, "default");
+        assert!(!state.mode_dropdown_open);
     }
 
     #[test]
@@ -440,6 +634,10 @@ mod tests {
             BranchChanged(String),
             MainBranch(bool),
             AutoSuggest(bool),
+            ModelSelected(String),
+            ModelDropdown,
+            ModeSelected(String),
+            ModeDropdown,
             Launch,
             Voice,
             Cancel,
@@ -454,6 +652,10 @@ mod tests {
             Msg::BranchChanged,
             Msg::MainBranch,
             Msg::AutoSuggest,
+            Msg::ModelSelected,
+            Msg::ModelDropdown,
+            Msg::ModeSelected,
+            Msg::ModeDropdown,
             Msg::Launch,
             Msg::Voice,
             Msg::Cancel,


### PR DESCRIPTION
## Summary
- Add **Model** (Opus/Sonnet/Haiku) and **Permission Mode** (Default/Plan/Auto) dropdowns to the Quick Claude dialog, visible only when Claude Code is the selected AI tool
- Model maps to `claude --model {model}`, permission mode maps to `--plan` or `--dangerously-skip-permissions` CLI flags
- Dropdowns render side-by-side using `FillPortion(1)` layout; dialog width increased from 520 to 600 to accommodate

## Files changed
- `src-tauri/native/iced-shell/src/quick_claude_dialog.rs` — state fields, view params, dropdown UI
- `src-tauri/native/iced-shell/src/quick_claude.rs` — `default_launch_steps` accepts model/mode, builds CLI command
- `src-tauri/native/iced-shell/src/app.rs` — message variants, handlers, view wiring
- `changelog/unreleased/feat-quick-claude-cli-flags.md` — changelog fragment

## Test plan
- [x] `cargo check -p godly-iced-shell` passes
- [x] `cargo test -p godly-iced-shell -- quick_claude` — all 12 tests pass (including 3 new CLI flag tests)
- [ ] Manual: open Quick Claude dialog, select Claude Code, verify Model and Mode dropdowns appear
- [ ] Manual: select non-Claude Code AI tool, verify dropdowns disappear
- [ ] Manual: launch with Opus + Plan mode, verify CLI command includes `--model opus --plan`