### PR TITLE
fix: use --permission-mode plan instead of invalid --plan flag

### DIFF
--- a/changelog/unreleased/fix-quick-claude-plan-mode-flag.md
+++ b/changelog/unreleased/fix-quick-claude-plan-mode-flag.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Quick Claude plan mode flag** — changed invalid `--plan` flag to correct `--permission-mode plan` (#fix-quick-claude-plan-mode-flag)

--- a/src-tauri/native/iced-shell/src/quick_claude.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude.rs
@@ -85,7 +85,7 @@ pub fn default_launch_steps(
     cmd.push_str(&format!(" --model {}", model));
     // Add mode flag
     match mode {
-        "plan" => cmd.push_str(" --plan"),
+        "plan" => cmd.push_str(" --permission-mode plan"),
         "auto" => cmd.push_str(" --dangerously-skip-permissions"),
         _ => {} // "default" — no flag
     }
@@ -509,7 +509,7 @@ mod tests {
     fn default_steps_with_model_and_mode() {
         let steps = default_launch_steps(1, "", "opus", "plan", None);
         if let LaunchStep::RunCommand { command, .. } = &steps[2] {
-            assert_eq!(command, "claude --model opus --plan");
+            assert_eq!(command, "claude --model opus --permission-mode plan");
         } else {
             panic!("Expected RunCommand at index 2");
         }


### PR DESCRIPTION
## Summary
Claude Code CLI does not support the `--plan` flag. The correct flag is `--permission-mode plan`. This fix updates Quick Claude's command builder to generate valid commands.

## Changes
- Updated flag in `default_launch_steps()` from `--plan` to `--permission-mode plan`
- Updated corresponding test assertion
- Added changelog fragment

## Test Plan
- [x] Verify test passes: `cargo test -p godly-iced-shell`
- [x] Manual test: Quick Claude with plan mode preset should now launch correctly