### PR TITLE
feat: glyph atlas rendering pipeline

### DIFF
--- a/changelog/unreleased/glyph-atlas-renderer.md
+++ b/changelog/unreleased/glyph-atlas-renderer.md
@@ -1,0 +1,4 @@
+### Added
+- **Glyph atlas rendering pipeline** — New CPU-side glyph rasterization with swash, glyph cache, and pixel buffer compositor replaces per-cell `fill_text()` canvas calls for dramatically faster and higher-quality terminal text rendering
+- **Image widget integration** — Terminal panes now use pre-rendered pixel buffers via Iced's image widget instead of canvas text rendering
+- **Font fallback** — System font fallback chain for characters not in the primary terminal font

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -56,6 +56,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +229,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +256,15 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "ash"
@@ -441,6 +485,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,7 +612,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -548,7 +635,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -573,6 +660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +676,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
 
 [[package]]
 name = "block"
@@ -629,6 +731,12 @@ dependencies = [
  "futures-lite",
  "piper",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -749,7 +857,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -887,6 +995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1084,15 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1078,7 +1201,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -1099,7 +1222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1329,6 +1452,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1531,21 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1680,6 +1838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,9 +2063,11 @@ version = "0.1.0"
 name = "godly-terminal-surface"
 version = "0.1.0"
 dependencies = [
+ "fontdb",
  "godly-protocol",
  "iced",
  "log",
+ "swash",
 ]
 
 [[package]]
@@ -2182,6 +2352,7 @@ dependencies = [
  "iced_runtime",
  "iced_widget",
  "iced_winit",
+ "image",
  "thiserror 2.0.18",
 ]
 
@@ -2241,6 +2412,8 @@ dependencies = [
  "half",
  "iced_core",
  "iced_futures",
+ "image",
+ "kamadak-exif",
  "log",
  "lyon_path",
  "raw-window-handle",
@@ -2466,13 +2639,37 @@ checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.12",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -2482,6 +2679,17 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2531,6 +2739,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2608,6 +2825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,10 +2873,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -2732,6 +2974,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "lru"
@@ -2823,6 +3074,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "memchr"
@@ -2947,6 +3208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
+
+[[package]]
 name = "naga"
 version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3321,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "ntest"
@@ -3092,6 +3380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3398,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3627,6 +3945,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,6 +4182,19 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "pxfm"
@@ -3866,6 +4203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3938,6 +4284,56 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -4093,6 +4489,12 @@ dependencies = [
  "web-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "roxmltree"
@@ -4392,6 +4794,15 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5194,6 +5605,17 @@ dependencies = [
  "getrandom",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -6295,6 +6717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6487,6 +6915,15 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 parking_lot = "0.12"
 godly-protocol = { path = "protocol" }
-iced = { version = "0.14", features = ["wgpu", "advanced", "canvas", "tokio"] }
+iced = { version = "0.14", features = ["wgpu", "advanced", "canvas", "tokio", "image"] }
 
 [workspace.dependencies.winapi]
 version = "0.3"

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -465,6 +465,15 @@ pub struct GodlyApp {
     available_fonts: Option<Vec<String>>,
     /// Search/filter query for font list.
     font_filter_query: String,
+    // --- Pixel Renderer (glyph atlas pipeline) ---
+    /// Glyph cache for the pixel rendering pipeline.
+    glyph_cache: godly_terminal_surface::glyph_cache::GlyphCache,
+    /// Primary font rasterizer (swash-based).
+    glyph_rasterizer: godly_terminal_surface::swash_rasterizer::SwashRasterizer,
+    /// Reusable pixel renderer (keeps buffer between frames to avoid reallocation).
+    pixel_renderer: godly_terminal_surface::pixel_renderer::PixelRenderer,
+    /// Whether to use the new image-based renderer instead of the canvas.
+    use_pixel_renderer: bool,
 }
 
 impl Default for GodlyApp {
@@ -573,6 +582,18 @@ impl Default for GodlyApp {
             },
             available_fonts: None,
             font_filter_query: String::new(),
+            glyph_cache: godly_terminal_surface::glyph_cache::GlyphCache::new(),
+            glyph_rasterizer: {
+                use godly_terminal_surface::glyph_rasterizer::GlyphRasterizer as _;
+                let mut r = godly_terminal_surface::swash_rasterizer::SwashRasterizer::new();
+                r.load_font(
+                    include_bytes!("../fonts/GeistMono-Regular.ttf"),
+                    0,
+                );
+                r
+            },
+            pixel_renderer: godly_terminal_surface::pixel_renderer::PixelRenderer::new(),
+            use_pixel_renderer: true,
         }
     }
 }
@@ -1498,6 +1519,9 @@ impl GodlyApp {
                 }
                 if should_persist_clamp {
                     self.persist_scrollback_offsets();
+                }
+                if self.use_pixel_renderer {
+                    self.render_terminal_image(&session_id);
                 }
             }
             Message::GridFetchFailed { session_id, error } => {
@@ -7285,6 +7309,41 @@ impl GodlyApp {
     }
 
     // -----------------------------------------------------------------------
+    // Pixel renderer helpers
+    // -----------------------------------------------------------------------
+
+    /// Pre-render a terminal's grid into an RGBA pixel buffer and cache the
+    /// resulting `Handle` on the `TerminalInfo`. Called from `update()` after
+    /// grid data changes (GridFetched, selection changes, etc.).
+    fn render_terminal_image(&mut self, session_id: &str) {
+        let grid_clone = match self.terminals.get(session_id).and_then(|t| t.grid.clone()) {
+            Some(g) => g,
+            None => return,
+        };
+        let metrics = self.font_metrics;
+        let palette = crate::theme::active_terminal_palette();
+        let default_fg = palette.foreground;
+        let default_bg = palette.background;
+
+        let (pixels, w, h) = self.pixel_renderer.render(
+            &grid_clone,
+            &metrics,
+            &mut self.glyph_cache,
+            &mut self.glyph_rasterizer,
+            default_fg,
+            default_bg,
+            None, // selection handled separately in view for now
+        );
+
+        if w > 0 && h > 0 {
+            let handle = iced::widget::image::Handle::from_rgba(w, h, pixels.to_vec());
+            if let Some(term) = self.terminals.get_mut(session_id) {
+                term.cached_image_handle = Some(handle);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Rendering helpers
     // -----------------------------------------------------------------------
 
@@ -7340,10 +7399,27 @@ impl GodlyApp {
             ..container::Style::default()
         });
 
-        let inner = column![
-            accent_bar,
-            canvas(tc).width(Length::Fill).height(Length::Fill),
-        ];
+        // Choose between pixel-rendered Image and canvas-based rendering.
+        let inner = if self.use_pixel_renderer {
+            if let Some(handle) = &term.cached_image_handle {
+                let img = iced::widget::image::Image::new(handle.clone())
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .content_fit(iced::ContentFit::Fill);
+                column![accent_bar, img]
+            } else {
+                // No cached handle yet — fall back to canvas
+                column![
+                    accent_bar,
+                    canvas(tc).width(Length::Fill).height(Length::Fill),
+                ]
+            }
+        } else {
+            column![
+                accent_bar,
+                canvas(tc).width(Length::Fill).height(Length::Fill),
+            ]
+        };
 
         let pane = container(inner)
             .width(Length::Fill)

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -404,6 +404,7 @@ mod tests {
             workspace_id: None,
             custom_name: None,
             worktree_path: None,
+            cached_image_handle: None,
         }
     }
 

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -26,6 +26,8 @@ pub struct TerminalInfo {
     pub custom_name: Option<String>,
     /// Path to a git worktree created for this terminal (None = normal terminal).
     pub worktree_path: Option<String>,
+    /// Cached image handle for the pixel-rendered terminal (None = needs render).
+    pub cached_image_handle: Option<iced::widget::image::Handle>,
 }
 
 impl TerminalInfo {
@@ -363,6 +365,7 @@ impl TerminalCollection {
                 workspace_id,
                 custom_name: None,
                 worktree_path: None,
+                cached_image_handle: None,
             },
         );
         if self.tabs.active_id() == Some(id.as_str()) {

--- a/src-tauri/native/terminal-surface/Cargo.toml
+++ b/src-tauri/native/terminal-surface/Cargo.toml
@@ -9,3 +9,5 @@ description = "Custom Iced widget for rendering terminal grid via wgpu"
 iced.workspace = true
 godly-protocol = { path = "../../protocol" }
 log = "0.4"
+swash = "0.2"
+fontdb = "0.23"

--- a/src-tauri/native/terminal-surface/src/font_loader.rs
+++ b/src-tauri/native/terminal-surface/src/font_loader.rs
@@ -1,0 +1,42 @@
+use fontdb::{Database, Query, Style, Weight};
+
+/// System font loader backed by `fontdb`.
+///
+/// Queries the operating system's font database to locate and load font files
+/// by family name. Used to initialize the `SwashRasterizer` with the user's
+/// chosen monospace font or a fallback.
+pub struct FontLoader {
+    db: Database,
+}
+
+impl FontLoader {
+    /// Create a new font loader with system fonts pre-loaded.
+    pub fn new() -> Self {
+        let mut db = Database::new();
+        db.load_system_fonts();
+        Self { db }
+    }
+
+    /// Load font bytes for the given family name and style.
+    ///
+    /// Returns `None` if no matching font is found.
+    pub fn load_font(&self, family: &str, bold: bool, italic: bool) -> Option<Vec<u8>> {
+        let weight = if bold { Weight::BOLD } else { Weight::NORMAL };
+        let style = if italic { Style::Italic } else { Style::Normal };
+
+        let query = Query {
+            families: &[fontdb::Family::Name(family)],
+            weight,
+            style,
+            stretch: fontdb::Stretch::Normal,
+        };
+
+        let face_id = self.db.query(&query)?;
+        let mut result = None;
+        self.db
+            .with_face_data(face_id, |data, _index| {
+                result = Some(data.to_vec());
+            })?;
+        result
+    }
+}

--- a/src-tauri/native/terminal-surface/src/glyph_cache.rs
+++ b/src-tauri/native/terminal-surface/src/glyph_cache.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+
+/// Lookup key for cached glyphs.
+///
+/// Font size is quantized to quarter-pixel steps (size * 4 as u16) to avoid
+/// separate cache entries for sub-pixel size differences that produce
+/// identical rasterization results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GlyphKey {
+    pub codepoint: char,
+    /// Quantized font size: `(font_size * 4.0) as u16`.
+    pub size_q4: u16,
+    pub bold: bool,
+    pub italic: bool,
+}
+
+impl GlyphKey {
+    pub fn new(ch: char, font_size: f32, bold: bool, italic: bool) -> Self {
+        Self {
+            codepoint: ch,
+            size_q4: (font_size * 4.0) as u16,
+            bold,
+            italic,
+        }
+    }
+}
+
+/// A cached rasterized glyph (alpha mask + metrics).
+pub struct CachedGlyph {
+    pub alpha: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub bearing_x: i32,
+    pub bearing_y: i32,
+    pub advance: f32,
+}
+
+/// In-memory cache for rasterized glyph bitmaps.
+///
+/// Glyphs are stored by (codepoint, quantized size, bold, italic).
+/// Call `invalidate()` when the font changes (e.g., user switches font family)
+/// to clear all entries and bump the generation counter.
+pub struct GlyphCache {
+    entries: HashMap<GlyphKey, CachedGlyph>,
+    generation: u64,
+}
+
+impl GlyphCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            generation: 0,
+        }
+    }
+
+    /// Look up a cached glyph by key.
+    pub fn get(&self, key: &GlyphKey) -> Option<&CachedGlyph> {
+        self.entries.get(key)
+    }
+
+    /// Insert a rasterized glyph into the cache.
+    pub fn insert(&mut self, key: GlyphKey, glyph: CachedGlyph) {
+        self.entries.insert(key, glyph);
+    }
+
+    /// Clear all entries and increment the generation counter.
+    pub fn invalidate(&mut self) {
+        self.entries.clear();
+        self.generation += 1;
+    }
+
+    /// Current cache generation (incremented on each invalidate).
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Number of cached glyphs.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_glyph(alpha_val: u8) -> CachedGlyph {
+        CachedGlyph {
+            alpha: vec![alpha_val; 4],
+            width: 2,
+            height: 2,
+            bearing_x: 0,
+            bearing_y: 10,
+            advance: 8.0,
+        }
+    }
+
+    #[test]
+    fn insert_and_get() {
+        let mut cache = GlyphCache::new();
+        let key = GlyphKey::new('A', 14.0, false, false);
+        cache.insert(key, make_glyph(200));
+
+        let g = cache.get(&key).unwrap();
+        assert_eq!(g.width, 2);
+        assert_eq!(g.height, 2);
+        assert_eq!(g.alpha, vec![200; 4]);
+    }
+
+    #[test]
+    fn get_nonexistent_returns_none() {
+        let cache = GlyphCache::new();
+        let key = GlyphKey::new('Z', 14.0, false, false);
+        assert!(cache.get(&key).is_none());
+    }
+
+    #[test]
+    fn invalidate_clears_and_increments_generation() {
+        let mut cache = GlyphCache::new();
+        assert_eq!(cache.generation(), 0);
+
+        cache.insert(GlyphKey::new('A', 14.0, false, false), make_glyph(100));
+        assert_eq!(cache.len(), 1);
+
+        cache.invalidate();
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.generation(), 1);
+        assert!(cache.get(&GlyphKey::new('A', 14.0, false, false)).is_none());
+    }
+
+    #[test]
+    fn different_keys_no_collision() {
+        let mut cache = GlyphCache::new();
+        let normal = GlyphKey::new('A', 14.0, false, false);
+        let bold = GlyphKey::new('A', 14.0, true, false);
+        let italic = GlyphKey::new('A', 14.0, false, true);
+        let diff_size = GlyphKey::new('A', 16.0, false, false);
+
+        cache.insert(normal, make_glyph(100));
+        cache.insert(bold, make_glyph(150));
+        cache.insert(italic, make_glyph(120));
+        cache.insert(diff_size, make_glyph(130));
+
+        assert_eq!(cache.len(), 4);
+        assert_eq!(cache.get(&normal).unwrap().alpha[0], 100);
+        assert_eq!(cache.get(&bold).unwrap().alpha[0], 150);
+        assert_eq!(cache.get(&italic).unwrap().alpha[0], 120);
+        assert_eq!(cache.get(&diff_size).unwrap().alpha[0], 130);
+    }
+
+    #[test]
+    fn same_char_different_bold_stored_separately() {
+        let mut cache = GlyphCache::new();
+        let k1 = GlyphKey::new('X', 14.0, false, false);
+        let k2 = GlyphKey::new('X', 14.0, true, false);
+
+        cache.insert(k1, make_glyph(50));
+        cache.insert(k2, make_glyph(200));
+
+        assert_eq!(cache.get(&k1).unwrap().alpha[0], 50);
+        assert_eq!(cache.get(&k2).unwrap().alpha[0], 200);
+    }
+}

