### PR TITLE
chore: clean up compiler warnings

### DIFF
--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -1,6 +1,4 @@
 use std::collections::{HashMap, HashSet};
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude_dialog.rs
@@ -46,6 +46,8 @@ pub struct SkillEntry {
     pub name: String,
     pub description: String,
     pub scope: SkillScope,
+    /// Path to the skill's .md file on disk; stored for future use (e.g., opening in editor).
+    #[allow(dead_code)]
     pub file_path: String,
 }
 

--- a/src-tauri/native/iced-shell/src/quick_claude_sessions.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude_sessions.rs
@@ -71,14 +71,6 @@ pub fn add_session(record: QuickClaudeSessionRecord) -> Result<(), String> {
     save_sessions(&sessions)
 }
 
-pub fn update_session_status(session_id: &str, status: SessionStatus) -> Result<(), String> {
-    let mut sessions = load_sessions();
-    if let Some(session) = sessions.iter_mut().find(|s| s.id == session_id) {
-        session.status = status;
-    }
-    save_sessions(&sessions)
-}
-
 /// Remove sessions whose terminal_id is not in the set of live terminal IDs.
 pub fn cleanup_stale_sessions(live_terminal_ids: &[String]) -> Result<Vec<QuickClaudeSessionRecord>, String> {
     let mut sessions = load_sessions();

--- a/src-tauri/native/iced-shell/src/subscription.rs
+++ b/src-tauri/native/iced-shell/src/subscription.rs
@@ -215,8 +215,8 @@ mod tests {
 
         sink.on_terminal_output("sess1");
 
-        match rx.try_next() {
-            Ok(Some(DaemonEventMsg::TerminalOutput { session_id })) => {
+        match rx.try_recv() {
+            Ok(DaemonEventMsg::TerminalOutput { session_id }) => {
                 assert_eq!(session_id, "sess1");
             }
             other => panic!("Expected TerminalOutput, got: {:?}", other),
@@ -230,11 +230,11 @@ mod tests {
 
         sink.on_session_closed("sess2", Some(0));
 
-        match rx.try_next() {
-            Ok(Some(DaemonEventMsg::SessionClosed {
+        match rx.try_recv() {
+            Ok(DaemonEventMsg::SessionClosed {
                 session_id,
                 exit_code,
-            })) => {
+            }) => {
                 assert_eq!(session_id, "sess2");
                 assert_eq!(exit_code, Some(0));
             }
@@ -249,11 +249,11 @@ mod tests {
 
         sink.on_process_changed("sess3", "vim");
 
-        match rx.try_next() {
-            Ok(Some(DaemonEventMsg::ProcessChanged {
+        match rx.try_recv() {
+            Ok(DaemonEventMsg::ProcessChanged {
                 session_id,
                 process_name,
-            })) => {
+            }) => {
                 assert_eq!(session_id, "sess3");
                 assert_eq!(process_name, "vim");
             }
@@ -268,8 +268,8 @@ mod tests {
 
         sink.on_bell("sess4");
 
-        match rx.try_next() {
-            Ok(Some(DaemonEventMsg::Bell { session_id })) => {
+        match rx.try_recv() {
+            Ok(DaemonEventMsg::Bell { session_id }) => {
                 assert_eq!(session_id, "sess4");
             }
             other => panic!("Expected Bell, got: {:?}", other),
@@ -283,8 +283,8 @@ mod tests {
 
         sink.on_grid_diff("sess5", &[1, 2, 3]);
 
-        match rx.try_next() {
-            Ok(Some(DaemonEventMsg::TerminalOutput { session_id })) => {
+        match rx.try_recv() {
+            Ok(DaemonEventMsg::TerminalOutput { session_id }) => {
                 assert_eq!(session_id, "sess5");
             }
             other => panic!("Expected TerminalOutput from grid_diff, got: {:?}", other),

--- a/src-tauri/remote/src/detection.rs
+++ b/src-tauri/remote/src/detection.rs
@@ -76,26 +76,6 @@ impl PromptDetector {
         None
     }
 
-    /// Check text and return all matches (not just the first).
-    pub fn detect_all(&self, text: &str) -> Vec<DetectedPrompt> {
-        let mut results = Vec::new();
-        for (regex, source, type_label) in &self.patterns {
-            if regex.is_match(text) {
-                let menu_options = if type_label == "select_menu" {
-                    Some(parse_select_menu(text))
-                } else {
-                    None
-                };
-                results.push(DetectedPrompt {
-                    matched_pattern: source.clone(),
-                    prompt_type: type_label.clone(),
-                    context_text: text.to_string(),
-                    menu_options,
-                });
-            }
-        }
-        results
-    }
 }
 
 /// Parse a Claude Code select menu from terminal output.
@@ -203,14 +183,6 @@ mod tests {
     fn no_match_on_empty() {
         let detector = PromptDetector::new();
         assert!(detector.detect("").is_none());
-    }
-
-    #[test]
-    fn detect_all_returns_multiple() {
-        let detector = PromptDetector::new();
-        // Text that matches both yes_no and tool_approval
-        let result = detector.detect_all("Do you want to allow this? (Y)es (N)o");
-        assert!(result.len() >= 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Remove unused import** `std::os::windows::process::CommandExt` from `app.rs` (line 3) — a second, scoped import at line 1748 is the one actually used.
- **Suppress `dead_code` on `SkillEntry::file_path`** with `#[allow(dead_code)]` — the field is populated during skill discovery and stored for future use (e.g., opening in editor) but not yet read.
- **Remove unused function `update_session_status`** from `quick_claude_sessions.rs` — never called anywhere in the codebase.
- **Replace deprecated `try_next()` with `try_recv()`** on `UnboundedReceiver` in 5 test functions in `subscription.rs`, adjusting match arms from `Ok(Some(..))` to `Ok(..)`.
- **Remove unused method `detect_all`** from `PromptDetector` in `detection.rs` and its companion test — only used by the test itself; external code uses `detect()`.

## Test plan

- [x] `cargo check -p godly-iced-shell -p godly-remote` passes with no errors
- [x] All five targeted warnings eliminated; verified with grep against compiler output
- [x] Remaining warnings are pre-existing and out of scope