### PR TITLE
fix: support pasting copied image files in Quick Claude

### DIFF
--- a/changelog/unreleased/fix-quick-claude-image-paste-from-explorer.md
+++ b/changelog/unreleased/fix-quick-claude-image-paste-from-explorer.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Quick Claude image paste from File Explorer** — Added fallback to read CF_HDROP clipboard format when bitmap image data is not available. This allows users to paste image files copied from File Explorer by Ctrl+V in the Quick Claude dialog.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ features = [
     "winnt",
     "jobapi2",
     "processenv",
+    "winuser",
+    "shellapi",
+    "windef",
 ]
 
 [profile.dev]

--- a/src-tauri/native/app-adapter/src/clipboard.rs
+++ b/src-tauri/native/app-adapter/src/clipboard.rs
@@ -1,5 +1,12 @@
 use arboard::Clipboard;
 
+#[cfg(target_os = "windows")]
+use {
+    winapi::um::winuser::{OpenClipboard, GetClipboardData},
+    winapi::um::shellapi::DragQueryFileW,
+    winapi::um::winuser::CF_HDROP,
+};
+
 /// Copy text to the system clipboard.
 pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
     let mut clipboard =
@@ -43,8 +50,80 @@ pub fn check_clipboard_image() -> Result<Option<String>, String> {
             let path = save_clipboard_image_as_png(img.width, img.height, &img.bytes)?;
             Ok(Some(path))
         }
-        Err(_) => Ok(None),
+        Err(e) => {
+            log::debug!("No bitmap image found on clipboard: {}", e);
+            Ok(None)
+        }
     }
