### PR TITLE
fix: scan .claude/commands/ directories in Quick Claude skill discovery

### DIFF
--- a/changelog/unreleased/fix-quick-claude-command-discovery.md
+++ b/changelog/unreleased/fix-quick-claude-command-discovery.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Quick Claude skill discovery** — now scans `~/.claude/commands/` and `.claude/commands/` directories in addition to `skills/` directories, enabling user-level commands like `/create-reproducible-issue` to appear in Quick Claude's autocomplete

--- a/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
@@ -1100,6 +1100,12 @@ pub fn discover_skills(workspace_folder: Option<&str>) -> Vec<SkillEntry> {
         if project_skills_dir.exists() {
             collect_skills_from_dir(&project_skills_dir, SkillScope::Project, &mut skills);
         }
+
+        // Also scan .claude/commands/ — Claude Code's project-level commands directory.
+        let project_commands_dir = std::path::Path::new(folder).join(".claude").join("commands");
+        if project_commands_dir.exists() {
+            collect_skills_from_dir(&project_commands_dir, SkillScope::Project, &mut skills);
+        }
     }
 
     if let Some(home) = std::env::var("USERPROFILE")
@@ -1109,6 +1115,12 @@ pub fn discover_skills(workspace_folder: Option<&str>) -> Vec<SkillEntry> {
         let user_skills_dir = std::path::Path::new(&home).join(".claude").join("skills");
         if user_skills_dir.exists() {
             collect_skills_from_dir(&user_skills_dir, SkillScope::User, &mut skills);
+        }
+
+        // Also scan ~/.claude/commands/ — Claude Code's user-level commands directory.
+        let user_commands_dir = std::path::Path::new(&home).join(".claude").join("commands");
+        if user_commands_dir.exists() {
+            collect_skills_from_dir(&user_commands_dir, SkillScope::User, &mut skills);
         }
 
         // Discover skills from installed Claude Code plugins.


### PR DESCRIPTION
## Summary

Quick Claude's skill discovery now scans the `~/.claude/commands/` and `.claude/commands/` directories in addition to `skills/` directories. This fixes an issue where user-level commands (stored in `~/.claude/commands/`) like `/create-reproducible-issue` never appeared in Quick Claude's autocomplete.

## Changes

- Modified `discover_skills` function in `quick_claude_dialog.rs` to add scanning of project-level `.claude/commands/` directory
- Added scanning of user-level `~/.claude/commands/` directory
- Both directories are now discoverable alongside existing `skills/` directories

## Testing

The fix enables user-level commands to be discovered and made available in Quick Claude's autocomplete. Previously, these commands would only be available when typed manually.