### PR TITLE
fix: read native iced-shell session format instead of stale layout.json

### DIFF
--- a/changelog/unreleased/742-fix-layout-reader-session-format.md
+++ b/changelog/unreleased/742-fix-layout-reader-session-format.md
@@ -1,0 +1,2 @@
+### Fixed
+- **godly-remote layout reader** — Fixed reading stale workspace/terminal data from Tauri-era `layout.json` instead of native `iced-shell-session.json` (#742)

--- a/src-tauri/remote/src/layout_reader.rs
+++ b/src-tauri/remote/src/layout_reader.rs
@@ -9,9 +9,6 @@ use serde::{Deserialize, Serialize};
 /// TTL for cached layout data.
 const CACHE_TTL: Duration = Duration::from_secs(5);
 
-/// Layout store key (matches Tauri app's LAYOUT_KEY).
-const LAYOUT_KEY: &str = "layout";
-
 /// AI tool mode (mirrors state/models.rs).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -74,25 +71,68 @@ pub struct Layout {
     pub split_views: HashMap<String, SplitView>,
 }
 
-/// Tauri plugin-store format: the layout.json file wraps values in a store object.
-/// The actual layout is under the "layout" key.
+// --- Native session format (iced-shell-session.json) ---
+
 #[derive(Deserialize)]
