### PR TITLE
fix: prevent false notification badge when switching workspaces

### DIFF
--- a/changelog/unreleased/fix-workspace-notification-badge.md
+++ b/changelog/unreleased/fix-workspace-notification-badge.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Workspace notification badge appearing on switch** — fixed false notification badge when switching away from a workspace. The issue occurred when non-focused terminals in the active workspace accumulated unread output counts. Now all visible terminals in the active workspace are marked as read, and `record_output` correctly checks all terminals in the active workspace rather than just the focused one.

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1058,6 +1058,16 @@ impl GodlyApp {
             .collect()
     }
 
+    /// Mark all terminals in the active workspace as read.
+    fn mark_active_workspace_read(&mut self) {
+        if let Some(ws) = self.workspaces.active() {
+            let ids: Vec<String> = ws.layout.all_leaf_ids().iter().map(|s| s.to_string()).collect();
+            for terminal_id in ids {
+                self.notifications.mark_read(&terminal_id);
+            }
+        }
+    }
+
     fn workspace_muted_for_terminal(&self, terminal_id: &str) -> bool {
         let Some(terminal) = self.terminals.get(terminal_id) else {
             return false;
@@ -1490,9 +1500,15 @@ impl GodlyApp {
                     }
                     term.dirty = true;
                 }
-                // Track notifications for non-focused terminals.
-                let is_focused = self.active_focused() == Some(session_id.as_str());
-                if !is_focused {
+                // Track notifications for terminals outside the active workspace.
+                // All terminals visible in the active workspace are considered "seen"
+                // — not just the single focused pane — so they don't accumulate
+                // false unread counts that would show a badge when switching away.
+                let in_active_workspace = self
+                    .workspaces
+                    .active()
+                    .map_or(false, |ws| ws.layout.find_leaf(&session_id));
+                if !in_active_workspace {
                     self.notifications.record_output(&session_id);
                 }
                 return self.fetch_grid(&session_id);
@@ -2184,9 +2200,7 @@ impl GodlyApp {
                 if decision.clear_context_menu {
                     self.workspace_context_menu_id = None;
                 }
-                if let Some(terminal_id) = decision.mark_terminal_read_id {
-                    self.notifications.mark_read(&terminal_id);
-                }
+                self.mark_active_workspace_read();
                 self.tab_context_menu_id = None;
             }
             Message::NewWorkspaceRequested => {
@@ -5898,26 +5912,12 @@ impl GodlyApp {
             }
             AppAction::NextWorkspace => {
                 self.workspaces.next();
-                let read_target = workspace_reducer::reduce_workspace_switch_read_target(
-                    self.workspaces
-                        .active()
-                        .map(|workspace| workspace.focused_terminal.clone()),
-                );
-                if let Some(terminal_id) = read_target {
-                    self.notifications.mark_read(&terminal_id);
-                }
+                self.mark_active_workspace_read();
                 Task::none()
             }
             AppAction::PrevWorkspace => {
                 self.workspaces.previous();
-                let read_target = workspace_reducer::reduce_workspace_switch_read_target(
-                    self.workspaces
-                        .active()
-                        .map(|workspace| workspace.focused_terminal.clone()),
-                );
-                if let Some(terminal_id) = read_target {
-                    self.notifications.mark_read(&terminal_id);
-                }
+                self.mark_active_workspace_read();
                 Task::none()
             }
             AppAction::ToggleSidebar => self.toggle_sidebar_visibility(),
@@ -6030,9 +6030,8 @@ impl GodlyApp {
                 if decision.clear_context_menu {
                     self.workspace_context_menu_id = None;
                 }
-                if let Some(terminal_id) = decision.mark_terminal_read_id {
-                    self.notifications.mark_read(&terminal_id);
-                }
+                // Mark all terminals in the destination workspace as read.
+                self.mark_active_workspace_read();
                 self.tab_context_menu_id = None;
                 Task::none()
             }
@@ -6247,9 +6246,7 @@ impl GodlyApp {
                 .active()
                 .map(|workspace| workspace.focused_terminal.clone()),
         );
-        if let Some(terminal_id) = decision.mark_terminal_read_id {
-            self.notifications.mark_read(&terminal_id);
-        }
+        self.mark_active_workspace_read();
         if let Some(terminal_id) = decision.fetch_grid_terminal_id {
             return self.fetch_grid(&terminal_id);
         }


### PR DESCRIPTION
## Summary

Fixed a bug where workspace notification badges (the small dot indicator) appeared on the previously active workspace even when there were no new notifications.

**Root Cause**: The `TerminalOutput` handler only checked if a terminal was the single focused terminal of the active workspace (`active_focused()`). Non-focused terminals (like split panes) still accumulated unread output counts, causing a false badge to appear when the user switched away.

## Changes

Two-part fix:

1. **Fixed `record_output` gate** — Changed from checking `active_focused()` (single terminal) to `ws.layout.find_leaf()` (all terminals in the active workspace). All visible terminals are now correctly considered "seen."

2. **Added `mark_active_workspace_read()` helper** — Marks all terminals in a workspace as read when switching to it. Applied to:
   - `SelectWorkspace` event
   - `WorkspaceClicked` event  
   - `NextWorkspace` / `PrevWorkspace` navigation
   - Post-workspace-delete handlers

## Files Changed

- `src-tauri/native/iced-shell/src/app.rs` — Updated output tracking and workspace switching logic
- `changelog/unreleased/fix-workspace-notification-badge.md` — Added changelog fragment

## Testing

- The badge no longer appears when switching between workspaces with split panes
- All terminals in the active workspace are correctly marked as read