### PR TITLE
fix: use PowerShell quote escaping for Quick Claude prompts

### DIFF
--- a/changelog/unreleased/fix-quick-claude-quote-escaping.md
+++ b/changelog/unreleased/fix-quick-claude-quote-escaping.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Quick Claude quote escaping** — single quotes in prompts (e.g., "isn't") are now correctly escaped for PowerShell using doubled quotes ('') instead of POSIX escaping, allowing prompts with contractions to work properly

--- a/src-tauri/native/iced-shell/src/quick_claude.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude.rs
@@ -92,7 +92,8 @@ pub fn default_launch_steps(
     // Pass prompt as CLI positional argument
     if !prompt.is_empty() {
         // Shell-escape: wrap in single quotes, escape embedded single quotes
-        let escaped = prompt.replace('\'', "'\\''");
+        // PowerShell escapes single quotes by doubling them: 'isn''t' -> isn't
+        let escaped = prompt.replace('\'', "''");
         cmd.push_str(&format!(" '{}'", escaped));
     }
 
@@ -491,8 +492,22 @@ mod tests {
     fn default_steps_prompt_with_single_quotes() {
         let steps = default_launch_steps(1, "fix it's broken", "sonnet", "auto", None);
         if let LaunchStep::RunCommand { command, .. } = &steps[2] {
-            // Single quotes in prompt should be escaped
-            assert!(command.contains("'fix it'\\''s broken'"));
+            // PowerShell escapes single quotes by doubling them
+            assert!(command.contains("'fix it''s broken'"), "got: {command}");
+        } else {
+            panic!("Expected RunCommand");
+        }
+    }
+
+    #[test]
+    fn default_steps_prompt_with_double_quotes() {
+        let steps = default_launch_steps(1, "what is \"the issue\"", "sonnet", "auto", None);
+        if let LaunchStep::RunCommand { command, .. } = &steps[2] {
+            // Double quotes inside single-quoted strings are literal (no escaping needed)
+            assert!(
+                command.contains("'what is \"the issue\"'"),
+                "got: {command}"
+            );
         } else {
             panic!("Expected RunCommand");
         }


### PR DESCRIPTION
## Summary

Single quotes in Quick Claude prompts (e.g., "isn't") broke the command because bash/POSIX escaping was used instead of PowerShell escaping. The terminal runs PowerShell, so single quotes must be doubled ('') not escaped with backslash (\'').

## Changes

- Fixed the escaping logic in `quick_claude.rs` to use PowerShell's doubling strategy for single quotes
- Updated the existing test for single quotes to verify the correct PowerShell escaping
- Added a new test for double quotes to ensure they're preserved correctly inside single-quoted strings

## Testing

The fix is covered by:
- `default_steps_prompt_with_single_quotes()` — verifies single quotes are doubled
- `default_steps_prompt_with_double_quotes()` — verifies double quotes are preserved