### PR TITLE
feat: use proportional sans-serif font for UI chrome

### DIFF
--- a/changelog/unreleased/feat-ui-proportional-font.md
+++ b/changelog/unreleased/feat-ui-proportional-font.md
@@ -1,0 +1,2 @@
+### Changed
+- **Proportional font for UI chrome** — title bar, tab bar, and status bar now use the system sans-serif font (Segoe UI on Windows) instead of Geist Mono for improved readability at small sizes

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -62,7 +62,16 @@ use iced::keyboard;
 use iced::widget::{
     button, canvas, center, column, container, mouse_area, row, stack, text, text_input, Space,
 };
-use iced::{event, window, Color, Element, Length, Padding, Point, Shadow, Subscription, Task, Vector};
+use iced::{event, window, Color, Element, Font, Length, Padding, Point, Shadow, Subscription, Task, Vector};
+
+/// Proportional UI font for chrome elements (title bar, tab bar, status bar).
+/// Uses the system's default sans-serif (Segoe UI on Windows, SF Pro on macOS).
+const UI_FONT: Font = Font {
+    family: iced::font::Family::SansSerif,
+    weight: iced::font::Weight::Normal,
+    stretch: iced::font::Stretch::Normal,
+    style: iced::font::Style::Normal,
+};
 
 use godly_app_adapter::clipboard;
 use godly_app_adapter::commands;
@@ -3518,6 +3527,7 @@ impl GodlyApp {
         let title = self.title();
         let title_bar_row = title_bar::view_title_bar(
             title,
+            UI_FONT,
             Message::TitleBarDragStart,
             Message::TitleBarMinimize,
             Message::TitleBarToggleMaximize,
@@ -3533,6 +3543,7 @@ impl GodlyApp {
             &ordered,
             active_id,
             &entry_progress,
+            UI_FONT,
             |id| Message::TabClicked(id),
             |id| Message::CloseTabRequested(id),
             |id| Message::TabDragStart(id),
@@ -3579,7 +3590,7 @@ impl GodlyApp {
                 cwd: term.extract_cwd().unwrap_or(""),
                 cols: term.cols,
                 rows: term.rows,
-                font: self.terminal_font,
+                font: UI_FONT,
             });
         let status_bar_el: Element<'_, Message> = status_bar::view_status_bar(status_info);
 

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use iced::widget::{button, column, container, mouse_area, row, rule, text, Space};
-use iced::{Border, Color, Element, Length, Padding};
+use iced::{Border, Color, Element, Font, Length, Padding};
 
 use crate::terminal_state::TerminalInfo;
 use crate::theme::{
@@ -155,6 +155,7 @@ pub fn view_tab_bar<'a, M: Clone + 'a>(
     terminals: &[&'a TerminalInfo],
     active_id: Option<&str>,
     entry_progress: &HashMap<String, f32>,
+    font: Font,
     on_tab_click: impl Fn(String) -> M + 'a,
     on_close: impl Fn(String) -> M + 'a,
     on_drag_start: impl Fn(String) -> M + 'a,
@@ -180,7 +181,7 @@ pub fn view_tab_bar<'a, M: Clone + 'a>(
         };
 
         let truncated = truncate_label(&terminal.tab_label(), 30);
-        let label = text(truncated).size(13).color(text_color);
+        let label = text(truncated).size(13).font(font).color(text_color);
         let icon_glyph = process_icon_glyph(terminal).map(|glyph| {
             let icon_color = if is_active { ACCENT() } else { TEXT_SECONDARY() };
             text(glyph).size(14).color(icon_color)
@@ -369,6 +370,8 @@ pub fn view_tab_bar<'a, M: Clone + 'a>(
 mod tests {
     use std::collections::HashMap;
 
+    use iced::Font;
+
     use super::{
         contains_ascii_insensitive, process_badge_label, process_icon_glyph, separator_after_tab,
         truncate_label, view_tab_bar,
@@ -471,6 +474,7 @@ mod tests {
             &terminals,
             Some("t-1"),
             &no_anim,
+            Font::default(),
             |_| TestMessage::TabClicked,
             |_| TestMessage::TabClosed,
             |_| TestMessage::TabDragStart,
@@ -493,6 +497,7 @@ mod tests {
             &terminals,
             Some("t-0"),
             &no_anim,
+            Font::default(),
             |_| TestMessage::TabClicked,
             |_| TestMessage::TabClosed,
             |_| TestMessage::TabDragStart,
@@ -515,6 +520,7 @@ mod tests {
             &terminals,
             Some("t-1"),
             &no_anim,
+            Font::default(),
             |_| TestMessage::TabClicked,
             |_| TestMessage::TabClosed,
             |_| TestMessage::TabDragStart,

--- a/src-tauri/native/iced-shell/src/title_bar.rs
+++ b/src-tauri/native/iced-shell/src/title_bar.rs
@@ -1,5 +1,5 @@
 use iced::widget::{button, canvas, container, mouse_area, row, text};
-use iced::{Border, Color, Element, Length, Padding, Point, Rectangle, Renderer, Size, Theme};
+use iced::{Border, Color, Element, Font, Length, Padding, Point, Rectangle, Renderer, Size, Theme};
 
 use crate::theme::{DANGER, GHOST_HOVER, TEXT_SECONDARY, TITLE_BAR_BG};
 
@@ -65,6 +65,7 @@ impl<Message> canvas::Program<Message> for TerminalIcon {
 /// Renders the custom window title bar with drag area and control buttons.
 pub fn view_title_bar<'a, M: Clone + 'a>(
     title: String,
+    font: Font,
     on_drag: M,
     on_minimize: M,
     on_maximize: M,
@@ -78,6 +79,7 @@ pub fn view_title_bar<'a, M: Clone + 'a>(
 
     let title_text = text(title)
         .size(12.5)
+        .font(font)
         .color(TEXT_SECONDARY());
 
     let title_content = row![
@@ -161,6 +163,7 @@ mod tests {
     fn title_bar_renders_without_panic() {
         let _ = view_title_bar(
             "pwsh — Godly Terminal".to_string(),
+            Font::default(),
             Msg::Drag,
             Msg::Min,
             Msg::Max,


### PR DESCRIPTION
## Summary
- Title bar, tab bar, and status bar now use the system default sans-serif font (`Family::SansSerif` — Segoe UI on Windows, SF Pro on macOS) instead of the monospace Geist Mono font
- Adds a `UI_FONT` constant and passes it through `view_title_bar`, `view_tab_bar`, and `StatusBarInfo`
- Proportional fonts render more naturally at small sizes for non-terminal UI text

## Test plan
- [x] `cargo check -p godly-iced-shell` — compiles cleanly
- [x] `cargo test -p godly-iced-shell` — all 315 tests pass
- [x] `cargo build -p godly-iced-shell` — binary builds
- [ ] Visual verification: launch app and confirm title bar, tab labels, and status bar use a proportional font