### PR TITLE
fix: use measured font metrics from swash instead of hardcoded ratios

### DIFF
--- a/changelog/unreleased/measured-font-metrics.md
+++ b/changelog/unreleased/measured-font-metrics.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Measured font metrics** — Terminal cell dimensions now use real font measurements via swash instead of hardcoded heuristic ratios, fixing character spacing gaps

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "godly-protocol",
  "iced",
  "log",
+ "swash",
 ]
 
 [[package]]

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -107,6 +107,23 @@ use crate::terminal_context_menu::{self, TermCtxAction};
 use crate::shell_picker::{self, AiToolMode, ShellPickerState, ShellPickerTab};
 use crate::whisper_ui;
 
+/// Default font family name for the bundled Geist Mono font.
+const DEFAULT_FONT_FAMILY: &str = "Geist Mono";
+
+/// Bundled Geist Mono Regular font bytes for measured metrics.
+/// Same file as the `fonts::REGULAR` constant in `main.rs`.
+const GEIST_MONO_REGULAR: &[u8] = include_bytes!("../fonts/GeistMono-Regular.ttf");
+
+/// Create font metrics using the bundled Geist Mono font file for accurate
+/// measurements. Falls back to heuristic ratios for non-default font families.
+fn measured_font_metrics(font_size: f32, font_family: &str) -> FontMetrics {
+    if font_family == DEFAULT_FONT_FAMILY {
+        FontMetrics::from_font_bytes(font_size, GEIST_MONO_REGULAR)
+    } else {
+        FontMetrics::from_font_size(font_size)
+    }
+}
+
 #[path = "mru_switcher.rs"]
 mod mru_switcher;
 