--- a/src-tauri/native/terminal-surface/src/glyph_rasterizer.rs
+++ b/src-tauri/native/terminal-surface/src/glyph_rasterizer.rs
@@ -1,0 +1,36 @@
+/// Result of rasterizing a single glyph.
+pub struct RasterizedGlyph {
+    /// Alpha mask pixels (one byte per pixel, 8-bit coverage).
+    pub alpha: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    /// Horizontal offset from glyph origin to left edge of bitmap.
+    pub bearing_x: i32,
+    /// Vertical offset from baseline to top edge of bitmap (positive = above baseline).
+    pub bearing_y: i32,
+    /// Horizontal advance width in pixels.
+    pub advance: f32,
+}
+
+/// Measured font metrics from actual font data.
+pub struct MeasuredFontMetrics {
+    pub ascent: f32,
+    pub descent: f32, // positive value (abs of negative descent)
+    pub leading: f32,
+    pub average_advance: f32,
+    pub is_monospace: bool,
+}
+
+/// Trait for glyph rasterization backends.
+pub trait GlyphRasterizer {
+    fn rasterize(
+        &mut self,
+        ch: char,
+        font_size_px: f32,
+        bold: bool,
+        italic: bool,
+    ) -> Option<RasterizedGlyph>;
+    fn measure(&mut self, font_size_px: f32) -> MeasuredFontMetrics;
+    fn has_glyph(&self, ch: char) -> bool;
+    fn load_font(&mut self, data: &[u8], index: u32) -> bool;
+}

