### PR TITLE
fix: preserve shim processes on daemon exit for crash recovery

### DIFF
--- a/changelog/unreleased/794-fix-crash-session-recovery.md
+++ b/changelog/unreleased/794-fix-crash-session-recovery.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Terminal sessions lost after crash** — daemon no longer kills shim processes on exit, allowing the next daemon instance to recover surviving sessions via `reconnect_surviving_shims()` (#794)

--- a/src-tauri/daemon/src/server.rs
+++ b/src-tauri/daemon/src/server.rs
@@ -195,28 +195,22 @@ impl DaemonServer {
         eprintln!("[daemon] Server shutting down");
         daemon_log!("Server shutting down");
 
-        // Close all sessions before exiting — sends Shutdown to each shim
-        // so they don't become orphan processes.
-        self.shutdown_all_sessions();
+        // Do NOT call shutdown_all_sessions() here. When the daemon exits,
+        // shim processes must survive so the next daemon instance can recover
+        // them via reconnect_surviving_shims(). Shims have a 90-second orphan
+        // timeout and will self-terminate if no daemon reconnects.
+        let session_count = self.sessions.read().len();
+        if session_count > 0 {
+            daemon_log!(
+                "Leaving {} session(s) alive for recovery (shims will self-terminate after 90s if not recovered)",
+                session_count
+            );
+        }
     }
 
-    /// Close all active sessions, sending Shutdown to each shim process.
-    /// Called during daemon shutdown to prevent orphaned pty-shim processes.
-    fn shutdown_all_sessions(&self) {
-        let sessions = self.sessions.read();
-        let count = sessions.len();
-        if count == 0 {
-            return;
-        }
-        daemon_log!("Shutting down {} session(s)", count);
-        for (id, session) in sessions.iter() {
-            daemon_log!("Closing session {} on shutdown", id);
-            session.close();
-        }
-        drop(sessions);
-        self.sessions.write().clear();
-        daemon_log!("All sessions closed");
-    }
+    // NOTE: shutdown_all_sessions was removed. The daemon must NOT kill shims
+    // on exit — they need to survive for recovery by the next daemon instance.
+    // Shims self-terminate after ORPHAN_TIMEOUT_SECS (90s) if no daemon reconnects.
 
     /// Accept a single named pipe connection (Windows implementation).
     /// Returns a single File handle used for both reading and writing.

--- a/src-tauri/daemon/src/session.rs
+++ b/src-tauri/daemon/src/session.rs
@@ -1484,15 +1484,19 @@ impl DaemonSession {
 
 impl Drop for DaemonSession {
     fn drop(&mut self) {
-        // Safety net: if the session is dropped without an explicit close(),
-        // send Shutdown to the shim so it doesn't become an orphan process.
+        // Do NOT kill the shim or remove metadata here. When the daemon exits
+        // (crash, restart, idle timeout), shims must survive so the next daemon
+        // can recover them via reconnect_surviving_shims(). The shim has its own
+        // 90-second orphan timeout (ORPHAN_TIMEOUT_SECS) and will self-terminate
+        // if no daemon reconnects.
+        //
+        // Explicit session closure (user closes a tab) uses close(), which
+        // correctly kills the shim and removes metadata.
         if self.running.load(Ordering::Relaxed) {
-            let _ = self
-                .shim_io_tx
-                .send(ShimIoMessage::Control(ShimRequest::Shutdown));
-            shim_metadata::remove_metadata(&self.id);
-            // Kill the shim process directly as a belt-and-suspenders measure
-            shim_client::kill_process(self.shim_pid);
+            eprintln!(
+                "[daemon] Session {} dropped without close() — shim pid={} left alive for recovery",
+                self.id, self.shim_pid
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
The daemon no longer kills shim processes or removes session metadata when exiting. Shims are left alive with a 90-second orphan timeout, allowing the next daemon instance to recover surviving sessions via `reconnect_surviving_shims()`.

This fixes the issue where daemon crashes would immediately terminate all active terminal sessions, defeating the entire session recovery mechanism.

### Changes
- **DaemonSession::Drop**: no longer kills shim or removes metadata
- **DaemonServer::run**: removed `shutdown_all_sessions()` call
- Added clarifying comments about the recovery design

fixes #794