### PR TITLE
fix: prevent Quick Claude getting stuck at workspace trust prompt

### DIFF
--- a/changelog/unreleased/fix-quick-claude-trust-prompt-early-exit.md
+++ b/changelog/unreleased/fix-quick-claude-trust-prompt-early-exit.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Quick Claude stuck at trust prompt** — Fixed false positive early exit in `handle_trust_prompt_if_needed` that occurred when "Claude Code" appeared in trust prompt text during incremental rendering, preventing the prompt from being dismissed. Also increased startup timeout from 8s to 20s to handle slower Windows environments.

--- a/src-tauri/native/iced-shell/src/quick_claude.rs
+++ b/src-tauri/native/iced-shell/src/quick_claude.rs
@@ -182,7 +182,7 @@ pub fn default_launch_steps(
         });
         steps.push(LaunchStep::HandleTrustPromptIfNeeded {
             agent_index: i,
-            timeout_ms: 8_000,
+            timeout_ms: 20_000,
         });
     }
     steps
@@ -579,15 +579,21 @@ fn handle_trust_prompt_if_needed(
             return Ok(());
         }
 
-        // Early exit: if Claude is already working (shows tool use, output markers,
-        // or the input prompt ">"), the trust prompt was never shown
-        let past_startup = text.contains("Task(")
-            || text.contains("Claude Code")
-            || text.lines().rev().any(|l| {
-                let t = l.trim();
-                t == ">" || t == "> "
-            });
-        if past_startup && start.elapsed() > Duration::from_millis(2_000) {
+        // Early exit: if Claude is genuinely past startup (not on the trust
+        // prompt screen), the trust prompt was never shown.
+        // NOTE: Do NOT use `text.contains("Claude Code")` here — the trust
+        // prompt screen itself shows "Claude Code'll be able to read, edit,
+        // and execute files here." which causes a false positive.
+        let on_trust_screen = text.contains("safety check")
+            || text.contains("Accessing workspace")
+            || text.contains("Esc to cancel");
+        let past_startup = !on_trust_screen
+            && (text.contains("Task(")
+                || text.lines().rev().any(|l| {
+                    let t = l.trim();
+                    t == ">" || t == "> "
+                }));
+        if past_startup && start.elapsed() > Duration::from_millis(3_000) {
             return Ok(());
         }
 
@@ -877,5 +883,16 @@ mod tests {
     #[test]
     fn has_trust_prompt_negative() {
         assert!(!has_trust_prompt_text("Claude Code v1.0.0\nLoading..."));
+    }
+
+    #[test]
+    fn default_steps_trust_timeout_is_20s() {
+        let steps = default_launch_steps(1, "test", "sonnet", "default", None, &[], IsolationMode::None, None);
+        match &steps[3] {
+            LaunchStep::HandleTrustPromptIfNeeded { timeout_ms, .. } => {
+                assert_eq!(*timeout_ms, 20_000);
+            }
+            _ => panic!("Expected HandleTrustPromptIfNeeded"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where Quick Claude gets stuck at the workspace trust prompt and never dismisses it.

### Root Cause
Two issues in `src-tauri/native/iced-shell/src/quick_claude.rs`:

1. **False positive early exit in `handle_trust_prompt_if_needed`**: The early exit condition checked `text.contains("Claude Code")` as a "past startup" indicator, but the trust prompt screen itself displays "Claude Code'll be able to read, edit, and execute files here." During incremental rendering, "Claude Code" appears before "I trust this folder" — the early exit fires before the trust prompt is fully rendered, causing the handler to return without dismissing it.

2. **Insufficient timeout**: The 8-second timeout was too short for Claude Code on Windows, especially in new worktree directories.

### Fix
- Replaced the "Claude Code" check with trust-screen-specific indicators (`safety check`, `Accessing workspace`, `Esc to cancel`) that only suppress the early exit while the trust screen is visible.
- Increased startup timeout from 8s to 20s.
- Added unit test to verify the 20s timeout.

### Testing
- Added `default_steps_trust_timeout_is_20s` unit test that validates the timeout value in the launch steps.