### PR TITLE
fix: resolve Quick Claude split view, prompt delivery, and model list issues

### DIFF
--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -2338,6 +2338,7 @@ impl GodlyApp {
                     steps,
                     num_agents,
                     ws_id,
+                    true, // new workspace
                 );
                 launch_state.agent_terminal_ids[0] = Some(placeholder_id);
 
@@ -2514,26 +2515,18 @@ impl GodlyApp {
                 let rows = self.calculate_rows();
                 let cols = self.calculate_cols();
 
-                let (ws_id, ws_name, cwd) = if let Some((id, name, folder)) = selected_ws {
-                    // Add terminal to the EXISTING workspace as a new tab
+                let (ws_id, ws_name, cwd, is_new_ws) = if let Some((id, name, folder)) = selected_ws {
+                    // Add terminal to the EXISTING workspace — it appears in
+                    // the tab bar without modifying the current layout or focus.
                     self.terminals.add_to_workspace(
                         placeholder_id.clone(),
                         rows,
                         cols,
                         id.clone(),
                     );
-                    // Split the focused terminal's leaf to show the new pane
-                    if let Some(ws) = self.workspaces.get_mut(&id) {
-                        let focused = ws.focused_terminal.clone();
-                        ws.layout.split_leaf(
-                            &focused,
-                            placeholder_id.clone(),
-                            SplitDirection::Horizontal,
-                        );
-                    }
-                    // Background launch: do NOT switch focus
+                    // Background launch: do NOT split, do NOT switch focus
                     let cwd = if folder.is_empty() { None } else { Some(folder) };
-                    (id, name, cwd)
+                    (id, name, cwd, false)
                 } else {
                     // No workspace selected — create a new one
                     let id = uuid::Uuid::new_v4().to_string();
@@ -2556,7 +2549,7 @@ impl GodlyApp {
                     );
                     // Background launch: do NOT switch focus
                     self.next_workspace_num += 1;
-                    (id, name, None)
+                    (id, name, None, true)
                 };
 
                 let steps = crate::quick_claude::default_launch_steps(
@@ -2568,6 +2561,7 @@ impl GodlyApp {
                     steps,
                     num_agents,
                     ws_id,
+                    is_new_ws,
                 );
                 launch_state.agent_terminal_ids[0] = Some(placeholder_id);
 
@@ -2694,6 +2688,7 @@ impl GodlyApp {
                     steps,
                     1,
                     ws_id,
+                    true, // new workspace
                 );
                 launch_state.agent_terminal_ids[0] = Some(placeholder_id);
 
@@ -7207,12 +7202,15 @@ impl GodlyApp {
                         if agent_index == 0 {
                             if let Some(placeholder) = placeholder_opt {
                                 if let Some(ws) = self.workspaces.get_mut(&ws_id) {
+                                    // Replace placeholder in layout (only meaningful
+                                    // for new workspaces where placeholder is the
+                                    // initial leaf; for existing workspaces the
+                                    // placeholder is not in the layout tree).
                                     replace_leaf_in_layout(
                                         &mut ws.layout,
                                         &placeholder,
                                         session_id.clone(),
                                     );
-                                    ws.focused_terminal = session_id.clone();
                                 }
                                 self.terminals.remove(&placeholder);
                             }
@@ -7272,70 +7270,76 @@ impl GodlyApp {
 
         let num_agents = terminal_ids.len();
         let ws_id = launch.workspace_id.clone();
+        let is_new_workspace = launch.is_new_workspace;
 
-        let two_agent_direction = {
-            let preset_name = launch.preset_name.clone();
-            let matching_preset = self
-                .quick_claude_presets
-                .iter()
-                .find(|p| p.name == preset_name);
-            match matching_preset.map(|p| p.layout) {
-                Some(QuickClaudeLayout::HSplit) => SplitDirection::Vertical,
-                _ => SplitDirection::Horizontal,
-            }
-        };
+        // Only set up the workspace layout for NEW workspaces.
+        // For existing workspaces the terminal is already in the tab bar;
+        // modifying the layout would destroy the user's current view.
+        if is_new_workspace {
+            let two_agent_direction = {
+                let preset_name = launch.preset_name.clone();
+                let matching_preset = self
+                    .quick_claude_presets
+                    .iter()
+                    .find(|p| p.name == preset_name);
+                match matching_preset.map(|p| p.layout) {
+                    Some(QuickClaudeLayout::HSplit) => SplitDirection::Vertical,
+                    _ => SplitDirection::Horizontal,
+                }
+            };
 
-        if let Some(ws) = self.workspaces.get_mut(&ws_id) {
-            match num_agents {
-                1 => {
-                    ws.layout = LayoutNode::Leaf {
-                        terminal_id: terminal_ids[0].clone(),
-                    };
-                    ws.focused_terminal = terminal_ids[0].clone();
-                }
-                2 => {
-                    ws.layout = LayoutNode::Leaf {
-                        terminal_id: terminal_ids[0].clone(),
-                    };
-                    ws.layout.split_leaf(
-                        &terminal_ids[0],
-                        terminal_ids[1].clone(),
-                        two_agent_direction,
-                    );
-                    ws.focused_terminal = terminal_ids[0].clone();
-                }
-                4 => {
-                    ws.layout = LayoutNode::Split {
-                        direction: SplitDirection::Horizontal,
-                        ratio: 0.5,
-                        first: Box::new(LayoutNode::Split {
-                            direction: SplitDirection::Vertical,
+            if let Some(ws) = self.workspaces.get_mut(&ws_id) {
+                match num_agents {
+                    1 => {
+                        ws.layout = LayoutNode::Leaf {
+                            terminal_id: terminal_ids[0].clone(),
+                        };
+                        ws.focused_terminal = terminal_ids[0].clone();
+                    }
+                    2 => {
+                        ws.layout = LayoutNode::Leaf {
+                            terminal_id: terminal_ids[0].clone(),
+                        };
+                        ws.layout.split_leaf(
+                            &terminal_ids[0],
+                            terminal_ids[1].clone(),
+                            two_agent_direction,
+                        );
+                        ws.focused_terminal = terminal_ids[0].clone();
+                    }
+                    4 => {
+                        ws.layout = LayoutNode::Split {
+                            direction: SplitDirection::Horizontal,
                             ratio: 0.5,
-                            first: Box::new(LayoutNode::Leaf {
-                                terminal_id: terminal_ids[0].clone(),
+                            first: Box::new(LayoutNode::Split {
+                                direction: SplitDirection::Vertical,
+                                ratio: 0.5,
+                                first: Box::new(LayoutNode::Leaf {
+                                    terminal_id: terminal_ids[0].clone(),
+                                }),
+                                second: Box::new(LayoutNode::Leaf {
+                                    terminal_id: terminal_ids[2].clone(),
+                                }),
                             }),
-                            second: Box::new(LayoutNode::Leaf {
-                                terminal_id: terminal_ids[2].clone(),
+                            second: Box::new(LayoutNode::Split {
+                                direction: SplitDirection::Vertical,
+                                ratio: 0.5,
+                                first: Box::new(LayoutNode::Leaf {
+                                    terminal_id: terminal_ids[1].clone(),
+                                }),
+                                second: Box::new(LayoutNode::Leaf {
+                                    terminal_id: terminal_ids[3].clone(),
+                                }),
                             }),
-                        }),
-                        second: Box::new(LayoutNode::Split {
-                            direction: SplitDirection::Vertical,
-                            ratio: 0.5,
-                            first: Box::new(LayoutNode::Leaf {
-                                terminal_id: terminal_ids[1].clone(),
-                            }),
-                            second: Box::new(LayoutNode::Leaf {
-                                terminal_id: terminal_ids[3].clone(),
-                            }),
-                        }),
-                    };
-                    ws.focused_terminal = terminal_ids[0].clone();
-                }
-                _ => {
-                    ws.layout = LayoutNode::Leaf {
-                        terminal_id: terminal_ids[0].clone(),
-                    };
-                    ws.focused_terminal = terminal_ids[0].clone();
+                        };
+                        ws.focused_terminal = terminal_ids[0].clone();
+                    }
+                    _ => {
+                        ws.layout = LayoutNode::Leaf {
+                            terminal_id: terminal_ids[0].clone(),
+                        };
+                        ws.focused_terminal = terminal_ids[0].clone();
+                    }
                 }
             }
         }

--- a/src-tauri/native/iced-shell/src/quick_claude.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude.rs
@@ -69,6 +69,10 @@ pub fn resume_launch_steps(session_id: &str, cwd: Option<&str>) -> Vec<LaunchSte
 }
 
 /// Build the default launch sequence for a preset with N agents.
+///
+/// The prompt is passed as a CLI positional argument to `claude`, avoiding
+/// the fragile interactive prompt detection that broke because Claude Code's
+/// TUI renders a hint bar below the `>` input prompt.
 pub fn default_launch_steps(
     num_agents: usize,
     prompt: &str,
@@ -80,11 +84,16 @@ pub fn default_launch_steps(
     // Add model flag (always, since we default to sonnet)
     cmd.push_str(&format!(" --model {}", model));
     // Add mode flag
-    let skip_trust = mode == "auto";
     match mode {
         "plan" => cmd.push_str(" --plan"),
         "auto" => cmd.push_str(" --dangerously-skip-permissions"),
         _ => {} // "default" — no flag
+    }
+    // Pass prompt as CLI positional argument
+    if !prompt.is_empty() {
+        // Shell-escape: wrap in single quotes, escape embedded single quotes
+        let escaped = prompt.replace('\'', "'\\''");
+        cmd.push_str(&format!(" '{}'", escaped));
     }
 
     let mut steps = Vec::new();
@@ -101,32 +110,6 @@ pub fn default_launch_steps(
             agent_index: i,
             command: cmd.clone(),
         });
-        // Adaptive wait: handles trust prompt if present, then waits for
-        // Claude's input prompt. Replaces the old rigid 3-step sequence that
-        // broke when the trust prompt was absent (auto mode, already-trusted dir).
-        steps.push(LaunchStep::WaitForClaudeReady {
-            agent_index: i,
-            skip_trust,
-            timeout_ms: 30000,
-        });
-        if !prompt.is_empty() {
-            // 3-step prompt delivery to avoid ink paste detection:
-            // 1. Write prompt text (no CR)
-            steps.push(LaunchStep::SendPrompt {
-                agent_index: i,
-                prompt: prompt.to_string(),
-            });
-            // 2. Wait for echo in grid (confirms TUI read the text)
-            steps.push(LaunchStep::WaitForEcho {
-                agent_index: i,
-                text_prefix: prompt.to_string(),
-                timeout_ms: 30000,
-            });
-            // 3. Send Enter separately (clean submit)
-            steps.push(LaunchStep::SendEnter {
-                agent_index: i,
-            });
-        }
     }
     steps
 }
@@ -139,18 +122,26 @@ pub struct LaunchState {
     pub current_step: usize,
     pub agent_terminal_ids: Vec<Option<String>>,
     pub workspace_id: String,
+    pub is_new_workspace: bool,
     pub completed: bool,
     pub error: Option<String>,
 }
 
 impl LaunchState {
-    pub fn new(preset_name: String, steps: Vec<LaunchStep>, num_agents: usize, workspace_id: String) -> Self {
+    pub fn new(
+        preset_name: String,
+        steps: Vec<LaunchStep>,
+        num_agents: usize,
+        workspace_id: String,
+        is_new_workspace: bool,
+    ) -> Self {
         Self {
             preset_name,
             steps,
             current_step: 0,
             agent_terminal_ids: vec![None; num_agents],
             workspace_id,
+            is_new_workspace,
             completed: false,
             error: None,
         }
@@ -477,28 +468,41 @@ mod tests {
     #[test]
     fn default_steps_single_no_prompt() {
         let steps = default_launch_steps(1, "", "sonnet", "default", None);
-        // CreateTerminal, WaitIdle, RunCommand, WaitForClaudeReady
-        assert_eq!(steps.len(), 4);
+        // CreateTerminal, WaitIdle, RunCommand
+        assert_eq!(steps.len(), 3);
         assert!(matches!(steps[0], LaunchStep::CreateTerminal { agent_index: 0, .. }));
+        assert!(matches!(steps[1], LaunchStep::WaitIdle { agent_index: 0, .. }));
         assert!(matches!(steps[2], LaunchStep::RunCommand { agent_index: 0, .. }));
-        assert!(matches!(steps[3], LaunchStep::WaitForClaudeReady { agent_index: 0, skip_trust: false, .. }));
     }
 
     #[test]
     fn default_steps_single_with_prompt() {
         let steps = default_launch_steps(1, "build the app", "sonnet", "default", None);
-        // 4 base steps + 3 prompt steps (SendPrompt + WaitForEcho + SendEnter)
-        assert_eq!(steps.len(), 7);
-        assert!(matches!(steps[4], LaunchStep::SendPrompt { agent_index: 0, .. }));
-        assert!(matches!(steps[5], LaunchStep::WaitForEcho { agent_index: 0, .. }));
-        assert!(matches!(steps[6], LaunchStep::SendEnter { agent_index: 0 }));
+        // Prompt is now a CLI arg — same 3 steps, prompt embedded in command
+        assert_eq!(steps.len(), 3);
+        if let LaunchStep::RunCommand { command, .. } = &steps[2] {
+            assert!(command.contains("'build the app'"));
+        } else {
+            panic!("Expected RunCommand");
+        }
+    }
+
+    #[test]
+    fn default_steps_prompt_with_single_quotes() {
+        let steps = default_launch_steps(1, "fix it's broken", "sonnet", "auto", None);
+        if let LaunchStep::RunCommand { command, .. } = &steps[2] {
+            // Single quotes in prompt should be escaped
+            assert!(command.contains("'fix it'\\''s broken'"));
+        } else {
+            panic!("Expected RunCommand");
+        }
     }
 
     #[test]
     fn default_steps_grid_2x2() {
         let steps = default_launch_steps(4, "test", "sonnet", "default", None);
-        // Each agent: 7 steps (with prompt). 4 agents = 28
-        assert_eq!(steps.len(), 28);
+        // Each agent: 3 steps. 4 agents = 12
+        assert_eq!(steps.len(), 12);
     }
 
     #[test]
@@ -519,8 +523,6 @@ mod tests {
         } else {
             panic!("Expected RunCommand at index 2");
         }
-        // Auto mode should skip trust prompt
-        assert!(matches!(steps[3], LaunchStep::WaitForClaudeReady { skip_trust: true, .. }));
     }
 
     #[test]
@@ -531,8 +533,6 @@ mod tests {
         } else {
             panic!("Expected RunCommand at index 2");
         }
-        // Default mode should NOT skip trust prompt
-        assert!(matches!(steps[3], LaunchStep::WaitForClaudeReady { skip_trust: false, .. }));
     }
 
     #[test]

--- a/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
@@ -1160,17 +1160,18 @@ fn format_relative_time(time: std::time::SystemTime) -> String {
     }
 }
 
-/// Default hardcoded model list used as fallback.
+/// Default model list — always includes the three core Claude Code aliases.
+/// Order matches Claude Code's default (Sonnet first as the default model).
 pub fn default_model_list() -> Vec<(String, String)> {
     vec![
-        ("Opus".to_string(), "opus".to_string()),
         ("Sonnet".to_string(), "sonnet".to_string()),
+        ("Opus".to_string(), "opus".to_string()),
         ("Haiku".to_string(), "haiku".to_string()),
     ]
 }
 
 /// Discover available models by running `claude --help` and parsing the --model description.
-/// Returns (display_name, value) pairs. Falls back to default list on failure.
+/// Merges discovered models with the default list so core aliases are always present.
 pub fn discover_models() -> Vec<(String, String)> {
     let output = match std::process::Command::new("claude")
         .args(["--help"])
@@ -1181,7 +1182,16 @@ pub fn discover_models() -> Vec<(String, String)> {
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_models_from_help(&stdout)
+    let discovered = parse_models_from_help(&stdout);
+
+    // Merge: start with defaults, add any newly discovered models
+    let mut models = default_model_list();
+    for (display, value) in discovered {
+        if !models.iter().any(|(_, v)| v == &value) {
+            models.push((display, value));
+        }
+    }
+    models
 }
 
 /// Parse model aliases from claude --help output.
@@ -1595,7 +1605,7 @@ mod tests {
         let models = parse_models_from_help(help);
         // Falls back to default list
         assert_eq!(models.len(), 3);
-        assert_eq!(models[0].1, "opus");
+        assert_eq!(models[0].1, "sonnet");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three Quick Claude bugs fixed:

1. **Split view + focus stealing**: When launching Quick Claude into an existing workspace, the terminal was inserted as a split pane (via `split_leaf()`) and stole focus (`focused_terminal = session_id`). Additionally, `finalize_launch()` destructively replaced the entire workspace layout. Fix: remove `split_leaf`, don't steal `focused_terminal`, and guard `finalize_launch()` to only modify layout for new workspaces. The terminal now appears silently as a new tab.

2. **Prompt never sent**: The 5-step interactive prompt delivery sequence (WaitForClaudeReady → SendPrompt → WaitForEcho → SendEnter) failed because Claude Code's TUI renders a hint/footer bar below the `>` input prompt, so the "last non-empty line is `>`" detection always timed out after 30s. Fix: pass the prompt as a CLI positional argument (`claude --model sonnet 'prompt text'`) instead of the fragile interactive sequence. This eliminates prompt detection entirely.

3. **Model list mismatch**: `discover_models()` parsed `claude --help` which only mentions 'sonnet' and 'opus' as examples (not 'haiku'). Since parsing succeeded, the fallback list (which included Haiku) was never used. Fix: merge discovered models with the default list so all three core aliases are always present.

## Files Changed

- `src-tauri/native/iced-shell/src/app.rs` — Remove split_leaf, don't steal focused_terminal, guard finalize_launch
- `src-tauri/native/iced-shell/src/quick_claude.rs` — Add is_new_workspace to LaunchState, pass prompt as CLI arg
- `src-tauri/native/iced-shell/src/quick_claude_dialog.rs` — Reorder default model list, merge with discovered models