### PR TITLE
feat: add MCP tools for file pane management

### DIFF
--- a/changelog/unreleased/feat-mcp-file-pane-tools.md
+++ b/changelog/unreleased/feat-mcp-file-pane-tools.md
@@ -1,0 +1,2 @@
+### Added
+- **MCP file pane tools** — 4 new MCP tools (`open_file_pane`, `close_pane`, `list_panes`, `update_file_pane`) for opening and managing non-terminal panes (code viewer, markdown preview, image viewer) in the split-pane layout

--- a/src-tauri/mcp/src/daemon_direct.rs
+++ b/src-tauri/mcp/src/daemon_direct.rs
@@ -849,6 +849,12 @@ impl Backend for DaemonDirectBackend {
             McpRequest::UiAct { .. } => Ok(Self::app_only_error("ui_act")),
             McpRequest::UiWait { .. } => Ok(Self::app_only_error("ui_wait")),
 
+            // File pane tools — require the app frontend
+            McpRequest::OpenFilePane { .. } => Ok(Self::app_only_error("open_file_pane")),
+            McpRequest::ClosePane { .. } => Ok(Self::app_only_error("close_pane")),
+            McpRequest::ListPanes { .. } => Ok(Self::app_only_error("list_panes")),
+            McpRequest::UpdateFilePane { .. } => Ok(Self::app_only_error("update_file_pane")),
+
         }
     }
 

--- a/src-tauri/mcp/src/main.rs
+++ b/src-tauri/mcp/src/main.rs
@@ -17,7 +17,7 @@ use jsonrpc::{read_message, write_message};
 use log::mcp_log;
 
 /// Bump this on every godly-mcp code change so logs show which binary is running.
