### PR TITLE
fix: exclude dead terminals from list_workspaces API response

### DIFF
--- a/changelog/unreleased/exclude-dead-terminals-from-api.md
+++ b/changelog/unreleased/exclude-dead-terminals-from-api.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Godly Remote shows stale terminal sessions** — fixed bug where dead terminals (PTY sessions that died but were still in persisted layout file) were returned as `alive: false` in the list_workspaces API response. Now dead terminals are excluded entirely from the response instead of being shown as dead entries.

--- a/src-tauri/remote/src/routes/workspaces.rs
+++ b/src-tauri/remote/src/routes/workspaces.rs
@@ -86,16 +86,16 @@ pub async fn list_workspaces(
                 .terminals
                 .iter()
                 .filter(|t| t.workspace_id == ws.id)
-                .map(|t| {
-                    let session = live_sessions.get(&t.id);
-                    WorkspaceTerminal {
+                .filter_map(|t| {
+                    let session = live_sessions.get(&t.id)?;
+                    Some(WorkspaceTerminal {
                         id: t.id.clone(),
                         name: t.name.clone(),
-                        title: session.map(|s| s.title.clone()).unwrap_or_default(),
+                        title: session.title.clone(),
                         shell_type: t.shell_type.display_name(),
                         cwd: t.cwd.as_deref().map(redact_cwd),
-                        alive: session.is_some(),
-                    }
+                        alive: true,
+                    })
                 })
                 .collect();
 


### PR DESCRIPTION
## Summary

Fixed a bug in Godly Remote where stale/dead terminal sessions were shown in the workspace list with a "Session not found" error when clicked.

**Root cause:** The `list_workspaces` endpoint reads terminal IDs from the persisted `iced-shell-session.json` file, then cross-references them with the daemon's live sessions. Dead terminals (where the PTY died but the persisted file still referenced them) were returned in the API response with `alive: false`.

**Fix:** Changed the terminal mapping in `workspaces.rs` to use `filter_map` instead of `map`, so terminals not found in the daemon's live session list are excluded entirely from the response instead of being shown as dead entries.

## Changes

- Modified `src-tauri/remote/src/routes/workspaces.rs` to filter out terminals not in live sessions
- Added changelog fragment documenting the fix

## Testing

When PTY sessions die, their terminal entries are now excluded from the API response. Only live sessions are returned.