### PR TITLE
feat: add workspace folder icons and increase header icon size

### DIFF
--- a/changelog/unreleased/feat-workspace-row-icons.md
+++ b/changelog/unreleased/feat-workspace-row-icons.md
@@ -1,0 +1,5 @@
+### Added
+- **Workspace folder icons** — Each workspace row now displays a folder icon, colored with the accent color when active, for improved visual hierarchy
+
+### Changed
+- **Sidebar icon size** — Header icon size increased from 12px to 16px for better visibility

--- a/src-tauri/native/iced-shell/src/sidebar.rs
+++ b/src-tauri/native/iced-shell/src/sidebar.rs
@@ -18,6 +18,8 @@ pub const SIDEBAR_MAX_WIDTH: f32 = 420.0;
 /// Resize handle width in logical pixels.
 pub const SIDEBAR_RESIZE_HANDLE_WIDTH: f32 = 6.0;
 
+const HEADER_ICON_SIZE: f32 = 16.0;
+
 /// Codicon font for pixel-hinted icons.
 const CODICON_FONT: Font = Font {
     family: iced::font::Family::Name("codicon"),


### PR DESCRIPTION
## Summary
- Add a codicon folder icon to each workspace row in the sidebar, colored with the accent color when active, for improved visual hierarchy
- Increase sidebar header icon size from 12px to 16px for better visibility
- Register the codicon font (codicon.ttf) in the iced application builder

## Test plan
- [x] `cargo check -p godly-iced-shell --lib` compiles cleanly
- [x] All 9 sidebar unit tests pass (`cargo test -p godly-iced-shell -- sidebar`)
- [x] No new clippy warnings in sidebar.rs
- [ ] Visual verification: folder icon appears in each workspace row
- [ ] Active workspace shows accent-colored folder icon; inactive shows secondary text color