### PR TITLE
chore: block cargo compilation commands locally

### DIFF
--- a/.claude/hooks/block-cargo-compile.py
+++ b/.claude/hooks/block-cargo-compile.py
@@ -1,0 +1,36 @@
+"""PreToolUse hook: block cargo compilation commands.
+
+Agents must not compile locally (cold worktree = full rebuild, 10-20 agents = machine death).
+Only cargo fmt is allowed. Everything else goes through CI/CD.
+"""
+import json
+import re
+import sys
+
+BLOCKED_SUBCOMMANDS = r"cargo\s+(build|check|test|nextest|bench|clippy|run|install|add|tauri)\b"
+
+data = json.load(sys.stdin)
+cmd = data.get("tool_input", {}).get("command", "")
+
+# Strip heredocs, single-quoted strings, and double-quoted strings so that
+# commit messages or echo statements mentioning "cargo build" don't trigger.
+cleaned = re.sub(r"<<'?(\w+)'?\n.*?\n\1", "", cmd, flags=re.DOTALL)
+cleaned = re.sub(r"'[^']*'", "", cleaned)
+cleaned = re.sub(r'"(?:[^"\\]|\\.)*"', "", cleaned)
+
+if re.search(BLOCKED_SUBCOMMANDS, cleaned):
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "BLOCKED: cargo compilation commands are delegated to CI/CD. "
+                        "Only 'cargo fmt' is allowed locally. "
+                        "Edit code and push your branch - CI validates."
+                    ),
+                }
+            }
+        )
+    )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/block-cargo-compile.py",
+            "timeout": 5,
+            "statusMessage": "Checking cargo command..."
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Adds a PreToolUse hook that blocks cargo build/check/test/nextest/bench/clippy/run/install/add/tauri commands
- Only `cargo fmt` is allowed locally — all compilation is delegated to CI/CD
- Strips heredocs and quoted strings to avoid false positives on commit messages

**Why:** With 10-20 parallel agents in cold worktrees, each cargo command triggers a full recompilation of all transitive dependencies. This would saturate CPU/RAM and grind the machine to a halt.

## Test plan
- [x] Hook blocks `cargo check -p protocol`
- [x] Hook blocks `cd src-tauri && cargo build --release`
- [x] Hook blocks `cargo nextest run -p daemon`
- [x] Hook blocks `cargo tauri build`
- [x] Hook allows `cargo fmt -- --check`
- [x] Hook allows `git commit` with messages mentioning cargo
- [x] Hook allows `echo "cargo build"` (quoted strings)
- [x] 9/9 test cases pass