### PR TITLE
fix: prevent workspace name text wrapping in sidebar

### DIFF
--- a/changelog/unreleased/fix-workspace-name-text-wrapping.md
+++ b/changelog/unreleased/fix-workspace-name-text-wrapping.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Workspace name text wrapping in sidebar** — long workspace names (e.g. "internal-debugging-tools") no longer wrap to multiple lines; text is now truncated at the sidebar boundary instead

--- a/src-tauri/native/iced-shell/src/sidebar.rs
+++ b/src-tauri/native/iced-shell/src/sidebar.rs
@@ -207,7 +207,12 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
         let row_text = TEXT_PRIMARY();
 
         let name_font = if is_active { SIDEBAR_FONT_SEMIBOLD } else { SIDEBAR_FONT };
-        let name_label = text(&ws.name).size(12).color(row_text).font(name_font);
+        let name_label = text(&ws.name)
+            .size(12)
+            .color(row_text)
+            .font(name_font)
+            .wrapping(text::Wrapping::None);
+        let name_clipped = container(name_label).width(Length::Fill).clip(true);
 
         let terminal_count = workspace_signals
             .workspace_terminal_count(ws.id.as_str())
@@ -295,12 +300,11 @@ pub fn view_sidebar<'a, M: Clone + 'a, S: SidebarWorkspaceSignals>(
             accent_bar,
             worktree_indicator,
             workspace_icon,
-            name_label,
+            name_clipped,
         ];
         if let Some(icon) = ai_mode_icon {
             item_content = item_content.push(text(icon).size(11));
         }
-        item_content = item_content.push(Space::new().width(Length::Fill));
         if has_workspace_notification {
             item_content = item_content.push(notification_indicator);
         }


### PR DESCRIPTION
## Summary
- Long workspace names (e.g. "internal-debugging-tools") no longer wrap to multiple lines in the sidebar
- Text is now truncated at the sidebar boundary instead of wrapping

## Changes
- Add `text::Wrapping::None` to prevent text wrapping on the workspace name
- Wrap name in a clipping container with `Length::Fill` to properly truncate long text
- Remove the `Space::new().width(Length::Fill)` spacer since the name container now fills the remaining space

## Testing
- Visual verification that long workspace names are truncated rather than wrapped