### PR TITLE
feat: live font preview in settings

### DIFF
--- a/changelog/unreleased/695-live-font-preview.md
+++ b/changelog/unreleased/695-live-font-preview.md
@@ -1,0 +1,5 @@
+### Added
+- **Live font preview in settings** — Settings dialog backdrop opacity reduced to 0.35 so users can see real-time terminal preview while changing fonts (#695)
+
+### Changed
+- **Font selection UI** — Current font selection now indicated with a checkmark in the Appearance tab

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -4183,11 +4183,23 @@ impl GodlyApp {
                     .font(preview_font)
                     .color(if is_active { TEXT_ACTIVE() } else { TEXT_PRIMARY() });
 
+                let font_label_row: Element<'_, Message> = if is_active {
+                    row![
+                        text("\u{2713}").size(13).color(ACCENT()),
+                        label,
+                    ]
+                    .spacing(6)
+                    .align_y(iced::Alignment::Center)
+                    .into()
+                } else {
+                    label.into()
+                };
+
                 let border_color = if is_active { ACCENT() } else { BORDER() };
                 let bg_color = if is_active { BG_TERTIARY() } else { BG_SECONDARY() };
 
                 let font_btn = button(
-                    container(label).padding(Padding::from([6, 10])),
+                    container(font_label_row).padding(Padding::from([6, 10])),
                 )
                 .on_press(Message::FontFamilyChanged(name_clone))
                 .padding(0)

--- a/src-tauri/native/iced-shell/src/settings_dialog.rs
+++ b/src-tauri/native/iced-shell/src/settings_dialog.rs
@@ -218,7 +218,7 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
         .width(Length::Fill)
         .height(Length::Fill)
         .style(|_theme| container::Style {
-            background: Some(Background::Color(tint(BACKDROP(), 0.84))),
+            background: Some(Background::Color(tint(BACKDROP(), 0.35))),
             ..container::Style::default()
         })
         .into()


### PR DESCRIPTION
## Summary
Enables live preview of font changes in the Settings dialog by making the dialog backdrop more transparent. Users can now see terminal rendering in real time while adjusting fonts.

## Changes
- Reduce settings dialog backdrop opacity from 0.84 to 0.35
- Add checkmark indicator next to currently selected font in Appearance tab
- Include changelog fragment

## Test plan
1. Open Settings (Cmd/Ctrl+,)
2. Navigate to Appearance tab
3. Verify checkmark appears next to current font
4. Verify terminal is visible behind dialog (not opaque)
5. Change font and observe live preview in terminal behind dialog

Fixes #695