### PR TITLE
fix: sidebar badge shows correct terminal count via workspace signal

### DIFF
--- a/changelog/unreleased/763-sidebar-badge-terminal-count.md
+++ b/changelog/unreleased/763-sidebar-badge-terminal-count.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Sidebar workspace badge shows wrong terminal count** — sidebar badge now displays the actual terminal count from the tab state instead of the layout pane count, which was always 1 after creating tabs (#763)

--- a/src-tauri/native/features-shell/tests/reducer_flows.rs
+++ b/src-tauri/native/features-shell/tests/reducer_flows.rs
@@ -352,3 +352,87 @@ fn close_tab_then_delete_workspace_flow_retargets_focus_and_read_marking() {
     assert_eq!(post_delete.mark_terminal_read_id.as_deref(), Some("t-3"));
     assert_eq!(post_delete.fetch_grid_terminal_id.as_deref(), Some("t-3"));
 }
+
+/// Bug #763: After creating multiple tabs, the tab state tracks all terminals
+/// even though the workspace layout only contains the currently visible pane.
+///
+/// The sidebar badge must use the tab-state terminal count (provided via the
+/// `workspace_terminal_count` signal), not `layout.leaf_count()`. This test
+/// verifies the data that feeds the signal is correct: all three terminals are
+/// tracked in the tab state while the layout only holds the last-created tab.
+#[test]
+fn sidebar_badge_data_tracks_all_tabs_not_just_layout_leaves() {
+    let mut tabs = TabState::new();
+    assert!(tabs.open("t-1"));
+    assert!(tabs.activate("t-1"));
+
+    let mut workspaces = WorkspaceCollection::new();
+    workspaces.add(workspace("w-1", "t-1", leaf("t-1")));
+
+    // Verify initial state: 1 terminal, leaf_count = 1.
+    let ws = workspaces.active().expect("active workspace");
+    assert_eq!(ws.layout.leaf_count(), 1);
+    assert_eq!(tabs.len(), 1);
+
+    // Create a second tab (not a split) via the new-tab flow.
+    let decision_2 = tab_reducer::reduce_terminal_created(tab_reducer::TerminalCreatedInput {
+        session_id: "t-2".into(),
+        active_workspace_id: workspaces.active_id().map(str::to_string),
+        terminal_in_active_layout: false,
+    });
+    apply_terminal_created(&mut tabs, &mut workspaces, decision_2);
+
+    // Create a third tab.
+    let decision_3 = tab_reducer::reduce_terminal_created(tab_reducer::TerminalCreatedInput {
+        session_id: "t-3".into(),
+        active_workspace_id: workspaces.active_id().map(str::to_string),
+        terminal_in_active_layout: false,
+    });
+    apply_terminal_created(&mut tabs, &mut workspaces, decision_3);
+
+    // The layout only contains the last-created tab (by design).
+    let ws = workspaces.active().expect("active workspace");
+    assert_eq!(
+        ws.layout.leaf_count(),
+        1,
+        "layout should only contain the currently visible pane"
+    );
+
+    // But the tab state has all 3 terminals — this is the data the sidebar
+    // badge should use (via the workspace_terminal_count signal).
+    assert_eq!(tabs.len(), 3, "tab state must track all workspace terminals");
+    assert!(tabs.contains("t-1"));
+    assert!(tabs.contains("t-2"));
+    assert!(tabs.contains("t-3"));
+}
+
+/// Bug #763: Verify the terminal count signal data is correct across
+/// multiple workspaces, each with different tab counts.
+#[test]
+fn sidebar_badge_data_correct_across_multiple_workspaces() {
+    let mut tabs = TabState::new();
+    assert!(tabs.open("t-1"));
+    assert!(tabs.open("t-x"));
+    assert!(tabs.activate("t-1"));
+
+    let mut workspaces = WorkspaceCollection::new();
+    workspaces.add(workspace("w-1", "t-1", leaf("t-1")));
+    workspaces.add(workspace("w-2", "t-x", leaf("t-x")));
+
+    // Add a second tab to w-1 (the active workspace).
+    let decision = tab_reducer::reduce_terminal_created(tab_reducer::TerminalCreatedInput {
+        session_id: "t-2".into(),
+        active_workspace_id: Some("w-1".into()),
+        terminal_in_active_layout: false,
+    });
+    apply_terminal_created(&mut tabs, &mut workspaces, decision);
+
+    // The layout reset to single leaf (by design), but we have 3 total tabs.
+    let ws1 = workspaces.get("w-1").expect("workspace w-1");
+    assert_eq!(ws1.layout.leaf_count(), 1, "layout resets on new tab");
+    assert_eq!(tabs.len(), 3, "tab state has t-1, t-2, t-x");
+
+    // w-2 layout still has its single leaf.
+    let ws2 = workspaces.get("w-2").expect("workspace w-2");
+    assert_eq!(ws2.layout.leaf_count(), 1);
+}

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -4193,6 +4193,9 @@ impl GodlyApp {
                             _ => None,
                         }
                     },