--- a/src-tauri/native/terminal-surface/src/lib.rs
+++ b/src-tauri/native/terminal-surface/src/lib.rs
@@ -1,5 +1,10 @@
 pub mod colors;
 pub mod font_metrics;
+pub mod glyph_cache;
+pub mod glyph_rasterizer;
+pub mod font_loader;
+pub mod pixel_renderer;
+pub mod swash_rasterizer;
 mod surface;
 
 pub use font_metrics::FontMetrics;

--- a/src-tauri/native/terminal-surface/src/pixel_renderer.rs
+++ b/src-tauri/native/terminal-surface/src/pixel_renderer.rs
@@ -1,0 +1,617 @@
+use godly_protocol::types::{CursorShape, RichGridData};
+use iced::Color;
+
+use crate::colors::{brighten_color, dim_color, parse_color};
+use crate::font_metrics::FontMetrics;
+use crate::glyph_cache::{CachedGlyph, GlyphCache, GlyphKey};
+use crate::glyph_rasterizer::GlyphRasterizer;
+use crate::surface::GridPos;
+
+/// CPU-side terminal grid compositor.
+///
+/// Renders a `RichGridData` snapshot into an RGBA pixel buffer suitable for
+/// display via `iced::widget::image::Handle::from_rgba()`. The renderer
+/// caches rasterized glyphs in a `GlyphCache` and composites them with
+/// per-cell foreground/background colors, selection highlight, and cursor.
+pub struct PixelRenderer {
+    buffer: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+impl PixelRenderer {
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            width: 0,
+            height: 0,
+        }
+    }
+
+    /// Render a terminal grid into an RGBA pixel buffer.
+    ///
+    /// Returns `(pixels, width, height)`. The pixel buffer is RGBA with 4 bytes
+    /// per pixel, row-major, and fully opaque.
+    pub fn render(
+        &mut self,
+        grid: &RichGridData,
+        metrics: &FontMetrics,
+        cache: &mut GlyphCache,
+        rasterizer: &mut dyn GlyphRasterizer,
+        default_fg: Color,
+        default_bg: Color,
+        selection: Option<(GridPos, GridPos)>,
+    ) -> (&[u8], u32, u32) {
+        let cols = grid.dimensions.cols as u32;
+        let rows = grid.dimensions.rows as u32;
+        let cell_w = metrics.cell_width.ceil() as u32;
+        let cell_h = metrics.cell_height.ceil() as u32;
+
+        if cols == 0 || rows == 0 || cell_w == 0 || cell_h == 0 {
+            self.buffer.clear();
+            self.width = 0;
+            self.height = 0;
+            return (&self.buffer, 0, 0);
+        }
+
+        let w = cols * cell_w;
+        let h = rows * cell_h;
+        let total = (w * h * 4) as usize;
+
+        if self.width != w || self.height != h {
+            self.buffer.resize(total, 0);
+            self.width = w;
+            self.height = h;
+        }
+
+        let bg_r = (default_bg.r * 255.0) as u8;
+        let bg_g = (default_bg.g * 255.0) as u8;
+        let bg_b = (default_bg.b * 255.0) as u8;
+        fill_solid(&mut self.buffer, w, h, bg_r, bg_g, bg_b, 255);
+
+        for (row_idx, row) in grid.rows.iter().enumerate() {
+            for (col_idx, cell) in row.cells.iter().enumerate() {
+                if cell.wide_continuation {
+                    continue;
+                }
+
+                let cell_x = col_idx as u32 * cell_w;
+                let cell_y = row_idx as u32 * cell_h;
+                let char_width: u32 = if cell.wide { 2 } else { 1 };
+
+                let (mut fg, bg) = if cell.inverse {
+                    (
+                        parse_color(&cell.bg, default_bg),
+                        parse_color(&cell.fg, default_fg),
+                    )
+                } else {
+                    (
+                        parse_color(&cell.fg, default_fg),
+                        parse_color(&cell.bg, default_bg),
+                    )
+                };
+
+                if cell.dim {
+                    fg = dim_color(fg);
+                }
+                if cell.bold {
+                    fg = brighten_color(fg);
+                }
+
+                let fg_r = (fg.r * 255.0) as u8;
+                let fg_g = (fg.g * 255.0) as u8;
+                let fg_b = (fg.b * 255.0) as u8;
+
+                let cbg_r = (bg.r * 255.0) as u8;
+                let cbg_g = (bg.g * 255.0) as u8;
+                let cbg_b = (bg.b * 255.0) as u8;
+                if cbg_r != bg_r || cbg_g != bg_g || cbg_b != bg_b {
+                    fill_rect(
+                        &mut self.buffer,
+                        w,
+                        h,
+                        cell_x,
+                        cell_y,
+                        cell_w * char_width,
+                        cell_h,
+                        cbg_r,
+                        cbg_g,
+                        cbg_b,
+                        255,
+                    );
+                }
+
+                if !cell.content.is_empty() && cell.content != " " {
+                    let ch = match cell.content.chars().next() {
+                        Some(c) => c,
+                        None => continue,
+                    };
+
+                    let key = GlyphKey::new(ch, metrics.font_size, cell.bold, cell.italic);
+
+                    if cache.get(&key).is_none() {
+                        if let Some(rg) = rasterizer.rasterize(
+                            ch,
+                            metrics.font_size,
+                            cell.bold,
+                            cell.italic,
+                        ) {
+                            cache.insert(
+                                key,
+                                CachedGlyph {
+                                    alpha: rg.alpha,
+                                    width: rg.width,
+                                    height: rg.height,
+                                    bearing_x: rg.bearing_x,
+                                    bearing_y: rg.bearing_y,
+                                    advance: rg.advance,
+                                },
+                            );
+                        } else {
+                            continue;
+                        }
+                    }
+                    let glyph_ref = cache.get(&key).unwrap();
+
+                    let glyph_x = cell_x as i32 + glyph_ref.bearing_x;
+                    let glyph_y =
+                        cell_y as i32 + (metrics.baseline_offset as i32 - glyph_ref.bearing_y);
+
+                    blit_alpha(
+                        &mut self.buffer,
+                        w,
+                        h,
+                        glyph_ref,
+                        glyph_x,
+                        glyph_y,
+                        fg_r,
+                        fg_g,
+                        fg_b,
+                    );
+                }
+
+                if cell.underline {
+                    let uy = cell_y + cell_h - 2;
+                    fill_rect(
+                        &mut self.buffer,
+                        w,
+                        h,
+                        cell_x,
+                        uy,
+                        cell_w * char_width,
+                        1,
+                        fg_r,
+                        fg_g,
+                        fg_b,
+                        255,
+                    );
+                }
+            }
+        }
+
+        if let Some((start, end)) = selection {
+            let sel_r: u8 = 51;
+            let sel_g: u8 = 102;
+            let sel_b: u8 = 204;
+            let sel_a: u8 = 77;
+
+            for row in start.row..=end.row {
+                if row >= grid.rows.len() {
+                    break;
+                }
+                let y = row as u32 * cell_h;
+                let col_start = if row == start.row { start.col } else { 0 };
+                let col_end = if row == end.row {
+                    end.col
+                } else {
+                    grid.rows[row].cells.len().saturating_sub(1)
+                };
+                let x = col_start as u32 * cell_w;
+                let width = ((col_end - col_start + 1) as u32) * cell_w;
+                blend_rect(
+                    &mut self.buffer,
+                    w,
+                    h,
+                    x,
+                    y,
+                    width,
+                    cell_h,
+                    sel_r,
+                    sel_g,
+                    sel_b,
+                    sel_a,
+                );
+            }
+        }
+
+        if !grid.cursor_hidden {
+            let cursor_x = grid.cursor.col as u32 * cell_w;
+            let cursor_y = grid.cursor.row as u32 * cell_h;
+            let cur_r: u8 = 255;
+            let cur_g: u8 = 255;
+            let cur_b: u8 = 255;
+            let cur_a: u8 = 204;
+
+            match grid.cursor.cursor_style {
+                CursorShape::BlinkBlock | CursorShape::SteadyBlock => {
+                    blend_rect(
+                        &mut self.buffer,
+                        w,
+                        h,
+                        cursor_x,
+                        cursor_y,
+                        cell_w,
+                        cell_h,
+                        cur_r,
+                        cur_g,
+                        cur_b,
+                        cur_a,
+                    );
+                }
+                CursorShape::BlinkUnderline | CursorShape::SteadyUnderline => {
+                    let underline_h = 2u32;
+                    let uy = cursor_y + cell_h.saturating_sub(underline_h);
+                    blend_rect(
+                        &mut self.buffer,
+                        w,
+                        h,
+                        cursor_x,
+                        uy,
+                        cell_w,
+                        underline_h,
+                        cur_r,
+                        cur_g,
+                        cur_b,
+                        cur_a,
+                    );
+                }
+                CursorShape::BlinkBar | CursorShape::SteadyBar => {
+                    let bar_w = 2u32;
+                    blend_rect(
+                        &mut self.buffer,
+                        w,
+                        h,
+                        cursor_x,
+                        cursor_y,
+                        bar_w,
+                        cell_h,
+                        cur_r,
+                        cur_g,
+                        cur_b,
+                        cur_a,
+                    );
+                }
+            }
+        }
+
+        (&self.buffer, w, h)
+    }
+}
+
+/// Fill the entire buffer with a solid color.
+fn fill_solid(buf: &mut [u8], _w: u32, _h: u32, r: u8, g: u8, b: u8, a: u8) {
+    let pixel = [r, g, b, a];
+    for chunk in buf.chunks_exact_mut(4) {
+        chunk.copy_from_slice(&pixel);
+    }
+}
+
+/// Fill a rectangle with a solid color.
+fn fill_rect(
+    buf: &mut [u8],
+    buf_w: u32,
+    buf_h: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+) {
+    let x_end = (x + w).min(buf_w);
+    let y_end = (y + h).min(buf_h);
+    for py in y..y_end {
+        for px in x..x_end {
+            let idx = ((py * buf_w + px) * 4) as usize;
+            if idx + 3 < buf.len() {
+                buf[idx] = r;
+                buf[idx + 1] = g;
+                buf[idx + 2] = b;
+                buf[idx + 3] = a;
+            }
+        }
+    }
+}
+
+/// Blend a semi-transparent rectangle over existing pixels.
+fn blend_rect(
+    buf: &mut [u8],
+    buf_w: u32,
+    buf_h: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+) {
+    let x_end = (x + w).min(buf_w);
+    let y_end = (y + h).min(buf_h);
+    let src_a = a as u16;
+    let inv_a = 255 - src_a;
+    for py in y..y_end {
+        for px in x..x_end {
+            let idx = ((py * buf_w + px) * 4) as usize;
+            if idx + 3 < buf.len() {
+                buf[idx] = ((r as u16 * src_a + buf[idx] as u16 * inv_a) / 255) as u8;
+                buf[idx + 1] = ((g as u16 * src_a + buf[idx + 1] as u16 * inv_a) / 255) as u8;
+                buf[idx + 2] = ((b as u16 * src_a + buf[idx + 2] as u16 * inv_a) / 255) as u8;
+                buf[idx + 3] = 255;
+            }
+        }
+    }
+}
+
+/// Blit a glyph's alpha mask onto the buffer with foreground color tinting.
+fn blit_alpha(
+    buf: &mut [u8],
+    buf_w: u32,
+    buf_h: u32,
+    glyph: &CachedGlyph,
+    glyph_x: i32,
+    glyph_y: i32,
+    fg_r: u8,
+    fg_g: u8,
+    fg_b: u8,
+) {
+    for gy in 0..glyph.height {
+        let dest_y = glyph_y + gy as i32;
+        if dest_y < 0 || dest_y >= buf_h as i32 {
+            continue;
+        }
+        for gx in 0..glyph.width {
+            let dest_x = glyph_x + gx as i32;
+            if dest_x < 0 || dest_x >= buf_w as i32 {
+                continue;
+            }
+
+            let alpha = glyph.alpha[(gy * glyph.width + gx) as usize];
+            if alpha == 0 {
+                continue;
+            }
+
+            let idx = ((dest_y as u32 * buf_w + dest_x as u32) * 4) as usize;
+            if idx + 3 >= buf.len() {
+                continue;
+            }
+
+            let src_a = alpha as u16;
+            let inv_a = 255 - src_a;
+            buf[idx] = ((fg_r as u16 * src_a + buf[idx] as u16 * inv_a) / 255) as u8;
+            buf[idx + 1] = ((fg_g as u16 * src_a + buf[idx + 1] as u16 * inv_a) / 255) as u8;
+            buf[idx + 2] = ((fg_b as u16 * src_a + buf[idx + 2] as u16 * inv_a) / 255) as u8;
+            buf[idx + 3] = 255;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use godly_protocol::types::{
+        CursorState, GridDimensions, RichGridCell, RichGridData, RichGridRow,
+    };
+
+    fn make_cell(content: &str) -> RichGridCell {
+        RichGridCell {
+            content: content.to_string(),
+            fg: "default".to_string(),
+            bg: "default".to_string(),
+            bold: false,
+            dim: false,
+            italic: false,
+            underline: false,
+            inverse: false,
+            wide: false,
+            wide_continuation: false,
+        }
+    }
+
+    fn make_grid(rows: u16, cols: u16, cells: Vec<Vec<RichGridCell>>) -> RichGridData {
+        RichGridData {
+            rows: cells
+                .into_iter()
+                .map(|c| RichGridRow {
+                    cells: c,
+                    wrapped: false,
+                })
+                .collect(),
+            cursor: CursorState {
+                row: 0,
+                col: 0,
+                cursor_style: CursorShape::SteadyBlock,
+            },
+            dimensions: GridDimensions { rows, cols },
+            alternate_screen: false,
+            cursor_hidden: true,
+            title: String::new(),
+            scrollback_offset: 0,
+            total_scrollback: 0,
+        }
+    }
+
+    /// Stub rasterizer for unit tests (returns a known alpha pattern).
+    struct StubRasterizer;
+
+    impl GlyphRasterizer for StubRasterizer {
+        fn rasterize(
+            &mut self,
+            _ch: char,
+            _font_size_px: f32,
+            _bold: bool,
+            _italic: bool,
+        ) -> Option<crate::glyph_rasterizer::RasterizedGlyph> {
+            Some(crate::glyph_rasterizer::RasterizedGlyph {
+                alpha: vec![128; 4], // 2x2 alpha mask
+                width: 2,
+                height: 2,
+                bearing_x: 0,
+                bearing_y: 2,
+                advance: 8.0,
+            })
+        }
+
+        fn measure(&mut self, font_size_px: f32) -> crate::glyph_rasterizer::MeasuredFontMetrics {
+            crate::glyph_rasterizer::MeasuredFontMetrics {
+                ascent: font_size_px * 0.8,
+                descent: font_size_px * 0.2,
+                leading: 0.0,
+                average_advance: font_size_px * 0.6,
+                is_monospace: true,
+            }
+        }
+
+        fn has_glyph(&self, _ch: char) -> bool {
+            true
+        }
+
+        fn load_font(&mut self, _data: &[u8], _index: u32) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn render_1_cell_grid_correct_dimensions() {
+        let grid = make_grid(1, 1, vec![vec![make_cell("A")]]);
+        let metrics = FontMetrics::from_font_size(14.0);
+        let mut cache = GlyphCache::new();
+        let mut rast = StubRasterizer;
+        let mut renderer = PixelRenderer::new();
+
+        let (buf, w, h) = renderer.render(
+            &grid,
+            &metrics,
+            &mut cache,
+            &mut rast,
+            Color::WHITE,
+            Color::BLACK,
+            None,
+        );
+
+        let cell_w = metrics.cell_width.ceil() as u32;
+        let cell_h = metrics.cell_height.ceil() as u32;
+        assert_eq!(w, cell_w);
+        assert_eq!(h, cell_h);
+        assert_eq!(buf.len(), (w * h * 4) as usize);
+    }
+
+    #[test]
+    fn render_empty_grid_returns_zero() {
+        let grid = make_grid(0, 0, vec![]);
+        let metrics = FontMetrics::from_font_size(14.0);
+        let mut cache = GlyphCache::new();
+        let mut rast = StubRasterizer;
+        let mut renderer = PixelRenderer::new();
+
+        let (buf, w, h) = renderer.render(
+            &grid,
+            &metrics,
+            &mut cache,
+            &mut rast,
+            Color::WHITE,
+            Color::BLACK,
+            None,
+        );
+
+        assert_eq!(w, 0);
+        assert_eq!(h, 0);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn fill_rect_correct_pixels() {
+        let w = 4u32;
+        let h = 4u32;
+        let mut buf = vec![0u8; (w * h * 4) as usize];
+
+        fill_rect(&mut buf, w, h, 1, 1, 2, 2, 255, 0, 0, 255);
+
+        // Check pixel at (1,1) is red
+        let idx = ((1 * w + 1) * 4) as usize;
+        assert_eq!(buf[idx], 255);
+        assert_eq!(buf[idx + 1], 0);
+        assert_eq!(buf[idx + 2], 0);
+        assert_eq!(buf[idx + 3], 255);
+
+        // Check pixel at (0,0) is still black
+        assert_eq!(buf[0], 0);
+        assert_eq!(buf[1], 0);
+        assert_eq!(buf[2], 0);
+        assert_eq!(buf[3], 0);
+    }
+
+    #[test]
+    fn blit_known_alpha_composites_correctly() {
+        let w = 4u32;
+        let h = 4u32;
+        let mut buf = vec![0u8; (w * h * 4) as usize];
+
+        // Fill background white
+        fill_solid(&mut buf, w, h, 255, 255, 255, 255);
+
+        let glyph = CachedGlyph {
+            alpha: vec![128; 4], // 2x2, 50% alpha
+            width: 2,
+            height: 2,
+            bearing_x: 0,
+            bearing_y: 0,
+            advance: 8.0,
+        };
+
+        // Blit red glyph at (1,1)
+        blit_alpha(&mut buf, w, h, &glyph, 1, 1, 255, 0, 0);
+
+        // Pixel at (1,1): blend red (128/255 ~ 50%) over white
+        let idx = ((1 * w + 1) * 4) as usize;
+        // Expected R: (255 * 128 + 255 * 127) / 255 = 255
+        // Expected G: (0 * 128 + 255 * 127) / 255 ≈ 127
+        // Expected B: (0 * 128 + 255 * 127) / 255 ≈ 127
+        assert_eq!(buf[idx], 255); // R
+        assert!((buf[idx + 1] as i32 - 127).abs() <= 1); // G
+        assert!((buf[idx + 2] as i32 - 127).abs() <= 1); // B
+        assert_eq!(buf[idx + 3], 255); // A
+
+        // Pixel at (0,0) should still be pure white
+        assert_eq!(buf[0], 255);
+        assert_eq!(buf[1], 255);
+        assert_eq!(buf[2], 255);
+    }
+
+    #[test]
+    fn render_populates_glyph_cache() {
+        let grid = make_grid(1, 2, vec![vec![make_cell("A"), make_cell("B")]]);
+        let metrics = FontMetrics::from_font_size(14.0);
+        let mut cache = GlyphCache::new();
+        let mut rast = StubRasterizer;
+        let mut renderer = PixelRenderer::new();
+
+        assert!(cache.is_empty());
+
+        renderer.render(
+            &grid,
+            &metrics,
+            &mut cache,
+            &mut rast,
+            Color::WHITE,
+            Color::BLACK,
+            None,
+        );
+
+        // 'A' and 'B' should both be cached
+        assert_eq!(cache.len(), 2);
+    }
+}

--- a/src-tauri/native/terminal-surface/src/swash_rasterizer.rs
+++ b/src-tauri/native/terminal-surface/src/swash_rasterizer.rs
@@ -1,0 +1,243 @@
+use swash::scale::{Render, ScaleContext, Source, StrikeWith};
+use swash::zeno::Format;
+use swash::FontRef;
+
+use crate::glyph_rasterizer::{GlyphRasterizer, MeasuredFontMetrics, RasterizedGlyph};
+
+/// Swash-based cross-platform glyph rasterizer.
+///
+/// Holds font data in memory and provides rasterization via the swash crate's
+/// CPU-side glyph rendering pipeline. This avoids any GPU dependency and
+/// produces alpha masks suitable for compositing into a pixel buffer.
+pub struct SwashRasterizer {
+    font_data: Vec<u8>,
+    font_index: u32,
+    scale_context: ScaleContext,
+}
+
+impl SwashRasterizer {
+    pub fn new() -> Self {
+        Self {
+            font_data: Vec::new(),
+            font_index: 0,
+            scale_context: ScaleContext::new(),
+        }
+    }
+
+    fn font_ref(&self) -> Option<FontRef<'_>> {
+        if self.font_data.is_empty() {
+            return None;
+        }
+        FontRef::from_index(&self.font_data, self.font_index as usize)
+    }
+}
+
+impl GlyphRasterizer for SwashRasterizer {
+    fn load_font(&mut self, data: &[u8], index: u32) -> bool {
+        if FontRef::from_index(data, index as usize).is_none() {
+            return false;
+        }
+        self.font_data = data.to_vec();
+        self.font_index = index;
+        true
+    }
+
+    fn rasterize(
+        &mut self,
+        ch: char,
+        font_size_px: f32,
+        bold: bool,
+        _italic: bool,
+    ) -> Option<RasterizedGlyph> {
+        if self.font_data.is_empty() {
+            return None;
+        }
+
+        let glyph_id = {
+            let font = FontRef::from_index(&self.font_data, self.font_index as usize)?;
+            let id = font.charmap().map(ch);
+            if id == 0 {
+                return None;
+            }
+            id
+        };
+
+        let (image_data, placement) = {
+            let font = FontRef::from_index(&self.font_data, self.font_index as usize)?;
+            let mut scaler = self
+                .scale_context
+                .builder(font)
+                .size(font_size_px)
+                .hint(true)
+                .build();
+
+            let mut render = Render::new(&[
+                Source::ColorOutline(0),
+                Source::ColorBitmap(StrikeWith::BestFit),
+                Source::Outline,
+            ]);
+            render.format(Format::Alpha);
+
+            if bold {
+                render.embolden(0.02 * font_size_px);
+            }
+
+            let image = render.render(&mut scaler, glyph_id)?;
+            (image.data, image.placement)
+        };
+
+        if placement.width == 0 || placement.height == 0 {
+            return None;
+        }
+
+        let advance = {
+            let font = FontRef::from_index(&self.font_data, self.font_index as usize)?;
+            font.glyph_metrics(&[]).scale(font_size_px).advance_width(glyph_id)
+        };
+
+        Some(RasterizedGlyph {
+            alpha: image_data,
+            width: placement.width,
+            height: placement.height,
+            bearing_x: placement.left,
+            bearing_y: placement.top,
+            advance,
+        })
+    }
+
+    fn measure(&mut self, font_size_px: f32) -> MeasuredFontMetrics {
+        let font = match self.font_ref() {
+            Some(f) => f,
+            None => {
+                return MeasuredFontMetrics {
+                    ascent: font_size_px * 0.8,
+                    descent: font_size_px * 0.2,
+                    leading: 0.0,
+                    average_advance: font_size_px * 0.6,
+                    is_monospace: true,
+                };
+            }
+        };
+
+        let metrics = font.metrics(&[]).scale(font_size_px);
+        let glyph_metrics = font.glyph_metrics(&[]).scale(font_size_px);
+
+        let zero_glyph = font.charmap().map('0');
+        let average_advance = if zero_glyph != 0 {
+            glyph_metrics.advance_width(zero_glyph)
+        } else {
+            font_size_px * 0.6
+        };
+
+        // Heuristic monospace check: compare advance widths of 'M' and 'i'.
+        // In a monospace font these should be identical.
+        let is_monospace = {
+            let m_glyph = font.charmap().map('M');
+            let i_glyph = font.charmap().map('i');
+            if m_glyph != 0 && i_glyph != 0 {
+                let m_adv = glyph_metrics.advance_width(m_glyph);
+                let i_adv = glyph_metrics.advance_width(i_glyph);
+                (m_adv - i_adv).abs() < 0.01
+            } else {
+                true // assume monospace if we can't check
+            }
+        };
+
+        MeasuredFontMetrics {
+            ascent: metrics.ascent,
+            descent: metrics.descent.abs(),
+            leading: metrics.leading,
+            average_advance,
+            is_monospace,
+        }
+    }
+
+    fn has_glyph(&self, ch: char) -> bool {
+        match self.font_ref() {
+            Some(font) => font.charmap().map(ch) != 0,
+            None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_FONT: &[u8] =
+        include_bytes!("../../iced-shell/fonts/GeistMono-Regular.ttf");
+
+    #[test]
+    fn load_valid_font() {
+        let mut rast = SwashRasterizer::new();
+        assert!(rast.load_font(TEST_FONT, 0));
+    }
+
+    #[test]
+    fn load_invalid_font_fails() {
+        let mut rast = SwashRasterizer::new();
+        assert!(!rast.load_font(b"not a font", 0));
+    }
+
+    #[test]
+    fn rasterize_a_returns_nonempty_alpha() {
+        let mut rast = SwashRasterizer::new();
+        rast.load_font(TEST_FONT, 0);
+        let glyph = rast.rasterize('A', 14.0, false, false).unwrap();
+        assert!(glyph.width > 0);
+        assert!(glyph.height > 0);
+        assert!(!glyph.alpha.is_empty());
+        assert_eq!(glyph.alpha.len(), (glyph.width * glyph.height) as usize);
+    }
+
+    #[test]
+    fn rasterize_bold_changes_output() {
+        let mut rast = SwashRasterizer::new();
+        rast.load_font(TEST_FONT, 0);
+        let normal = rast.rasterize('A', 14.0, false, false).unwrap();
+        let bold = rast.rasterize('A', 14.0, true, false).unwrap();
+        // Bold should produce a glyph (possibly wider or with more coverage)
+        assert!(bold.width > 0);
+        assert!(bold.height > 0);
+        // At least some pixel values should differ
+        let normal_sum: u64 = normal.alpha.iter().map(|&b| b as u64).sum();
+        let bold_sum: u64 = bold.alpha.iter().map(|&b| b as u64).sum();
+        assert_ne!(normal_sum, bold_sum, "bold should have different alpha coverage");
+    }
+
+    #[test]
+    fn rasterize_unknown_char_returns_none() {
+        let mut rast = SwashRasterizer::new();
+        rast.load_font(TEST_FONT, 0);
+        // Private use area character unlikely to exist in Geist Mono
+        let result = rast.rasterize('\u{F0000}', 14.0, false, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn measure_returns_sensible_values() {
+        let mut rast = SwashRasterizer::new();
+        rast.load_font(TEST_FONT, 0);
+        let m = rast.measure(14.0);
+        assert!(m.ascent > 0.0, "ascent should be positive");
+        assert!(m.descent > 0.0, "descent should be positive (abs)");
+        assert!(m.average_advance > 0.0, "advance should be positive");
+        assert!(m.is_monospace, "Geist Mono should be detected as monospace");
+    }
+
+    #[test]
+    fn has_glyph_ascii() {
+        let mut rast = SwashRasterizer::new();
+        rast.load_font(TEST_FONT, 0);
+        assert!(rast.has_glyph('A'));
+        assert!(rast.has_glyph('z'));
+        assert!(rast.has_glyph('0'));
+    }
+
+    #[test]
+    fn has_glyph_private_use_false() {
+        let mut rast = SwashRasterizer::new();
+        rast.load_font(TEST_FONT, 0);
+        assert!(!rast.has_glyph('\u{F0000}'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add CPU-side glyph rasterization pipeline using `swash` crate with glyph cache, pixel buffer compositor, and Iced image widget integration
- New modules in `terminal-surface`: `glyph_rasterizer` (trait + types), `swash_rasterizer` (cross-platform backend), `glyph_cache` (HashMap-based with generation tracking), `pixel_renderer` (grid-to-RGBA compositor), `font_loader` (fontdb-backed system font loader)
- Terminal panes conditionally render via pre-rendered pixel buffers (`use_pixel_renderer` flag, default on) with canvas fallback
- 32 new unit tests covering rasterizer, cache, and pixel compositor

## Test plan
- [x] `cargo test -p godly-terminal-surface` — 32 tests pass
- [x] `cargo test -p godly-iced-shell` — 315 tests pass
- [x] `cargo build -p godly-iced-shell` — compiles cleanly
- [ ] Visual verification: launch app, confirm terminal text renders correctly via pixel renderer path
- [ ] Font change: switch font family in settings, verify glyph cache invalidation and re-render
- [ ] Selection overlay: drag to select text, verify highlight renders