### PR TITLE
fix: set terminal CWD to worktree path when launching from Quick Claude

### DIFF
--- a/changelog/unreleased/fix-quick-claude-worktree-cwd.md
+++ b/changelog/unreleased/fix-quick-claude-worktree-cwd.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Quick Claude worktree CWD** — terminal launched from Quick Claude now correctly starts in the created worktree directory, not the original repository folder

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -7204,7 +7204,13 @@ impl GodlyApp {
             return self.finalize_launch();
         }
 
-        let step = launch.steps[step_index].clone();
+        let mut step = launch.steps[step_index].clone();
+        // If a worktree was just created, override the CWD of the next CreateTerminal step
+        if let crate::quick_claude::LaunchStep::CreateTerminal { ref mut cwd, .. } = step {
+            if let Some(wt_path) = &launch.pending_worktree_path {
+                *cwd = Some(wt_path.clone());
+            }
+        }
         let agent_ids = launch.agent_terminal_ids.clone();
 
         let Some(client) = &self.client else {


### PR DESCRIPTION
## Summary
When Quick Claude creates a git worktree and launches a new terminal, the terminal's working directory was not being set to the worktree path. The CWD was baked at step-building time with the original repo folder, while the worktree path was only stored in `pending_worktree_path` metadata.

## Changes
- Override the `CreateTerminal` step's `cwd` with `pending_worktree_path` right before dispatching the step

## Test plan
- Create a git worktree via Quick Claude dialog
- Verify the spawned terminal starts with `pwd` showing the worktree directory, not the original repo
