### PR TITLE
fix: prevent terminal image trembling on keystroke

### DIFF
--- a/changelog/unreleased/fix-image-widget-trembling.md
+++ b/changelog/unreleased/fix-image-widget-trembling.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Terminal trembling on keystroke** — Changed image widget from `ContentFit::Fill` to `ContentFit::None` with nearest-neighbor filtering to prevent sub-pixel scaling jitter

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -7457,7 +7457,8 @@ impl GodlyApp {
                 let img = iced::widget::image::Image::new(handle.clone())
                     .width(Length::Fill)
                     .height(Length::Fill)
-                    .content_fit(iced::ContentFit::Fill);
+                    .content_fit(iced::ContentFit::None)
+                    .filter_method(iced::widget::image::FilterMethod::Nearest);
                 column![accent_bar, img]
             } else {
                 // No cached handle yet — fall back to canvas


### PR DESCRIPTION
## Summary
- Changed `ContentFit::Fill` to `ContentFit::None` with `FilterMethod::Nearest` on the terminal image widget
- `Fill` was stretching the integer-sized pixel buffer to fractional container dimensions, causing visible sub-pixel jitter each frame
- `None` displays at native resolution without scaling artifacts

## Test plan
- [ ] Rebuild and type in terminal — no more trembling/flickering