+                    |workspace_id: &str| -> usize {
+                        self.terminals.terminals_for_workspace(workspace_id).len()
+                    },
                 ),
                 sidebar_width,
                 self.terminal_font,

--- a/src-tauri/native/iced-shell/src/sidebar.rs
+++ b/src-tauri/native/iced-shell/src/sidebar.rs
@@ -177,6 +177,16 @@ pub trait SidebarWorkspaceSignals {
     fn workspace_ai_mode_icon(&self, _workspace_id: &str) -> Option<&'static str> {
         None
     }
+
+    /// Returns the total number of terminals in the workspace.
+    ///
+    /// Defaults to `None`, which makes the sidebar fall back to `layout.leaf_count()`.
+    /// Callers should provide an implementation that returns the actual terminal count
+    /// from the terminal collection so the badge is accurate even when the layout tree
+    /// only contains the currently visible pane(s).
+    fn workspace_terminal_count(&self, _workspace_id: &str) -> Option<usize> {
+        None
+    }
 }
 
 impl<'a> SidebarWorkspaceSignals for Option<&'a str> {
@@ -216,6 +226,29 @@ where
     }
 }
 
+impl<'a, F, G, H> SidebarWorkspaceSignals for (Option<&'a str>, F, G, H)
+where
+    F: for<'b> Fn(&'b str) -> bool,
+    G: for<'b> Fn(&'b str) -> Option<&'static str>,
+    H: for<'b> Fn(&'b str) -> usize,
+{
+    fn context_menu_workspace_id(&self) -> Option<&str> {
+        self.0
+    }
+
+    fn has_workspace_notification(&self, workspace_id: &str) -> bool {
+        (self.1)(workspace_id)
+    }
+
+    fn workspace_ai_mode_icon(&self, workspace_id: &str) -> Option<&'static str> {
+        (self.2)(workspace_id)
+    }
+
+    fn workspace_terminal_count(&self, workspace_id: &str) -> Option<usize> {
+        Some((self.3)(workspace_id))
+    }
+}
+
 /// Renders the workspace sidebar as a vertical list.
 ///
 /// - fixed header ("WORKSPACES") with compact controls
@@ -246,7 +279,9 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
 
         let name_label = text(&ws.name).size(13).color(row_text).font(font);
 
-        let terminal_count = ws.layout.leaf_count();
+        let terminal_count = workspace_signals
+            .workspace_terminal_count(ws.id.as_str())
+            .unwrap_or_else(|| ws.layout.leaf_count());
         let badge_bg = GHOST_SELECTED();
         let badge_text = TEXT_SECONDARY();
 


### PR DESCRIPTION
## Summary

Fixes the sidebar workspace badge that was always displaying 1 terminal, even when multiple tabs were open.

### Root Cause
The badge used , which only counts the currently visible pane. When new tabs are created (not splits), the layout tree is reset to a single leaf, causing incorrect badge counts.

### Fix
- Added  signal to the  trait
- Updated badge rendering to use this signal instead of 
- The app passes a closure that retrieves the actual terminal count from the active terminal collection
- Added regression tests to verify the data model tracks all terminals correctly

### Changes
- **sidebar.rs**: Added trait method and 4-tuple impl for the terminal count signal
- **app.rs**: Pass terminal count closure to the sidebar view
- **reducer_flows.rs**: Added 2 regression tests verifying tab state vs layout pane count

fixes #763