### PR TITLE
fix: apply font setting to UI chrome elements

### DIFF
--- a/changelog/unreleased/698-font-setting-chrome-elements.md
+++ b/changelog/unreleased/698-font-setting-chrome-elements.md
@@ -1,0 +1,2 @@
+### Changed
+- **Font setting now applies to UI chrome** — workspace sidebar names, tab bar labels, title bar text, and status bar CWD now respect the Settings > Appearance font configuration (#698)

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -3518,6 +3518,7 @@ impl GodlyApp {
         let title = self.title();
         let title_bar_row = title_bar::view_title_bar(
             title,
+            self.terminal_font,
             Message::TitleBarDragStart,
             Message::TitleBarMinimize,
             Message::TitleBarToggleMaximize,
@@ -3533,6 +3534,7 @@ impl GodlyApp {
             &ordered,
             active_id,
             &entry_progress,
+            self.terminal_font,
             |id| Message::TabClicked(id),
             |id| Message::CloseTabRequested(id),
             |id| Message::TabDragStart(id),
@@ -3614,6 +3616,7 @@ impl GodlyApp {
                     },
                 ),
                 sidebar_width,
+                self.terminal_font,
                 Message::SidebarAction,
                 Message::SidebarResizeStart,
                 Message::SidebarResizeEnd,

--- a/src-tauri/native/iced-shell/src/sidebar.rs
+++ b/src-tauri/native/iced-shell/src/sidebar.rs
@@ -3,7 +3,7 @@ use std::f32::consts::TAU;
 use iced::widget::{
     button, canvas, column, container, mouse_area, row, rule, scrollable, text, Space,
 };
-use iced::{Border, Color, Element, Length, Padding, Point, Rectangle, Renderer, Size, Theme};
+use iced::{Border, Color, Element, Font, Length, Padding, Point, Rectangle, Renderer, Size, Theme};
 
 use crate::theme::{
     ACCENT_HOVER, BG_SECONDARY, BORDER, DANGER, GHOST_HOVER, GHOST_SELECTED, SURFACE_BG,
@@ -226,6 +226,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
     active_id: Option<&str>,
     workspace_signals: S,
     sidebar_width: f32,
+    font: Font,
     on_action: impl Fn(SidebarAction) -> M + 'a,
     on_resize_start: M,
     on_resize_end: M,
@@ -243,7 +244,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
 
         let row_text = TEXT_PRIMARY();
 
-        let name_label = text(&ws.name).size(13).color(row_text);
+        let name_label = text(&ws.name).size(13).color(row_text).font(font);
 
         let terminal_count = ws.layout.leaf_count();
         let badge_bg = GHOST_HOVER();
@@ -670,6 +671,7 @@ mod tests {
             None,
             None,
             SIDEBAR_WIDTH,
+            Font::default(),
             |_action| TestMsg::Action,
             TestMsg::ResizeStart,
             TestMsg::ResizeEnd,
@@ -684,6 +686,7 @@ mod tests {
             Some("w1"),
             None,
             SIDEBAR_WIDTH,
+            Font::default(),
             |_action| TestMsg::Action,
             TestMsg::ResizeStart,
             TestMsg::ResizeEnd,
@@ -702,6 +705,7 @@ mod tests {
             Some("w2"),
             Some("w2"),
             SIDEBAR_WIDTH,
+            Font::default(),
             |_action| TestMsg::Action,
             TestMsg::ResizeStart,
             TestMsg::ResizeEnd,
@@ -723,6 +727,7 @@ mod tests {
             Some("w1"),
             (Some("w2"), has_notification as fn(&str) -> bool),
             SIDEBAR_WIDTH,
+            Font::default(),
             |_action| TestMsg::Action,
             TestMsg::ResizeStart,
             TestMsg::ResizeEnd,
@@ -752,6 +757,7 @@ mod tests {
             Some("w1"),
             None,
             72.0,
+            Font::default(),
             |_action| TestMsg::Action,
             TestMsg::ResizeStart,
             TestMsg::ResizeEnd,

--- a/src-tauri/native/iced-shell/src/status_bar.rs
+++ b/src-tauri/native/iced-shell/src/status_bar.rs
@@ -61,7 +61,8 @@ pub fn view_status_bar<'a, M: Clone + 'a>(info: Option<StatusBarInfo<'_>>) -> El
 
     let cwd_text = text(cwd)
         .size(11)
-        .color(TEXT_SECONDARY());
+        .color(TEXT_SECONDARY())
+        .font(status_font);
 
     let dims_text = text(dims)
         .size(11)

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use iced::widget::{button, column, container, mouse_area, row, rule, text, Space};
-use iced::{Border, Color, Element, Length, Padding};
+use iced::{Border, Color, Element, Font, Length, Padding};
 
 use crate::terminal_state::TerminalInfo;
 use crate::theme::{
@@ -155,6 +155,7 @@ pub fn view_tab_bar<'a, M: Clone + 'a>(
     terminals: &[&'a TerminalInfo],
     active_id: Option<&str>,
     entry_progress: &HashMap<String, f32>,
+    font: Font,
     on_tab_click: impl Fn(String) -> M + 'a,
     on_close: impl Fn(String) -> M + 'a,
     on_drag_start: impl Fn(String) -> M + 'a,
@@ -180,7 +181,7 @@ pub fn view_tab_bar<'a, M: Clone + 'a>(
         };
 
         let truncated = truncate_label(&terminal.tab_label(), 30);
-        let label = text(truncated).size(13).color(text_color);
+        let label = text(truncated).size(13).color(text_color).font(font);
         let icon_glyph = process_icon_glyph(terminal).map(|glyph| {
             let icon_color = if is_active { ACCENT() } else { TEXT_SECONDARY() };
             text(glyph).size(14).color(icon_color)
@@ -374,6 +375,7 @@ mod tests {
         truncate_label, view_tab_bar,
     };
     use crate::terminal_state::TerminalInfo;
+    use iced::Font;
 
     #[derive(Clone)]
     enum TestMessage {
@@ -471,6 +473,7 @@ mod tests {
             &terminals,
             Some("t-1"),
             &no_anim,
+            Font::default(),
             |_| TestMessage::TabClicked,
             |_| TestMessage::TabClosed,
             |_| TestMessage::TabDragStart,
@@ -493,6 +496,7 @@ mod tests {
             &terminals,
             Some("t-0"),
             &no_anim,
+            Font::default(),
             |_| TestMessage::TabClicked,
             |_| TestMessage::TabClosed,
             |_| TestMessage::TabDragStart,
@@ -515,6 +519,7 @@ mod tests {
             &terminals,
             Some("t-1"),
             &no_anim,
+            Font::default(),
             |_| TestMessage::TabClicked,
             |_| TestMessage::TabClosed,
             |_| TestMessage::TabDragStart,

--- a/src-tauri/native/iced-shell/src/title_bar.rs
+++ b/src-tauri/native/iced-shell/src/title_bar.rs
@@ -1,5 +1,5 @@
 use iced::widget::{button, canvas, container, mouse_area, row, text};
-use iced::{Border, Color, Element, Length, Padding, Point, Rectangle, Renderer, Size, Theme};
+use iced::{Border, Color, Element, Font, Length, Padding, Point, Rectangle, Renderer, Size, Theme};
 
 use crate::theme::{DANGER, GHOST_HOVER, TEXT_SECONDARY, TITLE_BAR_BG};
 
@@ -65,6 +65,7 @@ impl<Message> canvas::Program<Message> for TerminalIcon {
 /// Renders the custom window title bar with drag area and control buttons.
 pub fn view_title_bar<'a, M: Clone + 'a>(
     title: String,
+    font: Font,
     on_drag: M,
     on_minimize: M,
     on_maximize: M,
@@ -78,7 +79,8 @@ pub fn view_title_bar<'a, M: Clone + 'a>(
 
     let title_text = text(title)
         .size(12.5)
-        .color(TEXT_SECONDARY());
+        .color(TEXT_SECONDARY())
+        .font(font);
 
     let title_content = row![
         container(icon).padding(Padding { top: 0.0, right: 6.0, bottom: 0.0, left: 8.0 }),
@@ -161,6 +163,7 @@ mod tests {
     fn title_bar_renders_without_panic() {
         let _ = view_title_bar(
             "pwsh — Godly Terminal".to_string(),
+            Font::default(),
             Msg::Drag,
             Msg::Min,
             Msg::Max,


### PR DESCRIPTION
## Summary

The terminal font setting (configured in Settings > Appearance) now applies to all UI chrome elements — workspace sidebar names, tab bar labels, title bar text, and status bar CWD display.

## Changes

- Added `font` parameter to `view_sidebar`, `view_tab_bar`, and `view_title_bar` functions in their respective modules
- Applied `.font(font)` styling to text elements in sidebar, tab bar, and title bar
- Fixed missing font styling in status bar (CWD text was not respecting the setting)
- Updated all call sites in `app.rs` to pass `terminal_font` to these view functions

## Test Plan

- [x] Verify Settings > Appearance font selection changes workspace names in sidebar
- [x] Verify font selection changes tab labels in tab bar
- [x] Verify font selection changes title bar text
- [x] Verify font selection changes status bar CWD text
- [x] Verify tests updated for new function signatures

Fixes #678