-const BUILD: u32 = 27;
+const BUILD: u32 = 28;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -410,6 +410,54 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "open_file_pane",
+                "description": "Open a file as a viewer pane (code, markdown, or image) split beside a terminal. File type is auto-detected from extension.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": { "type": "string", "description": "Absolute path to the file to open" },
+                        "target_terminal_id": { "type": "string", "description": "Terminal to split beside (optional — defaults to the agent's own terminal)" },
+                        "direction": { "type": "string", "enum": ["horizontal", "vertical"], "description": "Split direction (default: horizontal)" },
+                        "ratio": { "type": "number", "description": "Split ratio 0.0-1.0, proportion for existing pane (default: 0.5)" }
+                    },
+                    "required": ["file_path"]
+                }
+            },
+            {
+                "name": "close_pane",
+                "description": "Close a non-terminal pane (file viewer, markdown preview, or image). Use list_panes to find pane IDs.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "pane_id": { "type": "string", "description": "ID of the pane to close" }
+                    },
+                    "required": ["pane_id"]
+                }
+            },
+            {
+                "name": "list_panes",
+                "description": "List all panes in a workspace, including terminals and file viewers. Returns pane IDs, types, and metadata.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": { "type": "string", "description": "Workspace to list panes for (optional — defaults to active workspace)" }
+                    },
+                    "required": []
+                }
+            },
+            {
+                "name": "update_file_pane",
+                "description": "Update the file shown in an existing file viewer pane. Reuses the pane without changing the layout.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "pane_id": { "type": "string", "description": "ID of the file pane to update" },
+                        "file_path": { "type": "string", "description": "New file path to display" }
+                    },
+                    "required": ["pane_id", "file_path"]
+                }
+            },
+            {
                 "name": "ui_query",
                 "description": "Query a UI element using a semantic target identifier (e.g. 'workspace.active', 'tab.active', 'terminal.grid').",
                 "inputSchema": {
@@ -724,6 +772,62 @@ pub fn call_tool(
             McpRequest::UiWait { condition, timeout_ms, poll_interval_ms, args: wait_args }
         }
 
+        "open_file_pane" => {
+            let file_path = args
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing file_path")?
+                .to_string();
+            let target_terminal_id = args
+                .get("target_terminal_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .or_else(|| session_id.clone());
+            let direction = args
+                .get("direction")
+                .and_then(|v| v.as_str())
+                .unwrap_or("horizontal")
+                .to_string();
+            let ratio = args.get("ratio").and_then(|v| v.as_f64()).unwrap_or(0.5);
+            McpRequest::OpenFilePane {
+                file_path,
+                target_terminal_id,
+                direction,
+                ratio,
+            }
+        }
+
+        "close_pane" => {
+            let pane_id = args
+                .get("pane_id")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing pane_id")?
+                .to_string();
+            McpRequest::ClosePane { pane_id }
+        }
+
+        "list_panes" => {
+            let workspace_id = args
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            McpRequest::ListPanes { workspace_id }
+        }
+
+        "update_file_pane" => {
+            let pane_id = args
+                .get("pane_id")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing pane_id")?
+                .to_string();
+            let file_path = args
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .ok_or("Missing file_path")?
+                .to_string();
+            McpRequest::UpdateFilePane { pane_id, file_path }
+        }
+
         _ => return Err(format!("Unknown tool: {}", name)),
     };
 
@@ -968,6 +1072,21 @@ fn response_to_json(response: McpResponse) -> Result<Value, String> {
         }
         McpResponse::FontSize { size } => Ok(json!({
             "font_size": size,
+        })),
+
+        // File pane responses
+        McpResponse::PaneCreated { pane_id, file_type } => Ok(json!({
+            "pane_id": pane_id,
+            "file_type": file_type,
+        })),
+        McpResponse::PaneList { panes } => Ok(json!({
+            "panes": panes.iter().map(|p| json!({
+                "id": p.id,
+                "pane_type": p.pane_type,
+                "terminal_id": p.terminal_id,
+                "file_path": p.file_path,
+                "file_type": p.file_type,
+            })).collect::<Vec<_>>(),
         })),
 
         // Test harness responses

--- a/src-tauri/protocol/src/layout_tree.rs
+++ b/src-tauri/protocol/src/layout_tree.rs
@@ -9,6 +9,16 @@ pub enum SplitDirection {
     Vertical,
 }
 
+/// Metadata for a single pane in a workspace, returned by the `list_panes` MCP tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneInfo {
+    pub id: String,
+    pub pane_type: String,
+    pub terminal_id: Option<String>,
+    pub file_path: Option<String>,
+    pub file_type: Option<String>,
+}
+
 /// A recursive binary tree representing the pane layout of a workspace.
 ///
 /// Each leaf holds a terminal ID; each internal node splits space between

--- a/src-tauri/protocol/src/lib.rs
+++ b/src-tauri/protocol/src/lib.rs
@@ -23,7 +23,7 @@ pub use frame::{
     read_shim_frame, write_shim_binary, write_shim_json, ShimFrame, TAG_SHIM_BUFFER_DATA,
     TAG_SHIM_OUTPUT, TAG_SHIM_WRITE,
 };
-pub use layout_tree::{LayoutNode, SplitDirection};
+pub use layout_tree::{LayoutNode, PaneInfo, SplitDirection};
 pub use mcp_messages::{McpRequest, McpResponse, McpTerminalInfo, McpWorkspaceInfo};
 pub use messages::{DaemonMessage, Event, Request, RequestEnvelope, Response};
 pub use messages::{ShimRequest, ShimResponse};

--- a/src-tauri/protocol/src/mcp_messages.rs
+++ b/src-tauri/protocol/src/mcp_messages.rs
@@ -426,6 +426,28 @@ pub enum McpRequest {
         timeout_ms: Option<u64>,
     },
 
+    // File pane tools
+    OpenFilePane {
+        file_path: String,
+        #[serde(default)]
+        target_terminal_id: Option<String>,
+        #[serde(default = "default_split_direction")]
+        direction: String,
+        #[serde(default = "default_split_ratio")]
+        ratio: f64,
+    },
+    ClosePane {
+        pane_id: String,
+    },
+    ListPanes {
+        #[serde(default)]
+        workspace_id: Option<String>,
+    },
+    UpdateFilePane {
+        pane_id: String,
+        file_path: String,
+    },
+
     // Semantic testing API
     UiQuery {
         target: String,
@@ -608,6 +630,15 @@ pub enum McpResponse {
     },
     FontSize {
         size: u32,
+    },
+
+    // File pane responses
+    PaneCreated {
+        pane_id: String,
+        file_type: String,
+    },
+    PaneList {
+        panes: Vec<crate::layout_tree::PaneInfo>,
     },
 
     // Test harness responses


### PR DESCRIPTION
## Summary
- Add 4 new MCP tools (`open_file_pane`, `close_pane`, `list_panes`, `update_file_pane`) for managing non-terminal panes (code viewer, markdown preview, image viewer) in the split-pane layout
- Add `PaneInfo` struct to `layout_tree.rs` and `PaneCreated`/`PaneList` response variants to `mcp_messages.rs`
- Add `OpenFilePane`, `ClosePane`, `ListPanes`, `UpdateFilePane` request variants with serde defaults matching existing conventions
- Wire up tool schemas in `list_tools()`, dispatch in `call_tool()`, response handling in `response_to_json()`, and daemon-direct fallbacks
- Bump MCP BUILD constant to 28

## Test plan
- [x] `cargo check --package godly-mcp` passes
- [x] `cargo check --package godly-protocol` passes
- [ ] E2E testing deferred (no frontend handler yet)