### PR TITLE
feat: add password field to phone remote preferences and fix Copy URL

### DIFF
--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -406,6 +406,8 @@ pub struct GodlyApp {
     phone_remote_port_input: String,
     /// Phone remote settings form: API key input.
     phone_remote_api_key_input: String,
+    /// Phone remote settings form: password input.
+    phone_remote_password_input: String,
     /// Active toast notifications rendered as overlay cards.
     toasts: Vec<ToastNotification>,
     /// Monotonic id source for toast notifications.
@@ -482,6 +484,7 @@ impl Default for GodlyApp {
         let phone_host_input = phone_prefs.host.clone();
         let phone_port_input = phone_prefs.port.to_string();
         let phone_key_input = phone_prefs.api_key.clone();
+        let phone_password_input = phone_prefs.password.clone();
         Self {
             client: None,
             terminals: TerminalCollection::new(),
@@ -549,6 +552,7 @@ impl Default for GodlyApp {
             phone_remote_host_input: phone_host_input,
             phone_remote_port_input: phone_port_input,
             phone_remote_api_key_input: phone_key_input,
+            phone_remote_password_input: phone_password_input,
             toasts: Vec::new(),
             next_toast_id: 1,
             dragging_tab_id: None,
@@ -859,6 +863,8 @@ pub enum Message {
     PhoneRemotePortInputChanged(String),
     /// Phone remote API key input changed.
     PhoneRemoteApiKeyInputChanged(String),
+    /// Phone remote password input changed.
+    PhoneRemotePasswordInputChanged(String),
     /// Toggle auto-start preference.
     PhoneRemoteAutoStartToggle,
     /// Save phone remote settings to disk and apply.
@@ -3009,6 +3015,8 @@ impl GodlyApp {
                         if !key.is_empty() {
                             self.phone_remote_prefs.api_key = key;
                         }
+                        self.phone_remote_prefs.password =
+                            self.phone_remote_password_input.trim().to_string();
                         crate::phone_remote::save_preferences(&self.phone_remote_prefs);
 
                         match crate::phone_remote::spawn_remote_server(&self.phone_remote_prefs) {
@@ -3070,6 +3078,9 @@ impl GodlyApp {
             Message::PhoneRemoteApiKeyInputChanged(value) => {
                 self.phone_remote_api_key_input = value;
             }
+            Message::PhoneRemotePasswordInputChanged(value) => {
+                self.phone_remote_password_input = value;
+            }
             Message::PhoneRemoteAutoStartToggle => {
                 self.phone_remote_prefs.auto_start = !self.phone_remote_prefs.auto_start;
                 crate::phone_remote::save_preferences(&self.phone_remote_prefs);
@@ -3092,6 +3103,8 @@ impl GodlyApp {
                 if !key.is_empty() {
                     self.phone_remote_prefs.api_key = key;
                 }
+                self.phone_remote_prefs.password =
+                    self.phone_remote_password_input.trim().to_string();
                 crate::phone_remote::save_preferences(&self.phone_remote_prefs);
 
                 // If server is running, restart with new settings
@@ -3123,9 +3136,10 @@ impl GodlyApp {
                 self.phone_remote_api_key_input = new_key;
             }
             Message::PhoneRemoteCopyUrl => {
+                let host = crate::phone_remote::display_host(&self.phone_remote_prefs.host);
                 let url = format!(
-                    "http://{}:{}/phone",
-                    self.phone_remote_prefs.host, self.phone_remote_prefs.port
+                    "http://{}:{}/phone#key={}",
+                    host, self.phone_remote_prefs.port, self.phone_remote_prefs.api_key
                 );
                 return iced::clipboard::write(url);
             }
@@ -5486,6 +5500,12 @@ impl GodlyApp {
                 .on_input(Message::PhoneRemotePortInputChanged)
                 .padding(Padding::from([4, 8]))
                 .size(12),
+            text("Password (for browser login)").size(12).color(TEXT_SECONDARY()),
+            text_input("Optional password for phone browser login", &self.phone_remote_password_input)
+                .on_input(Message::PhoneRemotePasswordInputChanged)
+                .padding(Padding::from([4, 8]))
+                .size(12)
+                .secure(true),
             text("API Key").size(12).color(TEXT_SECONDARY()),
             api_key_row,
             auto_start_btn,
@@ -5497,10 +5517,8 @@ impl GodlyApp {
         .width(Length::Fill);
 
         if self.phone_remote_status == PhoneRemoteStatus::Running {
-            let url = format!(
-                "http://{}:{}/phone",
-                self.phone_remote_prefs.host, self.phone_remote_prefs.port
-            );
+            let host = crate::phone_remote::display_host(&self.phone_remote_prefs.host);
+            let url = format!("http://{}:{}/phone", host, self.phone_remote_prefs.port);
             content = content
                 .push(text("Connection Info").size(12).color(TEXT_SECONDARY()))
                 .push(

--- a/src-tauri/native/iced-shell/src/phone_remote.rs
+++ b/src-tauri/native/iced-shell/src/phone_remote.rs
@@ -15,6 +15,7 @@ pub struct PhoneRemotePreferences {
     pub port: u16,
     pub api_key: String,
     pub auto_start: bool,
+    pub password: String,
 }
 
 impl Default for PhoneRemotePreferences {
@@ -24,6 +25,7 @@ impl Default for PhoneRemotePreferences {
             port: 3377,
             api_key: generate_api_key(),
             auto_start: false,
+            password: String::new(),
         }
     }
 }
@@ -119,6 +121,9 @@ pub fn spawn_remote_server(prefs: &PhoneRemotePreferences) -> Result<Child, Stri
     cmd.env("GODLY_REMOTE_HOST", &prefs.host)
         .env("GODLY_REMOTE_PORT", prefs.port.to_string())
         .env("GODLY_REMOTE_API_KEY", &prefs.api_key);
+    if !prefs.password.is_empty() {
+        cmd.env("GODLY_REMOTE_PASSWORD", &prefs.password);
+    }
 
     #[cfg(windows)]
     {
@@ -137,6 +142,32 @@ pub fn stop_remote_server(child: &mut Child) {
 }
 
 // ---------------------------------------------------------------------------
+// LAN IP detection
+// ---------------------------------------------------------------------------
+
+/// Detect the local LAN IP address by connecting a UDP socket to a public
+/// address (no data is actually sent). Returns `None` if detection fails.
+pub fn detect_lan_ip() -> Option<String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let addr = socket.local_addr().ok()?;
+    Some(addr.ip().to_string())
+}
+
+/// Return a display-friendly host for the phone remote URL.
+///
+/// When the server binds to all interfaces (`0.0.0.0` or `::`), we detect
+/// the LAN IP so the URL is directly usable from another device. Falls back
+/// to `"localhost"` when detection fails.
+pub fn display_host(host: &str) -> String {
+    if host == "0.0.0.0" || host == "::" {
+        detect_lan_ip().unwrap_or_else(|| "localhost".to_string())
+    } else {
+        host.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -151,6 +182,7 @@ mod tests {
         assert_eq!(prefs.port, 3377);
         assert_eq!(prefs.api_key.len(), 32);
         assert!(!prefs.auto_start);
+        assert!(prefs.password.is_empty());
     }
 
     #[test]
@@ -170,6 +202,7 @@ mod tests {
             port: 4000,
             api_key: "abc123".to_string(),
             auto_start: true,
+            password: "s3cret".to_string(),
         };
         let json = serde_json::to_string(&prefs).unwrap();
         let loaded: PhoneRemotePreferences = serde_json::from_str(&json).unwrap();
@@ -177,6 +210,7 @@ mod tests {
         assert_eq!(loaded.port, 4000);
         assert_eq!(loaded.api_key, "abc123");
         assert!(loaded.auto_start);
+        assert_eq!(loaded.password, "s3cret");
     }
 
     #[test]
@@ -188,5 +222,28 @@ mod tests {
         assert!(!loaded.auto_start);
         // api_key gets a fresh default (non-empty)
         assert!(!loaded.api_key.is_empty());
+        // password defaults to empty string when missing
+        assert!(loaded.password.is_empty());
+    }
+
+    #[test]
+    fn password_field_roundtrips_through_serde() {
+        let prefs = PhoneRemotePreferences {
+            password: "hunter2".to_string(),
+            ..PhoneRemotePreferences::default()
+        };
+        let json = serde_json::to_string(&prefs).unwrap();
+        let loaded: PhoneRemotePreferences = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.password, "hunter2");
+    }
+
+    #[test]
+    fn detect_lan_ip_returns_non_loopback() {
+        // This test may be skipped in environments without network access.
+        if let Some(ip) = detect_lan_ip() {
+            assert!(!ip.is_empty());
+            // Should not be the unspecified address
+            assert_ne!(ip, "0.0.0.0");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `password` field to `PhoneRemotePreferences` with serde default for backward compat
- Pass `GODLY_REMOTE_PASSWORD` env var to godly-remote when password is set
- Add secure password input to Remote settings tab in the Iced shell UI
- Fix Copy URL to detect LAN IP (instead of showing `0.0.0.0`) and include `#key=` fragment
- Fix Connection Info display to show the LAN IP

## Test plan
- [ ] Build: `cargo check -p iced-shell`
- [ ] Verify old `phone-remote-prefs.json` files without `password` field still load correctly
- [ ] Set a password in Remote settings → verify it persists across app restarts
- [ ] Copy URL when bound to `0.0.0.0` → should show LAN IP with `#key=...` fragment