### PR TITLE
feat: add rename_self MCP tool and auto-rename instructions

### DIFF
--- a/changelog/unreleased/feat-rename-self-mcp.md
+++ b/changelog/unreleased/feat-rename-self-mcp.md
@@ -1,0 +1,3 @@
+### Added
+- **`rename_self` MCP tool** — rename the current terminal tab with a single call, no terminal ID needed
+- **MCP server instructions** — Claude auto-renames tabs after understanding the user's first message, zero configuration required

--- a/src-tauri/mcp/src/handler.rs
+++ b/src-tauri/mcp/src/handler.rs
@@ -80,7 +80,8 @@ pub fn handle_request(
                     "serverInfo": {
                         "name": "godly-terminal",
                         "version": "0.1.0"
-                    }
+                    },
+                    "instructions": "After understanding the user's first message, auto-rename the terminal tab by calling the rename_self MCP tool with a brief, descriptive name derived from the task or context. This helps organize multiple concurrent Claude sessions."
                 }),
             )
         }
@@ -230,7 +231,8 @@ pub fn handle_request_ref(
                     "serverInfo": {
                         "name": "godly-terminal",
                         "version": "0.1.0"
-                    }
+                    },
+                    "instructions": "After understanding the user's first message, auto-rename the terminal tab by calling the rename_self MCP tool with a brief, descriptive name derived from the task or context. This helps organize multiple concurrent Claude sessions."
                 }),
             )
         }

--- a/src-tauri/mcp/src/tools.rs
+++ b/src-tauri/mcp/src/tools.rs
@@ -581,6 +581,20 @@ pub fn list_tools() -> Value {
                 }
             },
             {
+                "name": "rename_self",
+                "description": "Rename the current terminal tab with a single call, no terminal ID needed. Uses GODLY_SESSION_ID internally.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "New name for the terminal tab"
+                        }
+                    },
+                    "required": ["name"]
+                }
+            },
+            {
                 "name": "focus_terminal",
                 "description": "Focus/select a terminal, making it the active tab.",
                 "inputSchema": {
@@ -1775,6 +1789,15 @@ pub fn call_tool(
         "rename_terminal" => {
             let terminal_id = args.get("terminal_id").and_then(|v| v.as_str()).ok_or("Missing terminal_id")?.to_string();
             let name = args.get("name").and_then(|v| v.as_str()).ok_or("Missing name")?.to_string();
+            McpRequest::RenameTerminal { terminal_id, name }
+        }
+
+        "rename_self" => {
+            let name = args.get("name").and_then(|v| v.as_str()).ok_or("Missing name")?.to_string();
+            let terminal_id = session_id
+                .as_ref()
+                .cloned()
+                .ok_or("GODLY_SESSION_ID not set")?;
             McpRequest::RenameTerminal { terminal_id, name }
         }
 


### PR DESCRIPTION
## Summary

- Add `rename_self` MCP tool that auto-resolves terminal ID from GODLY_SESSION_ID environment variable
- Add `instructions` field to MCP initialize response to guide Claude in auto-renaming tabs
- Claude automatically renames the current terminal tab after understanding the user's first message
- Eliminates need for users to configure terminal renaming - works out of the box

## Benefits

Previously, renaming a tab from Claude required either:
- OSC escape sequences (doesn't work with Claude Code's output capture)
- The `rename_terminal` MCP tool (requires 2 separate tool calls for terminal ID + rename)
- Manual configuration in CLAUDE.md

Now: single `rename_self` call with just a name parameter, and Claude does it automatically via instructions.

## Test Plan

- [ ] Launch Claude Code from Godly Terminal
- [ ] Claude automatically renames the tab after understanding the task
- [ ] Verify the tab name reflects the task context
