### PR TITLE
fix: add Shift+Home/End keybindings for scrollback navigation

### DIFF
--- a/changelog/unreleased/678-shift-home-end-scroll.md
+++ b/changelog/unreleased/678-shift-home-end-scroll.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Shift+Home/End scroll keybindings** — Shift+Home now scrolls to top and Shift+End scrolls to bottom, matching standard terminal emulator behavior alongside Ctrl+Home/End (#678)

--- a/src-tauri/native/app-adapter/src/shortcuts.rs
+++ b/src-tauri/native/app-adapter/src/shortcuts.rs
@@ -373,7 +373,9 @@ fn check_named_shortcut(named: &Named, ctrl: bool, shift: bool, alt: bool) -> Op
         Named::PageUp if shift && !ctrl => Some(AppAction::ScrollPageUp),
         Named::PageDown if shift && !ctrl => Some(AppAction::ScrollPageDown),
         Named::Home if ctrl && !shift => Some(AppAction::ScrollToTop),
+        Named::Home if shift && !ctrl => Some(AppAction::ScrollToTop),
         Named::End if ctrl && !shift => Some(AppAction::ScrollToBottom),
+        Named::End if shift && !ctrl => Some(AppAction::ScrollToBottom),
         _ => None,
     }
 }
@@ -632,8 +634,11 @@ mod tests {
         assert_eq!(check_app_shortcut(&named_key(Named::Home), NONE), None);
     }
     #[test]
-    fn shift_home_is_not_shortcut() {
-        assert_eq!(check_app_shortcut(&named_key(Named::Home), shift()), None);
+    fn shift_home_is_scroll_to_top() {
+        assert_eq!(
+            check_app_shortcut(&named_key(Named::Home), shift()),
+            Some(AppAction::ScrollToTop)
+        );
     }
     #[test]
     fn ctrl_shift_home_is_not_shortcut() {
@@ -654,8 +659,11 @@ mod tests {
         assert_eq!(check_app_shortcut(&named_key(Named::End), NONE), None);
     }
     #[test]
-    fn shift_end_is_not_shortcut() {
-        assert_eq!(check_app_shortcut(&named_key(Named::End), shift()), None);
+    fn shift_end_is_scroll_to_bottom() {
+        assert_eq!(
+            check_app_shortcut(&named_key(Named::End), shift()),
+            Some(AppAction::ScrollToBottom)
+        );
     }
     #[test]
     fn ctrl_shift_end_is_not_shortcut() {

--- a/src-tauri/native/iced-shell/src/shortcuts_tab.rs
+++ b/src-tauri/native/iced-shell/src/shortcuts_tab.rs
@@ -107,11 +107,11 @@ const SCROLLBACK: &[ShortcutEntry] = &[
     },
     ShortcutEntry {
         action: "Scroll Top",
-        keys: "Ctrl+Home",
+        keys: "Ctrl+Home / Shift+Home",
     },
     ShortcutEntry {
         action: "Scroll Bottom",
-        keys: "Ctrl+End",
+        keys: "Ctrl+End / Shift+End",
     },
 ];
 


### PR DESCRIPTION
## Summary
- Added Shift+Home → ScrollToTop and Shift+End → ScrollToBottom keybindings
- Updated UI display strings to show "Ctrl+Home / Shift+Home" and "Ctrl+End / Shift+End"
- Updated tests to assert correct scroll actions instead of None

This fixes issue #678, where Shift+Home/End were not bound to scroll actions. Standard terminal emulators support both modifier combos (Ctrl and Shift variants).

Fixes #678