@@ -480,7 +497,7 @@ impl Default for GodlyApp {
             window_height: 800.0,
             window_id: None,
             window_focused: true,
-            font_metrics: FontMetrics::default(),
+            font_metrics: measured_font_metrics(14.0, DEFAULT_FONT_FAMILY),
             selection: SelectionState::default(),
             sidebar_visible: true,
             sidebar_width: SIDEBAR_WIDTH,
@@ -564,7 +581,7 @@ impl Default for GodlyApp {
             whisper_state: None,
             whisper_service: None,
             pending_screenshot_reply: None,
-            font_family: "Geist Mono".to_string(),
+            font_family: DEFAULT_FONT_FAMILY.to_string(),
             terminal_font: iced::Font {
                 family: iced::font::Family::Name("Geist Mono"),
                 weight: iced::font::Weight::Normal,
@@ -3016,13 +3033,13 @@ impl GodlyApp {
             }
             Message::FontSizeIncrement => {
                 log::info!("[FONT] size increment: {} -> {}", self.font_metrics.font_size, self.font_metrics.font_size + 1.0);
-                self.font_metrics = FontMetrics::from_font_size(self.font_metrics.font_size + 1.0);
+                self.font_metrics = measured_font_metrics(self.font_metrics.font_size + 1.0, &self.font_family);
                 return self.resize_all_terminals();
             }
             Message::FontSizeDecrement => {
                 let new_size = (self.font_metrics.font_size - 1.0).max(8.0);
                 log::info!("[FONT] size decrement: {} -> {}", self.font_metrics.font_size, new_size);
-                self.font_metrics = FontMetrics::from_font_size(new_size);
+                self.font_metrics = measured_font_metrics(new_size, &self.font_family);
                 return self.resize_all_terminals();
             }
             Message::ShortcutBadgeClicked(index) => {
@@ -5434,16 +5451,16 @@ impl GodlyApp {
                 self.cycle_tabs_by_mru(tab_reducer::TabMruCycleDirection::Backward)
             }
             AppAction::ZoomIn => {
-                self.font_metrics = FontMetrics::from_font_size(self.font_metrics.font_size + 1.0);
+                self.font_metrics = measured_font_metrics(self.font_metrics.font_size + 1.0, &self.font_family);
                 self.resize_all_terminals()
             }
             AppAction::ZoomOut => {
                 let new_size = (self.font_metrics.font_size - 1.0).max(8.0);
-                self.font_metrics = FontMetrics::from_font_size(new_size);
+                self.font_metrics = measured_font_metrics(new_size, &self.font_family);
                 self.resize_all_terminals()
             }
             AppAction::ZoomReset => {
-                self.font_metrics = FontMetrics::default();
+                self.font_metrics = measured_font_metrics(14.0, &self.font_family);
                 self.resize_all_terminals()
             }
             AppAction::ScrollPageUp => {
@@ -6050,7 +6067,7 @@ impl GodlyApp {
                     self.sidebar_visible = merged.sidebar_visible;
                     self.settings_open = merged.settings_open;
                     self.settings_tab = merged.settings_tab.clone();
-                    self.font_metrics = FontMetrics::from_font_size(merged.font_size);
+                    self.font_metrics = measured_font_metrics(merged.font_size, &merged.font_family);
                     self.font_family = merged.font_family.clone();
                     let interned = font_enumerator::intern_font_name(&merged.font_family);
                     self.terminal_font = iced::Font {

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -82,6 +82,7 @@ fn main() -> iced::Result {
     iced::application(boot, GodlyApp::update, GodlyApp::view)
         .title(GodlyApp::title)
         .subscription(GodlyApp::subscription)
+        .antialiasing(true)
         .font(fonts::REGULAR)
         .font(fonts::BOLD)
         .font(fonts::ITALIC)

--- a/src-tauri/native/terminal-surface/Cargo.toml
+++ b/src-tauri/native/terminal-surface/Cargo.toml
@@ -9,3 +9,4 @@ description = "Custom Iced widget for rendering terminal grid via wgpu"
 iced.workspace = true
 godly-protocol = { path = "../../protocol" }
 log = "0.4"
+swash = "0.2"

--- a/src-tauri/native/terminal-surface/src/font_metrics.rs
+++ b/src-tauri/native/terminal-surface/src/font_metrics.rs
@@ -39,6 +39,51 @@ impl FontMetrics {
             baseline_offset,
         }
     }
+
+    /// Create font metrics by measuring the actual font file via swash.
+    ///
+    /// Reads ascent, descent, and leading from the font's OS/2 and hhea tables,
+    /// and measures the advance width of the '0' glyph for the cell width.
+    /// Falls back to [`from_font_size`](Self::from_font_size) if the font
+    /// data cannot be parsed.
+    pub fn from_font_bytes(font_size: f32, font_data: &[u8]) -> Self {
+        let font = match swash::FontRef::from_index(font_data, 0) {
+            Some(f) => f,
+            None => return Self::from_font_size(font_size),
+        };
+
+        let metrics = font.metrics(&[]);
+        let upem = metrics.units_per_em as f32;
+        if upem == 0.0 {
+            return Self::from_font_size(font_size);
+        }
+
+        let scale = font_size / upem;
+        let ascent = metrics.ascent * scale;
+        let descent = metrics.descent.abs() * scale;
+        let leading = metrics.leading * scale;
+
+        let cell_height = ascent + descent + leading;
+        let baseline_offset = ascent;
+
+        // Measure advance width of '0' for cell width
+        let charmap = font.charmap();
+        let glyph_id = charmap.map('0');
+        let glyph_metrics = font.glyph_metrics(&[]).scale(font_size);
+        let cell_width = glyph_metrics.advance_width(glyph_id);
+
+        // Sanity check: if measurements look unreasonable, fall back
+        if cell_width <= 0.0 || cell_height <= 0.0 || baseline_offset <= 0.0 {
+            return Self::from_font_size(font_size);
+        }
+
+        Self {
+            cell_width,
+            cell_height,
+            font_size,
+            baseline_offset,
+        }
+    }
 }
 
 impl Default for FontMetrics {
@@ -112,5 +157,57 @@ mod tests {
                 size
             );
         }
+    }
+
+    /// Geist Mono Regular font bytes for testing measured metrics.
+    const GEIST_MONO: &[u8] = include_bytes!("../../iced-shell/fonts/GeistMono-Regular.ttf");
+
+    #[test]
+    fn from_font_bytes_cell_width_positive_and_less_than_font_size() {
+        for size in [12.0, 14.0, 16.0, 20.0] {
+            let m = FontMetrics::from_font_bytes(size, GEIST_MONO);
+            assert!(
+                m.cell_width > 0.0 && m.cell_width < size,
+                "cell_width ({}) should be > 0 and < font_size ({}) for monospace",
+                m.cell_width,
+                size,
+            );
+        }
+    }
+
+    #[test]
+    fn from_font_bytes_cell_height_greater_than_width() {
+        let m = FontMetrics::from_font_bytes(14.0, GEIST_MONO);
+        assert!(
+            m.cell_height > m.cell_width,
+            "cell_height ({}) should be > cell_width ({}) for monospace",
+            m.cell_height,
+            m.cell_width,
+        );
+    }
+
+    #[test]
+    fn from_font_bytes_baseline_within_cell() {
+        let m = FontMetrics::from_font_bytes(14.0, GEIST_MONO);
+        assert!(
+            m.baseline_offset > 0.0 && m.baseline_offset < m.cell_height,
+            "baseline_offset ({}) should be within (0, {})",
+            m.baseline_offset,
+            m.cell_height,
+        );
+    }
+
+    #[test]
+    fn from_font_bytes_invalid_data_falls_back() {
+        let m = FontMetrics::from_font_bytes(14.0, b"not a font");
+        let fallback = FontMetrics::from_font_size(14.0);
+        assert_eq!(m, fallback, "invalid font data should fall back to heuristic");
+    }
+
+    #[test]
+    fn from_font_bytes_empty_data_falls_back() {
+        let m = FontMetrics::from_font_bytes(14.0, &[]);
+        let fallback = FontMetrics::from_font_size(14.0);
+        assert_eq!(m, fallback, "empty font data should fall back to heuristic");
     }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded font metric ratios (0.6x width, 1.3x height) with real measurements from the bundled Geist Mono font file using the `swash` crate
- Add `FontMetrics::from_font_bytes()` constructor that reads ascent/descent/leading and glyph advance width from the actual font tables
- Enable MSAA antialiasing on the iced application for improved rendering quality
- Falls back to the existing heuristic ratios for non-bundled (system) fonts

## Test plan
- [x] `cargo test -p godly-terminal-surface` — 19 tests pass (5 new tests for measured metrics + fallback behavior)
- [x] `cargo check -p godly-iced-shell` — compiles cleanly
- [x] `cargo build -p godly-iced-shell` — binary builds successfully
- [ ] Visual verification: launch app and confirm text spacing looks correct at default and zoomed sizes