### PR TITLE
feat: add app-side handler for get_current_terminal MCP tool

### DIFF
--- a/changelog/unreleased/feat-get-current-session-handler.md
+++ b/changelog/unreleased/feat-get-current-session-handler.md
@@ -1,0 +1,3 @@
+### Added
+
+- **App-side handler for `get_current_terminal` MCP tool** — Terminal lookup by session_id now properly returns terminal info instead of falling through to unsupported request error

--- a/src-tauri/native/iced-shell/src/mcp_handler.rs
+++ b/src-tauri/native/iced-shell/src/mcp_handler.rs
@@ -221,6 +221,20 @@ impl GodlyApp {
                 },
                 iced::Task::none(),
             ),
+            McpRequest::GetCurrentSession { session_id } => match self.terminals.get(&session_id) {
+                Some(terminal) => (
+                    McpResponse::TerminalInfo {
+                        terminal: self.to_mcp_terminal_info(terminal),
+                    },
+                    iced::Task::none(),
+                ),
+                None => (
+                    McpResponse::Error {
+                        message: format!("Terminal not found for session_id: {}", session_id),
+                    },
+                    iced::Task::none(),
+                ),
+            },
             McpRequest::GetActiveTerminal => (
                 McpResponse::ActiveTerminal {
                     terminal: self


### PR DESCRIPTION
## Summary

Implements the app-side handler for the `get_current_terminal` MCP tool that was previously defined in the call dispatcher but had no implementation in the app handler.

## Changes

- Added terminal lookup by session_id in `mcp_handler.rs`
- Returns `McpResponse::TerminalInfo` with the terminal information
- Handles missing terminal case with appropriate error response

## Test Plan

- [ ] Verify `get_current_terminal` MCP tool returns correct terminal info
- [ ] Verify error handling when terminal session_id is not found