### PR TITLE
fix: send CSI u escape sequences for Enter with modifiers

### DIFF
--- a/changelog/unreleased/fix-shift-enter-csi-u.md
+++ b/changelog/unreleased/fix-shift-enter-csi-u.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Shift+Enter now sends CSI u escape sequence** — Enter key with modifiers (Shift, Ctrl, Alt) now sends CSI u format sequences (`\x1b[13;{mod}u`) instead of always sending `\r`. This allows tools like Claude Code that use the Kitty keyboard protocol to distinguish Shift+Enter for newline insertion.

--- a/src-tauri/native/app-adapter/src/keys.rs
+++ b/src-tauri/native/app-adapter/src/keys.rs
@@ -91,7 +91,15 @@ fn ss3_or_csi(letter: u8, modifiers: Modifiers) -> Vec<u8> {
 /// Convert a named key to PTY bytes.
 fn named_key_to_bytes(key: &Named, modifiers: Modifiers) -> Option<Vec<u8>> {
     match key {
-        Named::Enter => Some(b"\r".to_vec()),
+        Named::Enter => {
+            let m = csi_modifier(modifiers);
+            if m == 0 {
+                Some(b"\r".to_vec())
+            } else {
+                // CSI u format: \x1b[13;{mod}u  (keycode 13 = CR/Enter)
+                Some(format!("\x1b[13;{m}u").into_bytes())
+            }
+        }
         Named::Backspace => Some(vec![0x7F]), // DEL
         Named::Tab => {
             if modifiers.shift() {
@@ -259,6 +267,24 @@ mod tests {
     fn ctrl_f5() {
         let bytes = key_to_pty_bytes(&Key::Named(Named::F5), Modifiers::CTRL);
         assert_eq!(bytes, Some(b"\x1b[15;5~".to_vec()));
+    }
+
+    #[test]
+    fn shift_enter() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::Enter), Modifiers::SHIFT);
+        assert_eq!(bytes, Some(b"\x1b[13;2u".to_vec()));
+    }
+
+    #[test]
+    fn ctrl_enter() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::Enter), Modifiers::CTRL);
+        assert_eq!(bytes, Some(b"\x1b[13;5u".to_vec()));
+    }
+
+    #[test]
+    fn alt_enter() {
+        let bytes = key_to_pty_bytes(&Key::Named(Named::Enter), Modifiers::ALT);
+        assert_eq!(bytes, Some(b"\x1b[13;3u".to_vec()));
     }
 
     // --- Bug #668: Shift+letter should produce uppercase ---


### PR DESCRIPTION
## Summary
- Enter key now sends CSI u format sequences when modifiers are held
- Shift+Enter → `\x1b[13;2u`, Ctrl+Enter → `\x1b[13;5u`, Alt+Enter → `\x1b[13;3u`
- Plain Enter still sends `\r` for compatibility
- Fixes Shift+Enter handling in Claude Code and other tools using the Kitty keyboard protocol

## Changes
- Modified `named_key_to_bytes()` in `src-tauri/native/app-adapter/src/keys.rs` to check for modifiers and generate CSI u sequences
- Added three tests: `shift_enter()`, `ctrl_enter()`, `alt_enter()`
- Added changelog fragment

## Test Plan
- [ ] Run `cargo test` to verify new tests pass
- [ ] Test Shift+Enter in Claude Code to verify newline insertion works
- [ ] Test plain Enter still works without modifiers
- [ ] Test Ctrl+Enter and Alt+Enter sequences are sent correctly