-struct StoreFile {
-    #[serde(flatten)]
-    entries: HashMap<String, serde_json::Value>,
+struct NativeSessionState {
+    active_workspace_id: Option<String>,
+    #[serde(default)]
+    workspaces: Vec<NativeWorkspaceState>,
+    #[serde(default)]
+    terminal_worktree_paths: HashMap<String, String>,
+    /// Background tabs not in any layout tree.
+    #[serde(default)]
+    terminal_workspace_assignments: HashMap<String, String>,
 }
 
-/// Cached layout reader that avoids filesystem hits on every request.
+#[derive(Deserialize)]
+struct NativeWorkspaceState {
+    id: String,
+    name: String,
+    folder_path: String,
+    #[serde(default)]
+    worktree_mode: bool,
+    #[serde(default)]
+    #[allow(dead_code)]
+    focused_terminal: Option<String>,
+    layout: NativeLayoutNode,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum NativeLayoutNode {
+    Leaf {
+        terminal_id: String,
+    },
+    Split {
+        first: Box<NativeLayoutNode>,
+        second: Box<NativeLayoutNode>,
+        // direction and ratio are ignored — we only need terminal IDs
+    },
+}
+
+/// Recursively collect all terminal IDs from a layout tree.
+fn collect_terminal_ids(node: &NativeLayoutNode, out: &mut Vec<String>) {
+    match node {
+        NativeLayoutNode::Leaf { terminal_id } => out.push(terminal_id.clone()),
+        NativeLayoutNode::Split { first, second, .. } => {
+            collect_terminal_ids(first, out);
+            collect_terminal_ids(second, out);
+        }
+    }
+}
+
+/// Cached layout reader that reads from the native iced-shell session file.
 pub struct LayoutReader {
     cache: Mutex<Option<(Layout, Instant)>>,
-    layout_path: PathBuf,
+    session_path: PathBuf,
 }
 
 impl LayoutReader {
     pub fn new() -> Self {
         Self {
             cache: Mutex::new(None),
-            layout_path: Self::find_layout_path(),
+            session_path: Self::find_session_path(),
         }
     }
 
@@ -118,43 +158,102 @@ impl LayoutReader {
     }
 
     fn read_from_disk(&self) -> Layout {
-        let contents = match std::fs::read_to_string(&self.layout_path) {
+        let contents = match std::fs::read_to_string(&self.session_path) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!("Cannot read layout file {}: {}", self.layout_path.display(), e);
+                tracing::debug!(
+                    "Cannot read session file {}: {}",
+                    self.session_path.display(),
+                    e
+                );
                 return Layout::default();
             }
         };
 
-        // Tauri plugin-store saves as { "layout": { ... } }
-        let store: StoreFile = match serde_json::from_str(&contents) {
+        let session: NativeSessionState = match serde_json::from_str(&contents) {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!("Failed to parse layout store: {}", e);
+                tracing::warn!("Failed to parse native session: {}", e);
                 return Layout::default();
             }
         };
 
-        match store.entries.get(LAYOUT_KEY) {
-            Some(value) => serde_json::from_value(value.clone()).unwrap_or_else(|e| {
-                tracing::warn!("Failed to parse layout value: {}", e);
-                Layout::default()
-            }),
-            None => {
-                tracing::debug!("No '{}' key in layout store", LAYOUT_KEY);
-                Layout::default()
+        self.convert_session(session)
+    }
+
+    /// Convert the native session format into the Layout struct used by routes.
+    fn convert_session(&self, session: NativeSessionState) -> Layout {
+        let mut terminals = Vec::new();
+
+        let workspaces: Vec<Workspace> = session
+            .workspaces
+            .iter()
+            .map(|ws| {
+                // Collect terminal IDs from the layout tree
+                let mut term_ids = Vec::new();
+                collect_terminal_ids(&ws.layout, &mut term_ids);
+
+                for tid in &term_ids {
+                    terminals.push(TerminalInfo {
+                        id: tid.clone(),
+                        workspace_id: ws.id.clone(),
+                        name: "Terminal".to_string(),
+                        shell_type: ShellType::default(),
+                        cwd: None,
+                        worktree_path: session.terminal_worktree_paths.get(tid).cloned(),
+                        worktree_branch: None,
+                    });
+                }
+
+                Workspace {
+                    id: ws.id.clone(),
+                    name: ws.name.clone(),
+                    folder_path: ws.folder_path.clone(),
+                    tab_order: term_ids,
+                    shell_type: ShellType::default(),
+                    worktree_mode: ws.worktree_mode,
+                    ai_tool_mode: AiToolMode::default(),
+                }
+            })
+            .collect();
+
+        // Add background tabs (terminals not in any layout tree)
+        let layout_terminal_ids: std::collections::HashSet<String> =
+            terminals.iter().map(|t| t.id.clone()).collect();
+
+        for (tid, ws_id) in &session.terminal_workspace_assignments {
+            if !layout_terminal_ids.contains(tid) {
+                terminals.push(TerminalInfo {
+                    id: tid.clone(),
+                    workspace_id: ws_id.clone(),
+                    name: "Terminal".to_string(),
+                    shell_type: ShellType::default(),
+                    cwd: None,
+                    worktree_path: session.terminal_worktree_paths.get(tid).cloned(),
+                    worktree_branch: None,
+                });
             }
+        }
+
+        Layout {
+            workspaces,
+            terminals,
+            active_workspace_id: session.active_workspace_id,
+            split_views: HashMap::new(),
         }
     }
 
-    fn find_layout_path() -> PathBuf {
+    fn find_session_path() -> PathBuf {
         if let Ok(appdata) = std::env::var("APPDATA") {
             PathBuf::from(appdata)
-                .join("com.godly.terminal")
-                .join("layout.json")
+                .join(format!(
+                    "com.godly.terminal{}",
+                    godly_protocol::instance_suffix()
+                ))
+                .join("native")
+                .join("iced-shell-session.json")
         } else {
-            // Fallback
-            PathBuf::from("layout.json")
+            PathBuf::from("iced-shell-session.json")
         }
     }
 }
@@ -169,54 +268,112 @@ mod tests {
         assert_eq!(ShellType::Pwsh.display_name(), "pwsh");
         assert_eq!(ShellType::Cmd.display_name(), "cmd");
         assert_eq!(
-            ShellType::Wsl { distribution: Some("Ubuntu".into()) }.display_name(),
+            ShellType::Wsl {
+                distribution: Some("Ubuntu".into())
+            }
+            .display_name(),
             "Ubuntu"
         );
         assert_eq!(
-            ShellType::Wsl { distribution: None }.display_name(),
+            ShellType::Wsl {
+                distribution: None
+            }
+            .display_name(),
             "wsl"
         );
         assert_eq!(
-            ShellType::Custom { program: "nu.exe".into(), args: None }.display_name(),
+            ShellType::Custom {
+                program: "nu.exe".into(),
+                args: None
+            }
+            .display_name(),
             "nu"
         );
     }
 
     #[test]
-    fn parse_layout_from_store_format() {
-        let store_json = r#"{
-            "layout": {
-                "workspaces": [{
-                    "id": "ws-1",
-                    "name": "Test",
-                    "folder_path": "C:\\test",
-                    "tab_order": ["t-1"]
-                }],
-                "terminals": [{
-                    "id": "t-1",
-                    "workspace_id": "ws-1",
-                    "name": "Shell"
-                }],
-                "active_workspace_id": "ws-1"
+    fn parse_native_session_format() {
+        let session_json = r#"{
+            "version": 1,
+            "sidebar_visible": true,
+            "settings_open": false,
+            "settings_tab": "general",
+            "font_size": 14.0,
+            "font_family": "Geist Mono",
+            "next_workspace_num": 3,
+            "active_workspace_id": "ws-1",
+            "active_terminal_id": "t-1",
+            "workspaces": [{
+                "id": "ws-1",
+                "name": "Test Project",
+                "folder_path": "C:\\test",
+                "worktree_mode": false,
+                "focused_terminal": "t-1",
+                "layout": {
+                    "type": "split",
+                    "direction": "vertical",
+                    "ratio": 0.5,
+                    "first": {
+                        "type": "leaf",
+                        "terminal_id": "t-1"
+                    },
+                    "second": {
+                        "type": "leaf",
+                        "terminal_id": "t-2"
+                    }
+                }
+            }],
+            "terminal_worktree_paths": {
+                "t-1": "C:\\worktrees\\wt-1"
+            },
+            "terminal_workspace_assignments": {
+                "t-1": "ws-1",
+                "t-2": "ws-1",
+                "t-3": "ws-1"
             }
         }"#;
 
-        let store: StoreFile = serde_json::from_str(store_json).unwrap();
-        let layout: Layout = serde_json::from_value(
-            store.entries.get(LAYOUT_KEY).unwrap().clone(),
-        ).unwrap();
+        let session: NativeSessionState = serde_json::from_str(session_json).unwrap();
+        let reader = LayoutReader {
+            cache: Mutex::new(None),
+            session_path: PathBuf::from("unused"),
+        };
+        let layout = reader.convert_session(session);
 
         assert_eq!(layout.workspaces.len(), 1);
-        assert_eq!(layout.workspaces[0].name, "Test");
-        assert_eq!(layout.terminals.len(), 1);
-        assert_eq!(layout.terminals[0].id, "t-1");
+        assert_eq!(layout.workspaces[0].name, "Test Project");
+        assert_eq!(layout.active_workspace_id, Some("ws-1".to_string()));
+
+        // 2 from layout tree + 1 background tab (t-3)
+        assert_eq!(layout.terminals.len(), 3);
+        assert!(layout.terminals.iter().all(|t| t.workspace_id == "ws-1"));
+
+        // t-1 has worktree path
+        let t1 = layout.terminals.iter().find(|t| t.id == "t-1").unwrap();
+        assert_eq!(t1.worktree_path, Some("C:\\worktrees\\wt-1".to_string()));
+
+        // t-3 is a background tab
+        assert!(layout.terminals.iter().any(|t| t.id == "t-3"));
     }
 
     #[test]
-    fn empty_store_returns_default_layout() {
-        let store_json = "{}";
-        let store: StoreFile = serde_json::from_str(store_json).unwrap();
-        assert!(store.entries.get(LAYOUT_KEY).is_none());
+    fn collect_terminal_ids_from_nested_tree() {
+        let tree = NativeLayoutNode::Split {
+            first: Box::new(NativeLayoutNode::Split {
+                first: Box::new(NativeLayoutNode::Leaf {
+                    terminal_id: "a".into(),
+                }),
+                second: Box::new(NativeLayoutNode::Leaf {
+                    terminal_id: "b".into(),
+                }),
+            }),
+            second: Box::new(NativeLayoutNode::Leaf {
+                terminal_id: "c".into(),
+            }),
+        };
+        let mut ids = Vec::new();
+        collect_terminal_ids(&tree, &mut ids);
+        assert_eq!(ids, vec!["a", "b", "c"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixed godly-remote's layout reader to read from the native `iced-shell-session.json` format instead of the legacy Tauri `layout.json`, which is no longer kept in sync with the actual session state.

## Changes
- Rewrote `LayoutReader` to deserialize the native session format
- Added structs for `NativeSessionState`, `NativeWorkspaceState`, and `NativeLayoutNode`
- Implemented recursive terminal ID extraction from layout trees
- Added support for background tabs via `terminal_workspace_assignments`
- Updated all tests to cover the new format and edge cases

## Root Cause
The reader was still looking at the legacy Tauri plugin-store artifact (`layout.json`), which is no longer synchronized with the native session state maintained by iced-shell. This caused godly-remote to display stale workspace/terminal data.

## Test Coverage
- `parse_native_session_format()` — verifies deserialization and conversion of the native format, including background tabs
- `collect_terminal_ids_from_nested_tree()` — confirms recursive traversal of split layout trees
- `layout_default_is_empty()` — validates default state