### PR TITLE
feat: live perf overlay with real frame timing

### DIFF
--- a/changelog/unreleased/feat-live-perf-overlay.md
+++ b/changelog/unreleased/feat-live-perf-overlay.md
@@ -1,0 +1,2 @@
+### Added
+- **Live performance overlay** — Replaced hardcoded FPS/frame time placeholders with real rolling-average measurements, added render duration and renderer type display

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -443,6 +443,7 @@ pub struct GodlyApp {
     search: SearchState,
     // --- G6/G7: Scrollbar + Performance Overlay ---
     perf_overlay_visible: bool,
+    perf_stats: crate::perf_stats::PerfStats,
     // --- K1: CLAUDE.md Editor ---
     claude_md_editor: Option<crate::claude_md_editor::ClaudeMdEditorState>,
     // --- I4/I5: Voice/Whisper Integration ---
@@ -566,6 +567,7 @@ impl Default for GodlyApp {
             ctrl_held: false,
             search: SearchState::default(),
             perf_overlay_visible: false,
+            perf_stats: crate::perf_stats::PerfStats::new(),
             claude_md_editor: None,
             whisper_available: godly_app_adapter::whisper::whisper_binary_path().is_some(),
             whisper_state: None,
@@ -3081,6 +3083,7 @@ impl GodlyApp {
                 self.toasts.retain(|t| t.id != id);
             }
             Message::Heartbeat => {
+                self.perf_stats.frame_tick();
                 // Detect actual focus via Win32 API — Iced's Focused/Unfocused
                 // events are unreliable on Windows (missed on minimize, stolen
                 // on restore). This runs from RedrawRequested + WM_TIMER.
@@ -4059,8 +4062,10 @@ impl GodlyApp {
         // --- G7: Performance overlay (top-right corner) ---
         let with_perf: Element<'_, Message> = if self.perf_overlay_visible {
             let perf: Element<'_, Message> = crate::perf_overlay::view_perf_overlay(
-                60.0, // placeholder FPS
-                16.6, // placeholder frame_ms
+                self.perf_stats.fps(),
+                self.perf_stats.frame_ms(),
+                self.perf_stats.render_ms(),
+                if self.use_pixel_renderer { "Pixel" } else { "Canvas" },
                 self.terminals.count(),
             );
             let positioned = container(perf)
@@ -7678,6 +7683,7 @@ impl GodlyApp {
         let default_fg = palette.foreground;
         let default_bg = palette.background;
 
+        let t0 = std::time::Instant::now();
         let (pixels, w, h) = self.pixel_renderer.render(
             &grid_clone,
             &metrics,
@@ -7694,6 +7700,8 @@ impl GodlyApp {
                 term.cached_image_handle = Some(handle);
             }
         }
+
+        self.perf_stats.record_render_duration_us(t0.elapsed().as_micros() as f64);
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/native/iced-shell/src/lib.rs
+++ b/src-tauri/native/iced-shell/src/lib.rs
@@ -25,6 +25,7 @@ pub mod search;
 pub mod scrollbar;
 pub mod status_bar;
 pub mod perf_overlay;
+pub mod perf_stats;
 pub mod url_detector;
 pub mod terminal_context_menu;
 pub mod whisper_ui;

--- a/src-tauri/native/iced-shell/src/main.rs
+++ b/src-tauri/native/iced-shell/src/main.rs
@@ -42,6 +42,7 @@ mod search;
 mod scrollbar;
 mod status_bar;
 mod perf_overlay;
+mod perf_stats;
 mod url_detector;
 mod terminal_context_menu;
 mod whisper_ui;

--- a/src-tauri/native/iced-shell/src/perf_overlay.rs
+++ b/src-tauri/native/iced-shell/src/perf_overlay.rs
@@ -5,18 +5,27 @@ use iced::{Background, Border, Color, Element, Padding};
 pub fn view_perf_overlay<'a, M: 'a>(
     fps: f32,
     frame_ms: f32,
+    render_ms: f32,
+    renderer_type: &str,
     terminal_count: usize,
 ) -> Element<'a, M> {
+    let green = Color::from_rgba(0.0, 1.0, 0.0, 0.9);
     let content = column![
         text(format!("FPS: {:.0}", fps))
             .size(11)
-            .color(Color::from_rgba(0.0, 1.0, 0.0, 0.9)),
+            .color(green),
         text(format!("Frame: {:.1}ms", frame_ms))
             .size(11)
-            .color(Color::from_rgba(0.0, 1.0, 0.0, 0.9)),
+            .color(green),
+        text(format!("Render: {:.2}ms", render_ms))
+            .size(11)
+            .color(green),
+        text(format!("Renderer: {}", renderer_type))
+            .size(11)
+            .color(green),
         text(format!("Terminals: {}", terminal_count))
             .size(11)
-            .color(Color::from_rgba(0.0, 1.0, 0.0, 0.9)),
+            .color(green),
     ]
     .spacing(2);
 
@@ -43,6 +52,6 @@ mod tests {
 
     #[test]
     fn perf_overlay_renders() {
-        let _el: Element<'_, TestMsg> = view_perf_overlay(60.0, 16.6, 5);
+        let _el: Element<'_, TestMsg> = view_perf_overlay(60.0, 16.6, 0.5, "Canvas", 5);
     }
 }

--- a/src-tauri/native/iced-shell/src/perf_stats.rs
+++ b/src-tauri/native/iced-shell/src/perf_stats.rs
@@ -1,0 +1,85 @@
+use std::time::Instant;
+
+/// Rolling performance statistics with exponential moving average.
+pub struct PerfStats {
+    /// Exponential moving average of frame time (seconds).
+    ema_frame_time: f64,
+    /// Last render() call duration in microseconds.
+    last_render_us: f64,
+    /// When the last frame started.
+    last_frame_time: Option<Instant>,
+    /// Smoothing factor (0..1). Higher = more responsive.
+    alpha: f64,
+}
+
+impl PerfStats {
+    pub fn new() -> Self {
+        Self {
+            ema_frame_time: 1.0 / 60.0,
+            last_render_us: 0.0,
+            last_frame_time: None,
+            alpha: 0.1,
+        }
+    }
+
+    /// Call on each frame/heartbeat to update FPS tracking.
+    pub fn frame_tick(&mut self) {
+        let now = Instant::now();
+        if let Some(prev) = self.last_frame_time {
+            let dt = now.duration_since(prev).as_secs_f64();
+            if dt > 0.0 && dt < 1.0 {
+                self.ema_frame_time = self.alpha * dt + (1.0 - self.alpha) * self.ema_frame_time;
+            }
+        }
+        self.last_frame_time = Some(now);
+    }
+
+    /// Record how long the render() call took.
+    pub fn record_render_duration_us(&mut self, us: f64) {
+        self.last_render_us = us;
+    }
+
+    pub fn fps(&self) -> f32 {
+        if self.ema_frame_time > 0.0 {
+            (1.0 / self.ema_frame_time) as f32
+        } else {
+            0.0
+        }
+    }
+
+    pub fn frame_ms(&self) -> f32 {
+        (self.ema_frame_time * 1000.0) as f32
+    }
+
+    pub fn render_ms(&self) -> f32 {
+        (self.last_render_us / 1000.0) as f32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_near_60fps() {
+        let stats = PerfStats::new();
+        let fps = stats.fps();
+        assert!(
+            (fps - 60.0).abs() < 1.0,
+            "Expected fps near 60, got {}",
+            fps
+        );
+    }
+
+    #[test]
+    fn record_render_updates() {
+        let mut stats = PerfStats::new();
+        stats.record_render_duration_us(500.0);
+        let ms = stats.render_ms();
+        assert!(
+            (ms - 0.5).abs() < 0.01,
+            "Expected render_ms near 0.5, got {}",
+            ms
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded 60.0 FPS / 16.6ms placeholders in the perf overlay with real rolling-average measurements from `PerfStats` (EMA-based)
- Add `perf_stats.rs` module with exponential moving average tracking for FPS, frame time, and pixel renderer duration
- Expand perf overlay to show render duration and renderer type (Pixel/Canvas)
- Instrument `render_terminal_image()` to capture pixel renderer wall time

## Test plan
- [x] `cargo test -p godly-iced-shell -- perf_stats` passes (2 unit tests)
- [x] `cargo check -p godly-iced-shell` compiles cleanly
- [ ] Visual verification: toggle overlay in-app, confirm FPS/frame time update live