### PR TITLE
feat: sidebar typography hierarchy (sizes + weights)

### DIFF
--- a/changelog/unreleased/feat-sidebar-typography-hierarchy.md
+++ b/changelog/unreleased/feat-sidebar-typography-hierarchy.md
@@ -1,0 +1,2 @@
+### Changed
+- **Sidebar typography** — Improved typographic hierarchy: header uses semibold at 11pt, active workspace names use semibold weight, footer labels bumped to 11pt, all sidebar text uses proportional sans-serif

--- a/src-tauri/native/iced-shell/src/sidebar.rs
+++ b/src-tauri/native/iced-shell/src/sidebar.rs
@@ -21,6 +21,22 @@ pub const SIDEBAR_MAX_WIDTH: f32 = 420.0;
 pub const SIDEBAR_RESIZE_HANDLE_WIDTH: f32 = 6.0;
 const HEADER_ICON_SIZE: f32 = 12.0;
 
+/// Proportional sans-serif for sidebar labels and workspace names.
+const SIDEBAR_FONT: Font = Font {
+    family: iced::font::Family::SansSerif,
+    weight: iced::font::Weight::Normal,
+    stretch: iced::font::Stretch::Normal,
+    style: iced::font::Style::Normal,
+};
+
+/// Semibold variant for active workspace name and section headers.
+const SIDEBAR_FONT_SEMIBOLD: Font = Font {
+    family: iced::font::Family::SansSerif,
+    weight: iced::font::Weight::Semibold,
+    stretch: iced::font::Stretch::Normal,
+    style: iced::font::Style::Normal,
+};
+
 /// Clamp a sidebar width into the supported resize range.
 pub fn clamp_sidebar_width(width: f32) -> f32 {
     width.clamp(SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH)
@@ -259,7 +275,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
     active_id: Option<&str>,
     workspace_signals: S,
     sidebar_width: f32,
-    font: Font,
+    _font: Font,
     on_action: impl Fn(SidebarAction) -> M + 'a,
     on_resize_start: M,
     on_resize_end: M,
@@ -277,7 +293,8 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
 
         let row_text = TEXT_PRIMARY();
 
-        let name_label = text(&ws.name).size(13).color(row_text).font(font);
+        let name_font = if is_active { SIDEBAR_FONT_SEMIBOLD } else { SIDEBAR_FONT };
+        let name_label = text(&ws.name).size(12).color(row_text).font(name_font);
 
         let terminal_count = workspace_signals
             .workspace_terminal_count(ws.id.as_str())
@@ -419,7 +436,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             let move_down_id = ws.id.clone();
             let delete_id = ws.id.clone();
 
-            let rename_btn = button(text("Rename").size(12).color(TEXT_PRIMARY()))
+            let rename_btn = button(text("Rename").size(12).color(TEXT_PRIMARY()).font(SIDEBAR_FONT))
                 .on_press(on_action(SidebarAction::RenameWorkspace(rename_id)))
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
@@ -436,7 +453,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
                     }
                 });
 
-            let open_btn = button(text("Open in Explorer").size(12).color(TEXT_PRIMARY()))
+            let open_btn = button(text("Open in Explorer").size(12).color(TEXT_PRIMARY()).font(SIDEBAR_FONT))
                 .on_press(on_action(SidebarAction::OpenWorkspaceInExplorer(open_id)))
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
@@ -458,7 +475,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             } else {
                 "Enable Worktree Mode"
             };
-            let worktree_btn = button(text(worktree_label).size(12).color(TEXT_PRIMARY()))
+            let worktree_btn = button(text(worktree_label).size(12).color(TEXT_PRIMARY()).font(SIDEBAR_FONT))
                 .on_press(on_action(SidebarAction::ToggleWorkspaceWorktreeMode(
                     worktree_id,
                 )))
@@ -478,7 +495,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
                 });
 
             let move_up_btn = if idx > 0 {
-                button(text("Move Up").size(12).color(TEXT_PRIMARY()))
+                button(text("Move Up").size(12).color(TEXT_PRIMARY()).font(SIDEBAR_FONT))
                     .on_press(on_action(SidebarAction::MoveWorkspaceUp(move_up_id)))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
@@ -495,14 +512,14 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
                         }
                     })
             } else {
-                button(text("Move Up").size(12).color(TEXT_SECONDARY()))
+                button(text("Move Up").size(12).color(TEXT_SECONDARY()).font(SIDEBAR_FONT))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
                     .style(|_theme, _status| button::Style::default())
             };
 
             let move_down_btn = if idx + 1 < workspaces.len() {
-                button(text("Move Down").size(12).color(TEXT_PRIMARY()))
+                button(text("Move Down").size(12).color(TEXT_PRIMARY()).font(SIDEBAR_FONT))
                     .on_press(on_action(SidebarAction::MoveWorkspaceDown(move_down_id)))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
@@ -519,13 +536,13 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
                         }
                     })
             } else {
-                button(text("Move Down").size(12).color(TEXT_SECONDARY()))
+                button(text("Move Down").size(12).color(TEXT_SECONDARY()).font(SIDEBAR_FONT))
                     .padding(Padding::from([5, 8]))
                     .width(Length::Fill)
                     .style(|_theme, _status| button::Style::default())
             };
 
-            let delete_btn = button(text("Delete").size(12).color(DANGER()))
+            let delete_btn = button(text("Delete").size(12).color(DANGER()).font(SIDEBAR_FONT))
                 .on_press(on_action(SidebarAction::DeleteWorkspace(delete_id)))
                 .padding(Padding::from([5, 8]))
                 .width(Length::Fill)
@@ -587,7 +604,7 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
 
     let header = container(
         row![
-            text("Workspaces").size(10).color(TEXT_SECONDARY()),
+            text("Workspaces").size(11).color(TEXT_SECONDARY()).font(SIDEBAR_FONT_SEMIBOLD),
             Space::new().width(Length::Fill),
             settings_btn,
             new_btn,
@@ -619,8 +636,9 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
         let prefixed = label.to_string();
         button(
             text(prefixed)
-                .size(10)
-                .color(TEXT_SECONDARY()),
+                .size(11)
+                .color(TEXT_SECONDARY())
+                .font(SIDEBAR_FONT),
         )
         .on_press(on_action(action))
         .padding(Padding::from([4, 8]))


### PR DESCRIPTION
## Summary
- Added `SIDEBAR_FONT` (sans-serif normal) and `SIDEBAR_FONT_SEMIBOLD` (sans-serif semibold) constants for consistent sidebar typography
- Active workspace names now render in semibold weight for visual distinction from inactive workspaces
- Header "Workspaces" label upgraded to 11pt semibold (was 10pt normal)
- Footer CLAUDE.md button labels bumped from 10pt to 11pt with explicit `SIDEBAR_FONT`
- All context menu text items (Rename, Open in Explorer, Move Up/Down, Delete, etc.) now explicitly use `SIDEBAR_FONT` for consistency
- Workspace name size adjusted from 13pt to 12pt per design spec

## Test plan
- [x] `cargo check -p godly-iced-shell` compiles cleanly (no warnings in sidebar.rs)
- [x] Pre-existing test failures in `session_persistence` are unrelated (duplicate field bug on master)
- [x] Pre-existing clippy issues in `godly-protocol` are unrelated
- [ ] Visual verification: active workspace name appears bolder than inactive ones
- [ ] Visual verification: header "Workspaces" text is slightly larger and bolder
- [ ] Visual verification: footer buttons have readable 11pt text