### PR TITLE
feat: add worktree mode for isolated terminal sessions

### DIFF
--- a/changelog/unreleased/feat-worktree-mode.md
+++ b/changelog/unreleased/feat-worktree-mode.md
@@ -1,0 +1,2 @@
+### Added
+- **Worktree Mode for workspaces** — when enabled via sidebar context menu, new terminals automatically create isolated git worktrees in `.godly-worktrees/` and open in those directories. Closing a worktree terminal prompts to remove or keep the worktree on disk. Worktree paths persist across app restarts and `.godly-worktrees/` is auto-added to `.gitignore` on first use.

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -421,6 +421,8 @@ pub struct GodlyApp {
     tab_drag_start_pos: Option<Point>,
     /// Ctrl+Tab MRU switcher popup state while modifier is held.
     mru_switcher: Option<MruSwitcherState>,
+    // --- Worktree Mode ---
+    worktree_close_pending: Option<String>,
     // --- K2/K3: Quit Confirmation + Copy Preview ---
     quit_confirm_pending: bool,
     copy_preview_text: Option<String>,
@@ -541,6 +543,7 @@ impl Default for GodlyApp {
             dragging_tab_id: None,
             tab_drag_start_pos: None,
             mru_switcher: None,
+            worktree_close_pending: None,
             quit_confirm_pending: false,
             copy_preview_text: None,
             active_theme: crate::theme::ThemeId::Dusk,
@@ -878,6 +881,23 @@ pub enum Message {
     CopyPreviewShow(String),
     CopyPreviewConfirmed,
     CopyPreviewDismissed,
+    // --- Worktree Mode ---
+    /// A worktree was successfully created for a new terminal.
+    WorktreeCreated {
+        session_id: String,
+        worktree_path: String,
+    },
+    /// User confirmed worktree cleanup on terminal close.
+    WorktreeCloseConfirmed { session_id: String },
+    /// User chose to keep worktree on terminal close.
+    WorktreeCloseKeep { session_id: String },
+    /// Background worktree removal completed.
+    WorktreeRemoved {
+        session_id: String,
+        result: Result<(), String>,
+    },
+    /// Dismiss the worktree close dialog without closing.
+    WorktreeCloseCancelled,
     // --- F1-F4: Theme System ---
     ThemeChanged(crate::theme::ThemeId),
     // --- F5: Custom Theme Import/Export ---
@@ -1273,6 +1293,7 @@ impl GodlyApp {
         self.dragging_tab_id = None;
         self.tab_drag_start_pos = None;
         self.mru_switcher = None;
+        self.worktree_close_pending = None;
         self.quit_confirm_pending = false;
         self.copy_preview_text = None;
         self.terminal_context_menu_pos = None;
@@ -1303,6 +1324,15 @@ impl GodlyApp {
                     worktree_mode: workspace.worktree_mode,
                     focused_terminal: workspace.focused_terminal.clone(),
                     layout: session_persistence::PersistedLayoutNode::from_layout(&workspace.layout),
+                })
+                .collect(),
+            terminal_worktree_paths: self
+                .terminals
+                .iter()
+                .filter_map(|t| {
+                    t.worktree_path
+                        .as_ref()
+                        .map(|path| (t.id.clone(), path.clone()))
                 })
                 .collect(),
         }
@@ -1831,76 +1861,10 @@ impl GodlyApp {
                 return self.close_terminal(&id);
             }
             Message::TerminalCreated(Ok(session_id)) => {
-                let ws_id = self.workspaces.active_id().map(str::to_string);
-                let in_layout = self
-                    .active_layout()
-                    .map(|layout| layout.find_leaf(&session_id))
-                    .unwrap_or(false);
-                let decision =
-                    tab_reducer::reduce_terminal_created(tab_reducer::TerminalCreatedInput {
-                        session_id,
-                        active_workspace_id: ws_id.clone(),
-                        terminal_in_active_layout: in_layout,
-                    });
-                if let Some(workspace_mutation) = decision.workspace_mutation {
-                    if let Some(ws) = self.workspaces.active_mut() {
-                        match workspace_mutation {
-                            tab_reducer::WorkspaceTerminalMutation::FocusTerminal => {
-                                ws.focused_terminal = decision.session_id.clone();
-                            }
-                            tab_reducer::WorkspaceTerminalMutation::ResetLayoutToSingleTerminal => {
-                                ws.layout = LayoutNode::Leaf {
-                                    terminal_id: decision.session_id.clone(),
-                                };
-                                ws.focused_terminal = decision.session_id.clone();
-                            }
-                        }
-                    }
-                }
-                let (rows, cols) = self.terminal_grid_size(Some(decision.session_id.as_str()));
-                if let Some(ws_id) = &decision.assign_workspace_id {
-                    self.terminals.add_to_workspace(
-                        decision.session_id.clone(),
-                        rows,
-                        cols,
-                        ws_id.clone(),
-                    );
-                } else {
-                    self.terminals.add(decision.session_id.clone(), rows, cols);
-                }
-
-                if decision.set_terminal_active {
-                    self.terminals.set_active(&decision.session_id);
-                }
-                // Start tab entry animation.
-                self.entering_tabs
-                    .insert(decision.session_id.clone(), Self::now_ms());
-
-                // Auto-launch AI tool if workspace has a mode set.
-                if let Some(ws_id) = &ws_id {
-                    if let Some(client) = &self.client {
-                        let cmd = match self.workspace_ai_modes.get(ws_id) {
-                            Some(AiToolMode::Claude) => Some("claude\r"),
-                            Some(AiToolMode::Codex) => Some("codex\r"),
-                            Some(AiToolMode::Both) => Some("claude\r"),
-                            Some(AiToolMode::None) | None => None,
-                        };
-                        if let Some(cmd) = cmd {
-                            if let Err(e) = commands::write_to_terminal(
-                                client,
-                                &decision.session_id,
-                                cmd.as_bytes(),
-                            ) {
-                                log::warn!("Failed to auto-launch AI tool: {e}");
-                            }
-                        }
-                    }
-                }
-
-                return self.fetch_grid(&decision.fetch_grid_terminal_id);
+                return self.handle_terminal_created(Ok(session_id));
             }
             Message::TerminalCreated(Err(e)) => {
-                log::error!("Failed to create terminal: {}", e);
+                return self.handle_terminal_created(Err(e));
             }
 
             Message::WindowOpened(window_id) => {
@@ -3087,6 +3051,48 @@ impl GodlyApp {
             Message::CopyPreviewDismissed => {
                 self.copy_preview_text = None;
             }
+            // --- Worktree Mode ---
+            Message::WorktreeCreated { session_id, worktree_path } => {
+                self.terminals.set_worktree_path(&session_id, worktree_path);
+                return self.handle_terminal_created(Ok(session_id));
+            }
+            Message::WorktreeCloseConfirmed { session_id } => {
+                self.worktree_close_pending = None;
+                let worktree_path = self.terminals.get(&session_id)
+                    .and_then(|t| t.worktree_path.clone());
+                let repo_root = self.workspaces.active()
+                    .map(|ws| ws.folder_path.clone());
+                let close_task = self.close_terminal_immediate(&session_id);
+                if let (Some(wt_path), Some(root)) = (worktree_path, repo_root) {
+                    let sid = session_id.clone();
+                    let remove_task = Task::perform(
+                        async move {
+                            let (tx, rx) = futures_channel::oneshot::channel::<Result<(), String>>();
+                            std::thread::spawn(move || {
+                                let result = crate::git_worktree::remove_worktree(&root, &wt_path);
+                                let _ = tx.send(result);
+                            });
+                            rx.await.unwrap_or_else(|_| Err("Background thread panicked".into()))
+                        },
+                        move |result| Message::WorktreeRemoved { session_id: sid, result },
+                    );
+                    return Task::batch([close_task, remove_task]);
+                }
+                return close_task;
+            }
+            Message::WorktreeCloseKeep { session_id } => {
+                self.worktree_close_pending = None;
+                return self.close_terminal_immediate(&session_id);
+            }
+            Message::WorktreeRemoved { session_id, result } => {
+                match result {
+                    Ok(()) => log::info!("Worktree cleaned up for session {session_id}"),
+                    Err(ref e) => log::warn!("Failed to remove worktree for {session_id}: {e}"),
+                }
+            }
+            Message::WorktreeCloseCancelled => {
+                self.worktree_close_pending = None;
+            }
             Message::ThemeChanged(id) => {
                 self.active_theme = id;
                 self.active_custom_theme_id = None;
@@ -3725,9 +3731,31 @@ impl GodlyApp {
             with_tab_rename
         };
 
-        let with_copy_preview: Element<'_, Message> = if let Some(ref preview_text) = self.copy_preview_text {
+        let with_worktree_close: Element<'_, Message> = if let Some(ref pending_id) = self.worktree_close_pending {
+            let worktree_path = self
+                .terminals
+                .get(pending_id)
+                .and_then(|t| t.worktree_path.as_deref())
+                .unwrap_or("unknown");
+            let pid1 = pending_id.clone();
+            let pid2 = pending_id.clone();
             stack![
                 with_quit,
+                crate::confirm_dialog::view_worktree_close_confirm(
+                    worktree_path,
+                    Message::WorktreeCloseConfirmed { session_id: pid1 },
+                    Message::WorktreeCloseKeep { session_id: pid2 },
+                    Message::WorktreeCloseCancelled,
+                )
+            ]
+            .into()
+        } else {
+            with_quit
+        };
+
+        let with_copy_preview: Element<'_, Message> = if let Some(ref preview_text) = self.copy_preview_text {
+            stack![
+                with_worktree_close,
                 crate::confirm_dialog::view_copy_preview(
                     preview_text,
                     preview_text.len(),
@@ -3737,7 +3765,7 @@ impl GodlyApp {
             ]
             .into()
         } else {
-            with_quit
+            with_worktree_close
         };
 
         // Shell picker overlay (H1-H6)
@@ -5992,6 +6020,9 @@ impl GodlyApp {
                 let mut assigned_terminal_ids = HashSet::new();
 
                 if let Some(merged) = merged_session_state {
+                    // Restore worktree paths for surviving terminals.
+                    let worktree_paths = merged.terminal_worktree_paths.clone();
+
                     // Collect workspaces that lost all their terminals (e.g. after reinstall).
                     // They'll be filled from the missing_live_terminal_ids pool below.
                     let mut empty_workspaces: Vec<session_persistence::MergedWorkspaceState> =
@@ -6158,6 +6189,11 @@ impl GodlyApp {
                         self.last_test_terminal_id = Some(active_terminal_id);
                     } else if let Some(active_workspace) = self.workspaces.active() {
                         self.terminals.set_active(&active_workspace.focused_terminal);
+                    }
+
+                    // Apply persisted worktree paths to restored terminals.
+                    for (terminal_id, path) in worktree_paths {
+                        self.terminals.set_worktree_path(&terminal_id, path);
                     }
                 }
 
@@ -6356,18 +6392,23 @@ impl GodlyApp {
     }
 
     fn create_new_terminal(&self) -> Task<Message> {
-        let cwd = self
-            .workspaces
-            .active()
-            .map(|ws| ws.folder_path.clone());
-        self.create_terminal_task_with_cwd(uuid::Uuid::new_v4().to_string(), cwd)
+        let session_id = uuid::Uuid::new_v4().to_string();
+        if let Some(ws) = self.workspaces.active() {
+            if ws.worktree_mode {
+                return self.create_terminal_task_with_worktree(session_id, ws.folder_path.clone());
+            }
+        }
+        let cwd = self.workspaces.active().map(|ws| ws.folder_path.clone());
+        self.create_terminal_task_with_cwd(session_id, cwd)
     }
 
     fn create_terminal_task(&self, session_id: String) -> Task<Message> {
-        let cwd = self
-            .workspaces
-            .active()
-            .map(|ws| ws.folder_path.clone());
+        if let Some(ws) = self.workspaces.active() {
+            if ws.worktree_mode {
+                return self.create_terminal_task_with_worktree(session_id, ws.folder_path.clone());
+            }
+        }
+        let cwd = self.workspaces.active().map(|ws| ws.folder_path.clone());
         self.create_terminal_task_with_cwd(session_id, cwd)
     }
 
@@ -6404,6 +6445,84 @@ impl GodlyApp {
                     .unwrap_or_else(|_| Err("Background thread panicked".into()))
             },
             Message::TerminalCreated,
+        )
+    }
+
+    fn create_terminal_task_with_worktree(
+        &self,
+        session_id: String,
+        repo_folder: String,
+    ) -> Task<Message> {
+        let Some(client) = &self.client else {
+            return Task::done(Message::TerminalCreated(Err(
+                "No daemon connection".to_string(),
+            )));
+        };
+        let client = Arc::clone(client);
+        let (rows, cols) = self.terminal_grid_size(Some(session_id.as_str()));
+
+        Task::perform(
+            async move {
+                let (tx, rx) =
+                    futures_channel::oneshot::channel::<Result<(String, Option<String>), String>>();
+                std::thread::spawn(move || {
+                    // Check if it's a git repo.
+                    if !crate::git_worktree::is_git_repo(&repo_folder) {
+                        log::warn!("Worktree mode enabled but not a git repo: {repo_folder}");
+                        let result = commands::create_terminal(
+                            &client,
+                            &session_id,
+                            godly_protocol::ShellType::Windows,
+                            Some(&repo_folder),
+                            rows,
+                            cols,
+                        )
+                        .map(|_| (session_id, None::<String>));
+                        let _ = tx.send(result);
+                        return;
+                    }
+
+                    // Create worktree in detached HEAD.
+                    let dir_name = crate::git_worktree::generate_worktree_dir_name();
+                    match crate::git_worktree::create_worktree(&repo_folder, &dir_name) {
+                        Ok(worktree_path) => {
+                            let result = commands::create_terminal(
+                                &client,
+                                &session_id,
+                                godly_protocol::ShellType::Windows,
+                                Some(&worktree_path),
+                                rows,
+                                cols,
+                            )
+                            .map(|_| (session_id, Some(worktree_path)));
+                            let _ = tx.send(result);
+                        }
+                        Err(e) => {
+                            log::warn!("Worktree creation failed, falling back: {e}");
+                            let result = commands::create_terminal(
+                                &client,
+                                &session_id,
+                                godly_protocol::ShellType::Windows,
+                                Some(&repo_folder),
+                                rows,
+                                cols,
+                            )
+                            .map(|_| (session_id, None::<String>));
+                            let _ = tx.send(result);
+                        }
+                    }
+                });
+                rx.await
+                    .unwrap_or_else(|_| Err("Background thread panicked".into()))
+            },
+            |result| match result {
+                Ok((session_id, Some(worktree_path))) => Message::WorktreeCreated {
+                    session_id,
+                    worktree_path,
+                },
+                Ok((session_id, None)) => Message::TerminalCreated(Ok(session_id)),
+                Err(e) => Message::TerminalCreated(Err(e)),
+            },
         )
     }
 
@@ -6554,6 +6673,17 @@ impl GodlyApp {
     }
 
     pub(crate) fn close_terminal(&mut self, session_id: &str) -> Task<Message> {
+        // If this terminal has a worktree, show confirmation dialog.
+        if let Some(term) = self.terminals.get(session_id) {
+            if term.worktree_path.is_some() {
+                self.worktree_close_pending = Some(session_id.to_string());
+                return Task::none();
+            }
+        }
+        self.close_terminal_immediate(session_id)
+    }
+
+    fn close_terminal_immediate(&mut self, session_id: &str) -> Task<Message> {
         if self.dragging_tab_id.as_deref() == Some(session_id) {
             self.dragging_tab_id = None;
             self.tab_drag_start_pos = None;
@@ -6613,6 +6743,84 @@ impl GodlyApp {
         }
 
         Task::none()
+    }
+
+    fn handle_terminal_created(&mut self, result: Result<String, String>) -> Task<Message> {
+        match result {
+            Ok(session_id) => {
+                let ws_id = self.workspaces.active_id().map(str::to_string);
+                let in_layout = self
+                    .active_layout()
+                    .map(|layout| layout.find_leaf(&session_id))
+                    .unwrap_or(false);
+                let decision =
+                    tab_reducer::reduce_terminal_created(tab_reducer::TerminalCreatedInput {
+                        session_id,
+                        active_workspace_id: ws_id.clone(),
+                        terminal_in_active_layout: in_layout,
+                    });
+                if let Some(workspace_mutation) = decision.workspace_mutation {
+                    if let Some(ws) = self.workspaces.active_mut() {
+                        match workspace_mutation {
+                            tab_reducer::WorkspaceTerminalMutation::FocusTerminal => {
+                                ws.focused_terminal = decision.session_id.clone();
+                            }
+                            tab_reducer::WorkspaceTerminalMutation::ResetLayoutToSingleTerminal => {
+                                ws.layout = LayoutNode::Leaf {
+                                    terminal_id: decision.session_id.clone(),
+                                };
+                                ws.focused_terminal = decision.session_id.clone();
+                            }
+                        }
+                    }
+                }
+                let (rows, cols) = self.terminal_grid_size(Some(decision.session_id.as_str()));
+                if let Some(ws_id) = &decision.assign_workspace_id {
+                    self.terminals.add_to_workspace(
+                        decision.session_id.clone(),
+                        rows,
+                        cols,
+                        ws_id.clone(),
+                    );
+                } else {
+                    self.terminals.add(decision.session_id.clone(), rows, cols);
+                }
+
+                if decision.set_terminal_active {
+                    self.terminals.set_active(&decision.session_id);
+                }
+                // Start tab entry animation.
+                self.entering_tabs
+                    .insert(decision.session_id.clone(), Self::now_ms());
+
+                // Auto-launch AI tool if workspace has a mode set.
+                if let Some(ws_id) = &ws_id {
+                    if let Some(client) = &self.client {
+                        let cmd = match self.workspace_ai_modes.get(ws_id) {
+                            Some(AiToolMode::Claude) => Some("claude\r"),
+                            Some(AiToolMode::Codex) => Some("codex\r"),
+                            Some(AiToolMode::Both) => Some("claude\r"),
+                            Some(AiToolMode::None) | None => None,
+                        };
+                        if let Some(cmd) = cmd {
+                            if let Err(e) = commands::write_to_terminal(
+                                client,
+                                &decision.session_id,
+                                cmd.as_bytes(),
+                            ) {
+                                log::warn!("Failed to auto-launch AI tool: {e}");
+                            }
+                        }
+                    }
+                }
+
+                self.fetch_grid(&decision.fetch_grid_terminal_id)
+            }
+            Err(e) => {
+                log::error!("Failed to create terminal: {}", e);
+                Task::none()
+            }
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/native/iced-shell/src/confirm_dialog.rs
+++ b/src-tauri/native/iced-shell/src/confirm_dialog.rs
@@ -186,6 +186,153 @@ pub fn view_copy_preview<'a, M: Clone + 'a>(
     )
 }
 
+/// Render a worktree close confirmation dialog with three buttons:
+/// Remove Worktree (danger), Keep Worktree, Cancel.
+pub fn view_worktree_close_confirm<'a, M: Clone + 'a>(
+    worktree_path: &'a str,
+    on_remove: M,
+    on_keep: M,
+    on_cancel: M,
+) -> Element<'a, M> {
+    let body_text = column![
+        text("This terminal uses a git worktree at:")
+            .size(13)
+            .color(TEXT_PRIMARY()),
+        Space::new().height(6.0),
+        container(
+            text(worktree_path).size(12).color(TEXT_SECONDARY())
+        )
+        .padding(Padding::from([6, 10]))
+        .width(Length::Fill)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(BG_TERTIARY())),
+            border: Border {
+                color: BORDER(),
+                width: 1.0,
+                radius: RADIUS_SM.into(),
+            },
+            ..container::Style::default()
+        }),
+        Space::new().height(10.0),
+        text("Remove the worktree from disk, or keep it for later?")
+            .size(13)
+            .color(TEXT_PRIMARY()),
+    ];
+
+    let title_text = text("Close Worktree Terminal?").size(16).color(TEXT_ACTIVE());
+
+    let cancel_btn = button(text("Cancel").size(13).color(TEXT_PRIMARY()))
+        .on_press(on_cancel)
+        .padding(Padding::from([7, 18]))
+        .style(move |_theme, status| {
+            let bg = match status {
+                button::Status::Hovered => BG_TERTIARY(),
+                _ => Color::TRANSPARENT,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color: TEXT_PRIMARY(),
+                border: Border {
+                    color: Color::TRANSPARENT,
+                    width: 0.0,
+                    radius: RADIUS_MD.into(),
+                },
+                ..button::Style::default()
+            }
+        });
+
+    let keep_btn = button(text("Keep Worktree").size(13).color(TEXT_PRIMARY()))
+        .on_press(on_keep)
+        .padding(Padding::from([7, 18]))
+        .style(move |_theme, status| {
+            let bg = match status {
+                button::Status::Hovered => BG_TERTIARY(),
+                _ => Color::TRANSPARENT,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color: TEXT_PRIMARY(),
+                border: Border {
+                    color: BORDER(),
+                    width: 1.0,
+                    radius: RADIUS_MD.into(),
+                },
+                ..button::Style::default()
+            }
+        });
+
+    let danger_color = DANGER();
+    let remove_btn = button(text("Remove Worktree").size(13).color(Color::WHITE))
+        .on_press(on_remove)
+        .padding(Padding::from([7, 18]))
+        .style(move |_theme, status| {
+            let bg = match status {
+                button::Status::Hovered => Color::from_rgba(
+                    (danger_color.r * 1.1).min(1.0),
+                    (danger_color.g * 1.1).min(1.0),
+                    (danger_color.b * 1.1).min(1.0),
+                    1.0,
+                ),
+                _ => danger_color,
+            };
+            button::Style {
+                background: Some(Background::Color(bg)),
+                text_color: Color::WHITE,
+                border: Border {
+                    color: Color::TRANSPARENT,
+                    width: 0.0,
+                    radius: RADIUS_MD.into(),
+                },
+                ..button::Style::default()
+            }
+        });
+
+    let footer = row![
+        Space::new().width(Length::Fill),
+        cancel_btn,
+        keep_btn,
+        remove_btn,
+    ]
+    .spacing(8);
+
+    let dialog_content = column![
+        title_text,
+        Space::new().height(12.0),
+        body_text,
+        Space::new().height(16.0),
+        footer,
+    ];
+
+    let border_color = Color::from_rgba(DANGER().r, DANGER().g, DANGER().b, 0.25);
+
+    let dialog = container(dialog_content)
+        .padding(Padding::from([20, 24]))
+        .width(Length::Fixed(480.0))
+        .style(move |_theme| container::Style {
+            background: Some(Background::Color(BG_SECONDARY())),
+            border: Border {
+                color: border_color,
+                width: 0.5,
+                radius: RADIUS_LG.into(),
+            },
+            shadow: Shadow {
+                color: SHADOW_DANGER(),
+                offset: Vector::new(0.0, 8.0),
+                blur_radius: 24.0,
+            },
+            ..container::Style::default()
+        });
+
+    container(iced::widget::center(dialog))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(BACKDROP())),
+            ..container::Style::default()
+        })
+        .into()
+}
+
 /// Threshold in characters above which a copy preview is shown.
 pub const COPY_PREVIEW_THRESHOLD: usize = 500;
 

