### PR TITLE
fix: switch sidebar font from monospace to proportional sans-serif

### DIFF
--- a/changelog/unreleased/fix-sidebar-font-sans-serif.md
+++ b/changelog/unreleased/fix-sidebar-font-sans-serif.md
@@ -1,0 +1,2 @@
+### Changed
+- **Sidebar font** — Workspace names now render in the system proportional sans-serif font instead of the terminal's monospace font for improved readability

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -64,7 +64,7 @@ use iced::{event, window, Color, Element, Font, Length, Padding, Point, Shadow, 
 
 /// Proportional UI font for chrome elements (title bar, tab bar, status bar).
 /// Uses the system's default sans-serif (Segoe UI on Windows, SF Pro on macOS).
-const UI_FONT: Font = Font {
+pub(crate) const UI_FONT: Font = Font {
     family: iced::font::Family::SansSerif,
     weight: iced::font::Weight::Normal,
     stretch: iced::font::Stretch::Normal,
@@ -72,7 +72,7 @@ const UI_FONT: Font = Font {
 };
 
 /// Bold variant of the proportional UI font for headings and emphasis.
-const UI_FONT_BOLD: Font = Font {
+pub(crate) const UI_FONT_BOLD: Font = Font {
     family: iced::font::Family::SansSerif,
     weight: iced::font::Weight::Bold,
     stretch: iced::font::Stretch::Normal,
@@ -4196,7 +4196,7 @@ impl GodlyApp {
                     },
                 ),
                 sidebar_width,
-                self.terminal_font,
+                UI_FONT,
                 Message::SidebarAction,
                 Message::SidebarResizeStart,
                 Message::SidebarResizeEnd,


### PR DESCRIPTION
## Summary
- Pass `UI_FONT` (system sans-serif) to the sidebar instead of `self.terminal_font` (monospace)
- Makes `UI_FONT` and `UI_FONT_BOLD` `pub(crate)` for reuse by other modules
- Workspace names now render in Segoe UI (Windows) / SF Pro (macOS) for improved readability

Part of the sidebar design overhaul to match Zed editor quality.

## Test plan
- [ ] `cargo check -p godly-iced-shell` compiles cleanly
- [ ] Sidebar workspace names render in proportional sans-serif (visual)