+}
+
+/// Check clipboard for image files (CF_HDROP format).
+/// Windows File Explorer puts file paths on the clipboard, not bitmap data.
+/// Returns a list of image file paths found.
+#[cfg(target_os = "windows")]
+pub fn check_clipboard_image_files() -> Result<Vec<String>, String> {
+    unsafe {
+        if OpenClipboard(std::ptr::null_mut()) == 0 {
+            return Err("Failed to open clipboard".to_string());
+        }
+
+        let handle = GetClipboardData(CF_HDROP as u32);
+        let _guard = ClipboardGuard;
+
+        if handle.is_null() {
+            log::debug!("No CF_HDROP data on clipboard");
+            return Ok(Vec::new());
+        }
+
+        let hdrop = handle as winapi::um::shellapi::HDROP;
+        let count = DragQueryFileW(hdrop, 0xFFFFFFFF, std::ptr::null_mut(), 0);
+
+        let mut paths = Vec::new();
+        for i in 0..count {
+            let len = DragQueryFileW(hdrop, i, std::ptr::null_mut(), 0) + 1;
+            let mut buf = vec![0u16; len as usize];
+            DragQueryFileW(hdrop, i, buf.as_mut_ptr(), len);
+
+            // Remove null terminator for conversion.
+            buf.pop();
+            let path = String::from_utf16(&buf)
+                .unwrap_or_else(|_| String::new());
+
+            // Check if it's an image file by extension.
+            if is_image_file(&path) {
+                paths.push(path);
+            }
+        }
+
+        if !paths.is_empty() {
+            log::info!("Found {} image file(s) on clipboard", paths.len());
+        } else {
+            log::debug!("No image files found in CF_HDROP clipboard data");
+        }
+
+        Ok(paths)
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct ClipboardGuard;
+
+#[cfg(target_os = "windows")]
+impl Drop for ClipboardGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = winapi::um::winuser::CloseClipboard();
+        }
+    }
+}
+
+/// Check if a file path is an image file based on extension.
+fn is_image_file(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    matches!(
+        lower.split('.').last().unwrap_or(""),
+        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "webp" | "svg" | "tiff" | "ico"
+    )
 }
 
 /// Encode raw RGBA pixels as PNG and write to a temp file.

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -827,8 +827,8 @@ pub enum Message {
     QuickClaudeDialogModeDropdownToggle,
     /// Models discovered from claude CLI.
     QuickClaudeDialogModelsLoaded(Vec<(String, String)>),
-    /// Image pasted from clipboard into Quick Claude dialog.
-    QuickClaudeDialogImagePasted(Result<crate::quick_claude_dialog::ImageAttachment, String>),
+    /// Image(s) pasted from clipboard into Quick Claude dialog.
+    QuickClaudeDialogImagePasted(Result<Vec<crate::quick_claude_dialog::ImageAttachment>, String>),
     /// Remove an attached image from Quick Claude dialog by index.
     QuickClaudeDialogImageRemoved(usize),
     /// AI tool display name input changed.
@@ -2674,12 +2674,15 @@ impl GodlyApp {
             }
             Message::QuickClaudeDialogImagePasted(result) => {
                 match result {
-                    Ok(attachment) => {
+                    Ok(attachments) => {
                         if let Some(ref mut dlg) = self.quick_claude_dialog {
-                            if dlg.attached_images.len() < 10 {
-                                dlg.attached_images.push(attachment);
-                            } else {
-                                log::warn!("Quick Claude: max 10 image attachments reached");
+                            for attachment in attachments {
+                                if dlg.attached_images.len() < 10 {
+                                    dlg.attached_images.push(attachment);
+                                } else {
+                                    log::warn!("Quick Claude: max 10 image attachments reached");
+                                    break;
+                                }
                             }
                         }
                     }
@@ -7550,30 +7553,48 @@ impl GodlyApp {
             async move {
                 let (tx, rx) = futures_channel::oneshot::channel();
                 std::thread::spawn(move || {
-                    let result = clipboard::check_clipboard_image();
+                    // Try bitmap image first (arboard get_image).
+                    let result = if let Ok(Some(path)) = clipboard::check_clipboard_image() {
+                        Ok(vec![path])
+                    } else {
+                        // Fallback: check for image files via CF_HDROP (File Explorer drag-drop).
+                        #[cfg(target_os = "windows")]
+                        {
+                            match clipboard::check_clipboard_image_files() {
+                                Ok(paths) if !paths.is_empty() => Ok(paths),
+                                _ => Err("No image or image file found on clipboard".into()),
+                            }
+                        }
+                        #[cfg(not(target_os = "windows"))]
+                        {
+                            Err("No image found on clipboard".into())
+                        }
+                    };
                     let _ = tx.send(result);
                 });
                 rx.await
                     .unwrap_or_else(|_| Err("Clipboard background thread panicked".into()))
             },
             |result| match result {
-                Ok(Some(path)) => {
-                    let display_name = std::path::Path::new(&path)
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_else(|| "clipboard-image.png".to_string());
-                    let handle = iced::widget::image::Handle::from_path(&path);
-                    Message::QuickClaudeDialogImagePasted(Ok(
-                        crate::quick_claude_dialog::ImageAttachment {
+                Ok(paths) => {
+                    let mut attachments = Vec::new();
+                    for path in paths {
+                        let display_name = std::path::Path::new(&path)
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "image".to_string());
+                        let handle = iced::widget::image::Handle::from_path(&path);
+                        attachments.push(crate::quick_claude_dialog::ImageAttachment {
                             file_path: path,
                             thumbnail_handle: handle,
                             display_name,
-                        },
-                    ))
-                }
-                Ok(None) => {
-                    // No image on clipboard — text paste already handled by text_editor
-                    Message::ClipboardPasteFailed("Clipboard empty".into())
+                        });
+                    }
+                    if attachments.is_empty() {
+                        Message::ClipboardPasteFailed("No images found on clipboard".into())
+                    } else {
+                        Message::QuickClaudeDialogImagePasted(Ok(attachments))
+                    }
                 }
                 Err(e) => Message::QuickClaudeDialogImagePasted(Err(e)),
             },


### PR DESCRIPTION
## Summary
Fixed Quick Claude image paste (Ctrl+V) to work when users copy image files from File Explorer. The existing code only handled clipboard bitmap data, but File Explorer puts file paths (CF_HDROP format) on the clipboard instead.

## Changes
- Added `check_clipboard_image_files()` function to read CF_HDROP from Windows clipboard using Win32 API
- Fallback logic: try bitmap image first, then check for CF_HDROP file paths
- Updated `QuickClaudeDialogImagePasted` message to accept `Vec<ImageAttachment>` for multiple files
- Added proper diagnostic logging to clipboard module (previously errors were silently swallowed)
- Support pasting multiple image files at once (up to 10 total)

## Files Changed
1. `src-tauri/Cargo.toml` — Added `winuser`, `shellapi`, `windef` features to workspace winapi
2. `src-tauri/native/app-adapter/src/clipboard.rs` — New CF_HDROP support function with logging
3. `src-tauri/native/iced-shell/src/app.rs` — Updated message type and handler, added file path fallback

## Testing
- Manual test: Copy image file from File Explorer → paste in Quick Claude with Ctrl+V
- Existing bitmap paste still works (backward compatible)