--- a/src-tauri/native/iced-shell/src/git_worktree.rs
+++ b/src-tauri/native/iced-shell/src/git_worktree.rs
@@ -1,0 +1,158 @@
+//! Git worktree operations for Godly Terminal's worktree mode.
+//!
+//! All functions are synchronous and use `std::process::Command` to shell out to git.
+//! They are intended to be called from background threads via `Task::perform`.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Check if a directory is inside a git repository.
+pub fn is_git_repo(folder_path: &str) -> bool {
+    Command::new("git")
+        .args(["-C", folder_path, "rev-parse", "--is-inside-work-tree"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Find the root directory of the git repository containing `folder_path`.
+pub fn find_repo_root(folder_path: &str) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(["-C", folder_path, "rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| format!("Failed to run git: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Not a git repository: {stderr}"));
+    }
+
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if root.is_empty() {
+        return Err("git rev-parse returned empty root".to_string());
+    }
+    Ok(root)
+}
+
+/// Generate a unique worktree directory name.
+pub fn generate_worktree_dir_name() -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    format!("godly-wt-{}", &id[..8])
+}
+
+/// Create a git worktree in detached HEAD mode.
+///
+/// Creates the worktree at `<repo_root>/.godly-worktrees/<dir_name>/`.
+/// Returns the absolute path to the created worktree directory.
+pub fn create_worktree(repo_root: &str, dir_name: &str) -> Result<String, String> {
+    let worktrees_dir = Path::new(repo_root).join(".godly-worktrees");
+    let worktree_path = worktrees_dir.join(dir_name);
+    let worktree_path_str = worktree_path
+        .to_str()
+        .ok_or_else(|| "Worktree path contains invalid characters".to_string())?
+        .to_string();
+
+    // Ensure parent directory exists.
+    if !worktrees_dir.exists() {
+        std::fs::create_dir_all(&worktrees_dir)
+            .map_err(|e| format!("Failed to create .godly-worktrees directory: {e}"))?;
+    }
+
+    // Auto-add .godly-worktrees/ to .gitignore if not already present.
+    ensure_gitignore(repo_root);
+
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo_root,
+            "worktree",
+            "add",
+            "--detach",
+            &worktree_path_str,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to run git worktree add: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git worktree add failed: {stderr}"));
+    }
+
+    Ok(worktree_path_str)
+}
+
+/// Remove a git worktree.
+///
+/// Attempts `git worktree remove --force`, falling back to manual directory
+/// removal + `git worktree prune` on failure.
+pub fn remove_worktree(repo_root: &str, worktree_path: &str) -> Result<(), String> {
+    // Try git worktree remove --force first.
+    let output = Command::new("git")
+        .args(["-C", repo_root, "worktree", "remove", "--force", worktree_path])
+        .output()
+        .map_err(|e| format!("Failed to run git worktree remove: {e}"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    // Fallback: remove directory manually and prune.
+    let path = Path::new(worktree_path);
+    if path.exists() {
+        std::fs::remove_dir_all(path)
+            .map_err(|e| format!("Failed to remove worktree directory: {e}"))?;
+    }
+
+    let _ = Command::new("git")
+        .args(["-C", repo_root, "worktree", "prune"])
+        .output();
+
+    Ok(())
+}
+
+/// Ensure `.godly-worktrees/` is in the repo's `.gitignore`.
+fn ensure_gitignore(repo_root: &str) {
+    let gitignore_path = Path::new(repo_root).join(".gitignore");
+    let entry = ".godly-worktrees/";
+
+    if gitignore_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&gitignore_path) {
+            if content.lines().any(|line| line.trim() == entry) {
+                return; // Already present.
+            }
+            // Append to existing .gitignore.
+            let separator = if content.ends_with('\n') { "" } else { "\n" };
+            let new_content = format!("{content}{separator}{entry}\n");
+            let _ = std::fs::write(&gitignore_path, new_content);
+        }
+    } else {
+        // Create new .gitignore with just our entry.
+        let _ = std::fs::write(&gitignore_path, format!("{entry}\n"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_worktree_dir_name_format() {
+        let name = generate_worktree_dir_name();
+        assert!(name.starts_with("godly-wt-"));
+        assert_eq!(name.len(), "godly-wt-".len() + 8);
+    }
+
+    #[test]
+    fn generate_worktree_dir_name_unique() {
+        let a = generate_worktree_dir_name();
+        let b = generate_worktree_dir_name();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn is_git_repo_on_nonexistent_dir() {
+        assert!(!is_git_repo("/nonexistent/path/that/does/not/exist"));
+    }
+}

--- a/src-tauri/native/iced-shell/src/lib.rs
+++ b/src-tauri/native/iced-shell/src/lib.rs
@@ -30,6 +30,7 @@ pub mod terminal_context_menu;
 pub mod whisper_ui;
 pub mod quick_claude_dialog;
 pub mod font_enumerator;
+pub mod git_worktree;
 
 #[cfg(test)]
 pub mod testing;

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -49,6 +49,7 @@ mod quick_claude;
 mod quick_claude_dialog;
 mod session_persistence;
 mod font_enumerator;
+mod git_worktree;
 mod keybinding_persistence;
 
 use app::{GodlyApp, Message};

--- a/src-tauri/native/iced-shell/src/mcp_handler.rs
+++ b/src-tauri/native/iced-shell/src/mcp_handler.rs
@@ -384,6 +384,51 @@ impl GodlyApp {
                 iced::Task::none(),
             ),
 
+            McpRequest::ToggleWorktreeMode { workspace_id } => {
+                if let Some(ws) = self.workspaces.get(&workspace_id) {
+                    let new_mode = !ws.worktree_mode;
+                    let _ = self.workspaces.set_worktree_mode(&workspace_id, new_mode);
+                    let claude_code_mode = false; // TODO: read actual value
+                    (
+                        McpResponse::WorkspaceModes {
+                            worktree_mode: new_mode,
+                            claude_code_mode,
+                        },
+                        iced::Task::none(),
+                    )
+                } else {
+                    (
+                        McpResponse::Error {
+                            message: format!("Workspace {} not found", workspace_id),
+                        },
+                        iced::Task::none(),
+                    )
+                }
+            }
+
+            McpRequest::RemoveWorktree { worktree_path } => {
+                // Find repo root from any active workspace.
+                let repo_root = self.workspaces.active().map(|ws| ws.folder_path.clone());
+                if let Some(root) = repo_root {
+                    match crate::git_worktree::remove_worktree(&root, &worktree_path) {
+                        Ok(()) => (McpResponse::Ok, iced::Task::none()),
+                        Err(e) => (
+                            McpResponse::Error {
+                                message: format!("Failed to remove worktree: {e}"),
+                            },
+                            iced::Task::none(),
+                        ),
+                    }
+                } else {
+                    (
+                        McpResponse::Error {
+                            message: "No active workspace to determine repo root".to_string(),
+                        },
+                        iced::Task::none(),
+                    )
+                }
+            }
+
             other => (
                 McpResponse::Error {
                     message: format!("Unsupported native MCP request: {:?}", other),

--- a/src-tauri/native/iced-shell/src/session_persistence.rs
+++ b/src-tauri/native/iced-shell/src/session_persistence.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,9 @@ pub struct PersistedSessionState {
     pub active_workspace_id: Option<String>,
     pub active_terminal_id: Option<String>,
     pub workspaces: Vec<PersistedWorkspaceState>,
+    /// Worktree paths associated with terminal sessions (terminal_id → worktree_path).
+    #[serde(default)]
+    pub terminal_worktree_paths: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -67,6 +70,8 @@ pub struct MergedSessionState {
     pub active_terminal_id: Option<String>,
     pub workspaces: Vec<MergedWorkspaceState>,
     pub missing_live_terminal_ids: Vec<String>,
+    /// Worktree paths for terminals that survived the merge.
+    pub terminal_worktree_paths: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -330,6 +335,14 @@ pub fn merge_with_live_sessions(
         .cloned()
         .collect();
 
+    // Filter worktree paths to only include live terminals.
+    let terminal_worktree_paths: HashMap<String, String> = persisted
+        .terminal_worktree_paths
+        .iter()
+        .filter(|(id, _)| live_terminal_ids.contains(id.as_str()))
+        .map(|(id, path)| (id.clone(), path.clone()))
+        .collect();
+
     MergedSessionState {
         sidebar_visible: persisted.sidebar_visible,
         settings_open: persisted.settings_open,
@@ -341,6 +354,7 @@ pub fn merge_with_live_sessions(
         active_terminal_id,
         workspaces,
         missing_live_terminal_ids,
+        terminal_worktree_paths,
     }
 }
 
@@ -380,6 +394,7 @@ mod tests {
             next_workspace_num: 4,
             active_workspace_id: Some("w-1".to_string()),
             active_terminal_id: Some("t-2".to_string()),
+            terminal_worktree_paths: HashMap::new(),
             workspaces: vec![PersistedWorkspaceState {
                 id: "w-1".to_string(),
                 name: "Workspace 1".to_string(),
@@ -417,6 +432,7 @@ mod tests {
             next_workspace_num: 8,
             active_workspace_id: Some("w-2".to_string()),
             active_terminal_id: Some("t-3".to_string()),
+            terminal_worktree_paths: HashMap::new(),
             workspaces: vec![
                 PersistedWorkspaceState {
                     id: "w-1".to_string(),
@@ -555,6 +571,7 @@ mod tests {
             next_workspace_num: 2,
             active_workspace_id: Some("w-1".to_string()),
             active_terminal_id: Some("t-1".to_string()),
+            terminal_worktree_paths: HashMap::new(),
             workspaces: vec![PersistedWorkspaceState {
                 id: "w-1".to_string(),
                 name: "Main".to_string(),
@@ -640,6 +657,7 @@ mod tests {
             next_workspace_num: 4,
             active_workspace_id: Some("w-dev".to_string()),
             active_terminal_id: Some("t-old-3".to_string()),
+            terminal_worktree_paths: HashMap::new(),
             workspaces: vec![
                 PersistedWorkspaceState {
                     id: "w-default".to_string(),
@@ -743,6 +761,7 @@ mod tests {
             next_workspace_num: 3,
             active_workspace_id: Some("w-1".to_string()),
             active_terminal_id: Some("t-old-1".to_string()),
+            terminal_worktree_paths: HashMap::new(),
             workspaces: vec![
                 PersistedWorkspaceState {
                     id: "w-1".to_string(),

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -403,6 +403,7 @@ mod tests {
             total_scrollback: 0,
             workspace_id: None,
             custom_name: None,
+            worktree_path: None,
         }
     }
 

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -24,6 +24,8 @@ pub struct TerminalInfo {
     pub workspace_id: Option<String>,
     /// User-assigned custom name (overrides title/process_name in tab label).
     pub custom_name: Option<String>,
+    /// Path to a git worktree created for this terminal (None = normal terminal).
+    pub worktree_path: Option<String>,
 }
 
 impl TerminalInfo {
@@ -360,6 +362,7 @@ impl TerminalCollection {
                 total_scrollback: 0,
                 workspace_id,
                 custom_name: None,
+                worktree_path: None,
             },
         );
         if self.tabs.active_id() == Some(id.as_str()) {
@@ -377,6 +380,13 @@ impl TerminalCollection {
     pub fn rename(&mut self, id: &str, name: Option<String>) {
         if let Some(term) = self.get_mut(id) {
             term.custom_name = name;
+        }
+    }
+
+    /// Set the worktree path for a terminal.
+    pub fn set_worktree_path(&mut self, id: &str, path: String) {
+        if let Some(term) = self.get_mut(id) {
+            term.worktree_path = Some(path);
         }
     }
 


### PR DESCRIPTION
## Summary
Implement workspace-scoped worktree mode that automatically creates git worktrees when new terminals are opened. This provides isolated session contexts within a single git repository.

### Key Features
- Toggle Worktree Mode on any workspace via sidebar context menu
- Auto-create git worktrees in `.godly-worktrees/godly-wt-<uuid>/` when opening terminals in Worktree Mode workspaces
- Confirmation dialog when closing worktree terminals: remove, keep, or cancel
- Auto-add `.godly-worktrees/` to repository `.gitignore` on first creation
- Persist worktree paths across app restarts
- Fallback to normal terminal if not a git repo or worktree creation fails
- MCP handlers for ToggleWorktreeMode and RemoveWorktree commands

### Implementation Details
- New `git_worktree.rs` module for git operations (create, remove, gitignore management)
- Extended `TerminalInfo` with optional `worktree_path` field
- New `ConfirmWorktreeClose` dialog in `confirm_dialog.rs`
- Session persistence for `terminal_worktree_paths` mapping
- Integrated MCP handlers for remote control

### Files Changed
- `src-tauri/native/iced-shell/src/git_worktree.rs` (NEW)
- `src-tauri/native/iced-shell/src/terminal_state.rs`
- `src-tauri/native/iced-shell/src/app.rs`
- `src-tauri/native/iced-shell/src/confirm_dialog.rs`
- `src-tauri/native/iced-shell/src/session_persistence.rs`
- `src-tauri/native/iced-shell/src/mcp_handler.rs`
- `src-tauri/native/iced-shell/src/lib.rs`
- `src-tauri/native/iced-shell/src/main.rs`
- `src-tauri/native/iced-shell/src/tab_bar.rs`
- `changelog/unreleased/feat-worktree-mode.md`