### PR TITLE
fix: boost active workspace contrast in sidebar

### DIFF
--- a/changelog/unreleased/fix-sidebar-active-workspace-contrast.md
+++ b/changelog/unreleased/fix-sidebar-active-workspace-contrast.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Sidebar active workspace contrast** — Active workspace row now has stronger background contrast for better visibility across all themes (ghost_selected alpha 0.50 → 0.70)

--- a/src-tauri/native/iced-shell/src/theme.rs
+++ b/src-tauri/native/iced-shell/src/theme.rs
@@ -531,7 +531,7 @@ fn fill_derived_fields(p: &mut ThemePalette) {
         p.bg_active.r, p.bg_active.g, p.bg_active.b, 0.70,
     );
     p.ghost_selected = Color::from_rgba(
-        p.bg_tertiary.r, p.bg_tertiary.g, p.bg_tertiary.b, 0.50,
+        p.bg_tertiary.r, p.bg_tertiary.g, p.bg_tertiary.b, 0.70,
     );
     p.element_bg = p.bg_tertiary;
     p.element_hover = p.bg_active;
@@ -569,7 +569,7 @@ fn zed_one_dark() -> ThemePalette {
         text_placeholder: Color::from_rgb8(0x87, 0x8a, 0x98),
         ghost_hover: Color::from_rgb8(0x36, 0x3c, 0x46),
         ghost_active: Color::from_rgb8(0x45, 0x4a, 0x56),
-        ghost_selected: Color::from_rgb8(0x36, 0x3c, 0x46),
+        ghost_selected: Color::from_rgb8(0x3c, 0x42, 0x4e),
         element_bg: Color::from_rgb8(0x36, 0x3c, 0x46),
         element_hover: Color::from_rgb8(0x45, 0x4a, 0x56),
         element_active: Color::from_rgba8(0x74, 0xad, 0xe8, 0.20),


### PR DESCRIPTION
## Summary
- Increase `ghost_selected` alpha from 0.50 to 0.70 in `fill_derived_fields()` so the active workspace row stands out across all themes
- Bump Zed One Dark explicit `ghost_selected` from `#363c46` to `#3c424e` (~10% brighter) for clear distinction against `#2F343E` surface_bg

## Changes
- `src-tauri/native/iced-shell/src/theme.rs`: two constant value changes (alpha and hex color)
- `changelog/unreleased/fix-sidebar-active-workspace-contrast.md`: changelog fragment

## Test plan
- [x] `cargo check -p godly-iced-shell` compiles cleanly
- [ ] Visual verification: active workspace row in sidebar is clearly distinguishable from inactive rows and sidebar background