### PR TITLE
feat: add tmux-shim crate with core infrastructure and session commands

### DIFF
--- a/changelog/unreleased/feat-tmux-shim-core.md
+++ b/changelog/unreleased/feat-tmux-shim-core.md
@@ -1,0 +1,2 @@
+### Added
+- **Tmux shim crate** — `godly-tmux-shim` binary crate that intercepts tmux CLI commands and translates them to Godly Terminal operations via named pipes, enabling Claude Code agent teams support. Includes session lifecycle commands (new-session, has-session, kill-session, list-sessions), MCP and daemon pipe clients, tmux CLI arg parser, format string expansion, and persistent state file with file locking.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2103,6 +2103,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "godly-tmux-shim"
+version = "0.1.0"
+dependencies = [
+ "godly-protocol",
+ "serde",
+ "serde_json",
+ "winapi",
+]
+
+[[package]]
 name = "godly-vt"
 version = "0.9.0"
 dependencies = [

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "protocol", "daemon", "mcp", "notify", "godly-vt", "remote", "pty-shim", "whisper",
+    "tmux-shim",
     "native/app-adapter",
     "native/iced-shell",
     "native/terminal-surface",

--- a/src-tauri/tmux-shim/Cargo.toml
+++ b/src-tauri/tmux-shim/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "godly-tmux-shim"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "tmux"
+path = "src/main.rs"
+
+[dependencies]
+godly-protocol.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+winapi.workspace = true

--- a/src-tauri/tmux-shim/src/cli.rs
+++ b/src-tauri/tmux-shim/src/cli.rs
@@ -1,0 +1,175 @@
+use std::collections::HashMap;
+
+/// Parsed tmux CLI arguments.
+///
+/// tmux uses single-dash single-letter flags:
+///   - Boolean flags: `-d`, `-h`, `-v`, `-P`
+///   - Value flags: `-s name`, `-t target`, `-F format`, `-c dir`, `-x W`, `-y H`
+#[derive(Debug, Default)]
+pub struct TmuxArgs {
+    /// Boolean flags that were present (e.g., 'd', 'h', 'v', 'P')
+    pub flags: Vec<char>,
+    /// Key-value options (e.g., 's' -> "my-session", 't' -> "target")
+    pub options: HashMap<char, String>,
+    /// Positional arguments after all flags
+    pub positional: Vec<String>,
+}
+
+impl TmuxArgs {
+    /// Flags that take a value argument.
+    const VALUE_FLAGS: &[char] = &['s', 't', 'F', 'c', 'x', 'y', 'f', 'n', 'e'];
+
+    /// Parse tmux-style arguments from a slice of strings.
+    pub fn parse(args: &[String]) -> Self {
+        let mut result = TmuxArgs::default();
+        let mut i = 0;
+
+        while i < args.len() {
+            let arg = &args[i];
+
+            if arg.starts_with('-') && arg.len() >= 2 && arg.as_bytes()[1] != b'-' {
+                // Single-dash flag(s): could be `-d` or `-dt target` (combined)
+                let chars: Vec<char> = arg[1..].chars().collect();
+                let mut j = 0;
+
+                while j < chars.len() {
+                    let ch = chars[j];
+
+                    if Self::VALUE_FLAGS.contains(&ch) {
+                        // This flag takes a value
+                        let remaining: String = chars[j + 1..].iter().collect();
+                        if !remaining.is_empty() {
+                            // Value is concatenated: `-sMySession`
+                            result.options.insert(ch, remaining);
+                        } else if i + 1 < args.len() {
+                            // Value is the next argument: `-s MySession`
+                            i += 1;
+                            result.options.insert(ch, args[i].clone());
+                        }
+                        // Either way, we consumed the rest of this flag group
+                        break;
+                    } else {
+                        result.flags.push(ch);
+                    }
+                    j += 1;
+                }
+            } else {
+                result.positional.push(arg.clone());
+            }
+
+            i += 1;
+        }
+
+        result
+    }
+
+    /// Check if a boolean flag is set.
+    pub fn has_flag(&self, flag: char) -> bool {
+        self.flags.contains(&flag)
+    }
+
+    /// Get the value of an option flag.
+    pub fn get_option(&self, key: char) -> Option<&str> {
+        self.options.get(&key).map(|s| s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(s: &[&str]) -> Vec<String> {
+        s.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_empty() {
+        let parsed = TmuxArgs::parse(&[]);
+        assert!(parsed.flags.is_empty());
+        assert!(parsed.options.is_empty());
+        assert!(parsed.positional.is_empty());
+    }
+
+    #[test]
+    fn parse_boolean_flags() {
+        let parsed = TmuxArgs::parse(&args(&["-d", "-P"]));
+        assert!(parsed.has_flag('d'));
+        assert!(parsed.has_flag('P'));
+        assert!(!parsed.has_flag('v'));
+    }
+
+    #[test]
+    fn parse_combined_boolean_flags() {
+        let parsed = TmuxArgs::parse(&args(&["-dP"]));
+        assert!(parsed.has_flag('d'));
+        assert!(parsed.has_flag('P'));
+    }
+
+    #[test]
+    fn parse_value_flag_separate() {
+        let parsed = TmuxArgs::parse(&args(&["-s", "my-session"]));
+        assert_eq!(parsed.get_option('s'), Some("my-session"));
+    }
+
+    #[test]
+    fn parse_value_flag_concatenated() {
+        let parsed = TmuxArgs::parse(&args(&["-smy-session"]));
+        assert_eq!(parsed.get_option('s'), Some("my-session"));
+    }
+
+    #[test]
+    fn parse_combined_boolean_then_value() {
+        let parsed = TmuxArgs::parse(&args(&["-ds", "my-session"]));
+        assert!(parsed.has_flag('d'));
+        assert_eq!(parsed.get_option('s'), Some("my-session"));
+    }
+
+    #[test]
+    fn parse_format_flag() {
+        let parsed = TmuxArgs::parse(&args(&["-P", "-F", "#{pane_id}"]));
+        assert!(parsed.has_flag('P'));
+        assert_eq!(parsed.get_option('F'), Some("#{pane_id}"));
+    }
+
+    #[test]
+    fn parse_multiple_value_flags() {
+        let parsed = TmuxArgs::parse(&args(&["-s", "sess", "-t", "target", "-c", "/tmp"]));
+        assert_eq!(parsed.get_option('s'), Some("sess"));
+        assert_eq!(parsed.get_option('t'), Some("target"));
+        assert_eq!(parsed.get_option('c'), Some("/tmp"));
+    }
+
+    #[test]
+    fn parse_dimensions() {
+        let parsed = TmuxArgs::parse(&args(&["-x", "120", "-y", "40"]));
+        assert_eq!(parsed.get_option('x'), Some("120"));
+        assert_eq!(parsed.get_option('y'), Some("40"));
+    }
+
+    #[test]
+    fn parse_positional_args() {
+        let parsed = TmuxArgs::parse(&args(&["-d", "bash", "--login"]));
+        assert!(parsed.has_flag('d'));
+        assert_eq!(parsed.positional, vec!["bash", "--login"]);
+    }
+
+    #[test]
+    fn parse_mixed_everything() {
+        let parsed = TmuxArgs::parse(&args(&[
+            "-dP",
+            "-s",
+            "work",
+            "-F",
+            "#{pane_id}",
+            "-c",
+            "/home/user",
+            "bash",
+        ]));
+        assert!(parsed.has_flag('d'));
+        assert!(parsed.has_flag('P'));
+        assert_eq!(parsed.get_option('s'), Some("work"));
+        assert_eq!(parsed.get_option('F'), Some("#{pane_id}"));
+        assert_eq!(parsed.get_option('c'), Some("/home/user"));
+        assert_eq!(parsed.positional, vec!["bash"]);
+    }
+}

--- a/src-tauri/tmux-shim/src/commands/io.rs
+++ b/src-tauri/tmux-shim/src/commands/io.rs
@@ -1,0 +1,6 @@
+/// Handle I/O-related tmux commands (send-keys, display-message, capture-pane).
+/// Stub — will be implemented in a follow-up unit.
+pub fn handle_io_command(_args: &[String]) -> i32 {
+    eprintln!("tmux: io commands not yet implemented");
+    1
+}

--- a/src-tauri/tmux-shim/src/commands/mod.rs
+++ b/src-tauri/tmux-shim/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod io;
+pub mod pane;
+pub mod session;

--- a/src-tauri/tmux-shim/src/commands/pane.rs
+++ b/src-tauri/tmux-shim/src/commands/pane.rs
@@ -1,0 +1,6 @@
+/// Handle pane-related tmux commands (split-window, select-pane, list-panes, kill-pane).
+/// Stub — will be implemented in a follow-up unit.
+pub fn handle_pane_command(_args: &[String]) -> i32 {
+    eprintln!("tmux: pane commands not yet implemented");
+    1
+}

--- a/src-tauri/tmux-shim/src/commands/session.rs
+++ b/src-tauri/tmux-shim/src/commands/session.rs
@@ -1,0 +1,301 @@
+use godly_protocol::{McpRequest, McpResponse};
+
+use crate::cli::TmuxArgs;
+use crate::format::{self, FormatVars};
+use crate::mcp_client::McpPipeClient;
+use crate::state;
+
+/// Handle session lifecycle commands: new-session, has-session, kill-session, list-sessions.
+pub fn handle(command: &str, args: &[String]) -> i32 {
+    match command {
+        "new-session" => new_session(args),
+        "has-session" => has_session(args),
+        "kill-session" => kill_session(args),
+        "list-sessions" => list_sessions(args),
+        _ => {
+            eprintln!("tmux: unknown session command: {}", command);
+            1
+        }
+    }
+}
+
+/// `new-session -d -s <name> [-c <dir>] [-P] [-F <format>]`
+///
+/// Gets the active workspace, stores session->workspace mapping, and maps
+/// `$GODLY_SESSION_ID` as the initial pane (%0).
+fn new_session(args: &[String]) -> i32 {
+    let parsed = TmuxArgs::parse(args);
+
+    let session_name = match parsed.get_option('s') {
+        Some(name) => name.to_string(),
+        None => {
+            // tmux defaults to "0", "1", etc. if no name given
+            "0".to_string()
+        }
+    };
+
+    let cwd = parsed.get_option('c').map(|s| s.to_string());
+    let print_info = parsed.has_flag('P');
+    let format_str = parsed.get_option('F').unwrap_or("#{session_name}:");
+
+    // Connect to Godly Terminal MCP pipe
+    let client = match McpPipeClient::connect() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("tmux: {}", e);
+            return 1;
+        }
+    };
+
+    // Get the active workspace
+    let workspace = match client.send_request(&McpRequest::GetActiveWorkspace) {
+        Ok(McpResponse::ActiveWorkspace {
+            workspace: Some(ws),
+        }) => ws,
+        Ok(McpResponse::ActiveWorkspace { workspace: None }) => {
+            eprintln!("tmux: no active workspace");
+            return 1;
+        }
+        Ok(McpResponse::Error { message }) => {
+            eprintln!("tmux: {}", message);
+            return 1;
+        }
+        Ok(other) => {
+            eprintln!("tmux: unexpected response: {:?}", other);
+            return 1;
+        }
+        Err(e) => {
+            eprintln!("tmux: MCP error: {}", e);
+            return 1;
+        }
+    };
+
+    // Look up GODLY_SESSION_ID for the initial pane mapping
+    let godly_session_id = std::env::var("GODLY_SESSION_ID").ok();
+
+    // If a cwd was specified but we don't have a session ID, create a new terminal
+    let terminal_id = if let Some(session_id) = godly_session_id {
+        // Use the existing terminal session that spawned us
+        session_id
+    } else if cwd.is_some() {
+        // Create a new terminal in the workspace
+        match client.send_request(&McpRequest::CreateTerminal {
+            workspace_id: workspace.id.clone(),
+            shell_type: None,
+            cwd: cwd.clone(),
+            worktree_name: None,
+            worktree: None,
+            command: None,
+            focus: Some(false),
+        }) {
+            Ok(McpResponse::Created { id, .. }) => id,
+            Ok(McpResponse::Error { message }) => {
+                eprintln!("tmux: failed to create terminal: {}", message);
+                return 1;
+            }
+            Ok(other) => {
+                eprintln!("tmux: unexpected response creating terminal: {:?}", other);
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("tmux: MCP error creating terminal: {}", e);
+                return 1;
+            }
+        }
+    } else {
+        // No session ID and no cwd — use a placeholder; the caller will create panes
+        String::new()
+    };
+
+    // Store the session mapping in state
+    let pane_id = match state::with_state(|state| {
+        // Check if session already exists
+        if state.sessions.contains_key(&session_name) {
+            return Err(format!("duplicate session: {}", session_name));
+        }
+
+        state.sessions.insert(
+            session_name.clone(),
+            state::SessionMapping {
+                workspace_id: workspace.id.clone(),
+            },
+        );
+
+        // Map the initial terminal as %N
+        let pane_id = if !terminal_id.is_empty() {
+            state.allocate_pane_id(terminal_id.clone(), session_name.clone())
+        } else {
+            String::new()
+        };
+
+        Ok(pane_id)
+    }) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!("tmux: {}", e);
+            return 1;
+        }
+    };
+
+    // Print info if -P was specified
+    if print_info && !pane_id.is_empty() {
+        let vars = FormatVars {
+            pane_id,
+            session_name: session_name.clone(),
+            pane_width: 80,
+            pane_height: 24,
+            window_index: 0,
+        };
+        println!("{}", format::expand(format_str, &vars));
+    }
+
+    0
+}
+
+/// `has-session -t <name>`
+///
+/// Check if a session exists. Exit 0 if yes, 1 if no.
+fn has_session(args: &[String]) -> i32 {
+    let parsed = TmuxArgs::parse(args);
+
+    let target = match parsed.get_option('t') {
+        Some(name) => name.to_string(),
+        None => {
+            eprintln!("tmux: has-session requires -t <session-name>");
+            return 1;
+        }
+    };
+
+    match state::load() {
+        Ok(state) => {
+            if state.sessions.contains_key(&target) {
+                0
+            } else {
+                1
+            }
+        }
+        Err(e) => {
+            eprintln!("tmux: failed to read state: {}", e);
+            1
+        }
+    }
+}
+
+/// `kill-session -t <name>`
+///
+/// Close all panes in the session via MCP, then remove from state.
+fn kill_session(args: &[String]) -> i32 {
+    let parsed = TmuxArgs::parse(args);
+
+    let target = match parsed.get_option('t') {
+        Some(name) => name.to_string(),
+        None => {
+            eprintln!("tmux: kill-session requires -t <session-name>");
+            return 1;
+        }
+    };
+
+    // Load state to get all terminal IDs for this session
+    let pane_terminal_ids: Vec<String> = match state::load() {
+        Ok(state) => {
+            if !state.sessions.contains_key(&target) {
+                eprintln!("tmux: session not found: {}", target);
+                return 1;
+            }
+            state
+                .session_panes(&target)
+                .iter()
+                .filter_map(|pane_id| state.panes.get(pane_id).map(|p| p.terminal_id.clone()))
+                .collect()
+        }
+        Err(e) => {
+            eprintln!("tmux: failed to read state: {}", e);
+            return 1;
+        }
+    };
+
+    // Close each terminal via MCP
+    if !pane_terminal_ids.is_empty() {
+        let client = match McpPipeClient::connect() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("tmux: {}", e);
+                return 1;
+            }
+        };
+
+        for terminal_id in &pane_terminal_ids {
+            if terminal_id.is_empty() {
+                continue;
+            }
+            match client.send_request(&McpRequest::CloseTerminal {
+                terminal_id: terminal_id.clone(),
+            }) {
+                Ok(McpResponse::Ok) => {}
+                Ok(McpResponse::Error { message }) => {
+                    eprintln!(
+                        "tmux: warning: failed to close terminal {}: {}",
+                        terminal_id, message
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!(
+                        "tmux: warning: MCP error closing terminal {}: {}",
+                        terminal_id, e
+                    );
+                }
+            }
+        }
+    }
+
+    // Remove session from state
+    match state::with_state(|state| {
+        state.remove_session(&target);
+        Ok(())
+    }) {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("tmux: {}", e);
+            1
+        }
+    }
+}
+
+/// `list-sessions` / `ls`
+///
+/// Print sessions in tmux format: `session_name: N windows (created ...)`
+fn list_sessions(_args: &[String]) -> i32 {
+    let state = match state::load() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("tmux: failed to read state: {}", e);
+            return 1;
+        }
+    };
+
+    if state.sessions.is_empty() {
+        // tmux exits 1 with "no server running" when there are no sessions
+        eprintln!("no server running on this host");
+        return 1;
+    }
+
+    for (name, _mapping) in &state.sessions {
+        let pane_count = state.session_panes(name).len();
+        // tmux counts "windows", but we map 1 session = 1 window with N panes
+        println!("{}: 1 windows (created -) [{} panes]", name, pane_count);
+    }
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_dispatches_unknown_command() {
+        let code = handle("nonexistent", &[]);
+        assert_eq!(code, 1);
+    }
+}

--- a/src-tauri/tmux-shim/src/daemon_client.rs
+++ b/src-tauri/tmux-shim/src/daemon_client.rs
@@ -1,0 +1,86 @@
+use std::io;
+use std::sync::Mutex;
+
+use godly_protocol::{DaemonMessage, Request, Response};
+
+/// Client that communicates with the Godly Terminal daemon via the daemon named pipe.
+pub struct DaemonPipeClient {
+    pipe: Mutex<std::fs::File>,
+}
+
+impl DaemonPipeClient {
+    /// Connect to the daemon named pipe.
+    #[cfg(windows)]
+    pub fn connect() -> Result<Self, String> {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        use std::os::windows::io::FromRawHandle;
+        use winapi::um::errhandlingapi::GetLastError;
+        use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+        use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+
+        let pipe_name_str = godly_protocol::pipe_name();
+
+        let pipe_name: Vec<u16> = OsStr::new(&pipe_name_str)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        let handle = unsafe {
+            CreateFileW(
+                pipe_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if handle == INVALID_HANDLE_VALUE {
+            let err = unsafe { GetLastError() };
+            return Err(format!(
+                "Cannot connect to daemon pipe '{}' (error: {}). Is the daemon running?",
+                pipe_name_str, err
+            ));
+        }
+
+        let pipe = unsafe { std::fs::File::from_raw_handle(handle as _) };
+
+        Ok(Self {
+            pipe: Mutex::new(pipe),
+        })
+    }
+
+    #[cfg(not(windows))]
+    pub fn connect() -> Result<Self, String> {
+        Err("Daemon named pipes are only supported on Windows".to_string())
+    }
+
+    /// Send a daemon Request and read the Response, discarding async Events.
+    pub fn send_request(&self, request: &Request) -> Result<Response, io::Error> {
+        let mut pipe = self
+            .pipe
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Mutex poisoned: {}", e)))?;
+
+        godly_protocol::write_request(&mut *pipe, request)?;
+        use std::io::Write;
+        pipe.flush().ok();
+
+        // Read messages, discarding Events until we get a Response
+        loop {
+            let msg: DaemonMessage =
+                godly_protocol::read_daemon_message(&mut *pipe)?.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::UnexpectedEof, "Daemon pipe closed")
+                })?;
+
+            match msg {
+                DaemonMessage::Response(resp) => return Ok(resp),
+                DaemonMessage::Event(_) => continue,
+            }
+        }
+    }
+}

--- a/src-tauri/tmux-shim/src/format.rs
+++ b/src-tauri/tmux-shim/src/format.rs
@@ -1,0 +1,91 @@
+/// Expand tmux format strings like `#{pane_id}`, `#{session_name}`, etc.
+///
+/// Supported variables:
+/// - `#{pane_id}` — the tmux pane ID (e.g., %0)
+/// - `#{session_name}` — the tmux session name
+/// - `#{pane_width}` — terminal width in columns
+/// - `#{pane_height}` — terminal height in rows
+/// - `#{window_index}` — always 0 (we map sessions 1:1 with windows)
+pub fn expand(format: &str, vars: &FormatVars) -> String {
+    let mut result = format.to_string();
+
+    result = result.replace("#{pane_id}", &vars.pane_id);
+    result = result.replace("#{session_name}", &vars.session_name);
+    result = result.replace("#{pane_width}", &vars.pane_width.to_string());
+    result = result.replace("#{pane_height}", &vars.pane_height.to_string());
+    result = result.replace("#{window_index}", &vars.window_index.to_string());
+
+    result
+}
+
+/// Variables available for tmux format string expansion.
+#[derive(Debug, Default)]
+pub struct FormatVars {
+    pub pane_id: String,
+    pub session_name: String,
+    pub pane_width: u32,
+    pub pane_height: u32,
+    pub window_index: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_pane_id() {
+        let vars = FormatVars {
+            pane_id: "%0".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(expand("#{pane_id}", &vars), "%0");
+    }
+
+    #[test]
+    fn expand_session_name() {
+        let vars = FormatVars {
+            session_name: "work".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(expand("#{session_name}", &vars), "work");
+    }
+
+    #[test]
+    fn expand_multiple_vars() {
+        let vars = FormatVars {
+            pane_id: "%3".to_string(),
+            session_name: "dev".to_string(),
+            pane_width: 120,
+            pane_height: 40,
+            window_index: 0,
+        };
+        let result = expand("#{session_name}:#{window_index}.#{pane_id}", &vars);
+        assert_eq!(result, "dev:0.%3");
+    }
+
+    #[test]
+    fn expand_dimensions() {
+        let vars = FormatVars {
+            pane_width: 200,
+            pane_height: 50,
+            ..Default::default()
+        };
+        assert_eq!(expand("#{pane_width}x#{pane_height}", &vars), "200x50");
+    }
+
+    #[test]
+    fn expand_no_vars() {
+        let vars = FormatVars::default();
+        assert_eq!(expand("plain text", &vars), "plain text");
+    }
+
+    #[test]
+    fn expand_just_pane_id_format() {
+        // This is what Claude Code typically passes: -F '#{pane_id}'
+        let vars = FormatVars {
+            pane_id: "%5".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(expand("#{pane_id}", &vars), "%5");
+    }
+}

--- a/src-tauri/tmux-shim/src/main.rs
+++ b/src-tauri/tmux-shim/src/main.rs
@@ -1,0 +1,40 @@
+mod cli;
+mod commands;
+#[allow(dead_code)]
+mod daemon_client;
+mod format;
+mod mcp_client;
+mod state;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let exit_code = if args.len() <= 1 {
+        // Bare `tmux` = `new-session`
+        commands::session::handle("new-session", &args[1..])
+    } else {
+        match args[1].as_str() {
+            "-V" => {
+                println!("tmux 3.4");
+                0
+            }
+            "new-session" | "new" => commands::session::handle("new-session", &args[2..]),
+            "has-session" | "has" => commands::session::handle("has-session", &args[2..]),
+            "kill-session" => commands::session::handle("kill-session", &args[2..]),
+            "list-sessions" | "ls" => commands::session::handle("list-sessions", &args[2..]),
+            "split-window" | "splitw" => commands::pane::handle_pane_command(&args[1..]),
+            "select-pane" | "selectp" => commands::pane::handle_pane_command(&args[1..]),
+            "list-panes" | "lsp" => commands::pane::handle_pane_command(&args[1..]),
+            "kill-pane" | "killp" => commands::pane::handle_pane_command(&args[1..]),
+            "send-keys" | "send" => commands::io::handle_io_command(&args[1..]),
+            "display-message" | "display" => commands::io::handle_io_command(&args[1..]),
+            "capture-pane" | "capturep" => commands::io::handle_io_command(&args[1..]),
+            unknown => {
+                eprintln!("tmux: unknown command: {}", unknown);
+                1
+            }
+        }
+    };
+
+    std::process::exit(exit_code);
+}

--- a/src-tauri/tmux-shim/src/mcp_client.rs
+++ b/src-tauri/tmux-shim/src/mcp_client.rs
@@ -1,0 +1,81 @@
+use std::io;
+use std::sync::Mutex;
+
+use godly_protocol::{McpRequest, McpResponse};
+
+/// Client that communicates with the Godly Terminal app via the MCP named pipe.
+pub struct McpPipeClient {
+    pipe: Mutex<std::fs::File>,
+}
+
+impl McpPipeClient {
+    /// Connect to the MCP named pipe.
+    #[cfg(windows)]
+    pub fn connect() -> Result<Self, String> {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        use std::os::windows::io::FromRawHandle;
+        use winapi::um::errhandlingapi::GetLastError;
+        use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+        use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+
+        let pipe_name_str = godly_protocol::mcp_pipe_name();
+
+        let pipe_name: Vec<u16> = OsStr::new(&pipe_name_str)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        let handle = unsafe {
+            CreateFileW(
+                pipe_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if handle == INVALID_HANDLE_VALUE {
+            let err = unsafe { GetLastError() };
+            return Err(format!(
+                "Cannot connect to MCP pipe '{}' (error: {}). Is Godly Terminal running?",
+                pipe_name_str, err
+            ));
+        }
+
+        let pipe = unsafe { std::fs::File::from_raw_handle(handle as _) };
+
+        Ok(Self {
+            pipe: Mutex::new(pipe),
+        })
+    }
+
+    #[cfg(not(windows))]
+    pub fn connect() -> Result<Self, String> {
+        Err("MCP named pipes are only supported on Windows".to_string())
+    }
+
+    /// Send an MCP request and wait for the response.
+    pub fn send_request(&self, request: &McpRequest) -> Result<McpResponse, io::Error> {
+        let mut pipe = self
+            .pipe
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Mutex poisoned: {}", e)))?;
+
+        godly_protocol::write_message(&mut *pipe, request)?;
+        use std::io::Write;
+        pipe.flush().ok();
+
+        match godly_protocol::read_message::<_, McpResponse>(&mut *pipe)? {
+            Some(response) => Ok(response),
+            None => Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "MCP pipe closed",
+            )),
+        }
+    }
+}

--- a/src-tauri/tmux-shim/src/state.rs
+++ b/src-tauri/tmux-shim/src/state.rs
@@ -1,0 +1,266 @@
+use std::collections::HashMap;
+use std::io;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Persistent tmux shim state mapping tmux concepts to Godly Terminal UUIDs.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TmuxState {
+    /// Maps tmux session names to workspace info.
+    pub sessions: HashMap<String, SessionMapping>,
+    /// Maps tmux pane IDs (%0, %1, ...) to terminal info.
+    pub panes: HashMap<String, PaneMapping>,
+    /// Next pane ID counter.
+    pub next_pane_id: u32,
+}
+
+/// Mapping from a tmux session name to a Godly workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMapping {
+    pub workspace_id: String,
+}
+
+/// Mapping from a tmux pane ID to a Godly terminal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneMapping {
+    pub terminal_id: String,
+    pub session: String,
+}
+
+impl TmuxState {
+    /// Allocate the next pane ID (e.g., "%0", "%1") and return it.
+    pub fn allocate_pane_id(&mut self, terminal_id: String, session: String) -> String {
+        let pane_id = format!("%{}", self.next_pane_id);
+        self.panes.insert(
+            pane_id.clone(),
+            PaneMapping {
+                terminal_id,
+                session,
+            },
+        );
+        self.next_pane_id += 1;
+        pane_id
+    }
+
+    /// Get all pane IDs belonging to a session.
+    pub fn session_panes(&self, session_name: &str) -> Vec<String> {
+        self.panes
+            .iter()
+            .filter(|(_, v)| v.session == session_name)
+            .map(|(k, _)| k.clone())
+            .collect()
+    }
+
+    /// Remove a session and all its panes from state.
+    pub fn remove_session(&mut self, session_name: &str) {
+        self.sessions.remove(session_name);
+        self.panes.retain(|_, v| v.session != session_name);
+    }
+}
+
+/// Get the path to the tmux state file.
+fn state_file_path() -> PathBuf {
+    let appdata = std::env::var("APPDATA")
+        .unwrap_or_else(|_| std::env::var("HOME").unwrap_or_else(|_| ".".to_string()));
+    PathBuf::from(appdata)
+        .join("com.godly.terminal")
+        .join("tmux-state.json")
+}
+
+/// Load the tmux state from disk, returning default state if the file doesn't exist.
+pub fn load() -> Result<TmuxState, io::Error> {
+    let path = state_file_path();
+    if !path.exists() {
+        return Ok(TmuxState::default());
+    }
+    let contents = std::fs::read_to_string(&path)?;
+    serde_json::from_str(&contents).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Save the tmux state to disk atomically (write to temp file, then rename).
+/// Creates the parent directory if it doesn't exist.
+pub fn save(state: &TmuxState) -> Result<(), io::Error> {
+    let path = state_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let json = serde_json::to_string_pretty(state)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    // Atomic write: write to temp file, then rename
+    let tmp_path = path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, json.as_bytes())?;
+    std::fs::rename(&tmp_path, &path)?;
+
+    Ok(())
+}
+
+/// Execute a closure with exclusive access to the state file.
+/// Loads the state, passes it to the closure, and saves if the closure succeeds.
+pub fn with_state<F, T>(f: F) -> Result<T, String>
+where
+    F: FnOnce(&mut TmuxState) -> Result<T, String>,
+{
+    let _lock = lock_state_file().map_err(|e| format!("Failed to lock state file: {}", e))?;
+
+    let mut state = load().map_err(|e| format!("Failed to load tmux state: {}", e))?;
+    let result = f(&mut state)?;
+    save(&state).map_err(|e| format!("Failed to save tmux state: {}", e))?;
+
+    Ok(result)
+}
+
+/// Acquire an exclusive file lock on a lock file adjacent to the state file.
+/// Returns a guard that releases the lock when dropped.
+fn lock_state_file() -> Result<LockGuard, io::Error> {
+    let lock_path = state_file_path().with_extension("json.lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    LockGuard::acquire(&lock_path)
+}
+
+/// RAII guard for a file lock. Closing the file handle releases the lock.
+struct LockGuard {
+    _file: std::fs::File,
+}
+
+impl LockGuard {
+    #[cfg(windows)]
+    fn acquire(path: &std::path::Path) -> Result<Self, io::Error> {
+        use std::os::windows::io::AsRawHandle;
+        use winapi::shared::minwindef::DWORD;
+        use winapi::um::fileapi::LockFileEx;
+        use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, OVERLAPPED};
+
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+
+        let handle = file.as_raw_handle();
+        let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+
+        let result = unsafe {
+            LockFileEx(
+                handle as _,
+                LOCKFILE_EXCLUSIVE_LOCK,
+                0,
+                1 as DWORD,
+                0,
+                &mut overlapped,
+            )
+        };
+
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self { _file: file })
+    }
+
+    #[cfg(not(windows))]
+    fn acquire(path: &std::path::Path) -> Result<Self, io::Error> {
+        // On non-Windows, just open the file — no real locking needed for stubs
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+        Ok(Self { _file: file })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_state_is_empty() {
+        let state = TmuxState::default();
+        assert!(state.sessions.is_empty());
+        assert!(state.panes.is_empty());
+        assert_eq!(state.next_pane_id, 0);
+    }
+
+    #[test]
+    fn allocate_pane_id_increments() {
+        let mut state = TmuxState::default();
+        let id1 = state.allocate_pane_id("term-1".to_string(), "sess".to_string());
+        let id2 = state.allocate_pane_id("term-2".to_string(), "sess".to_string());
+        assert_eq!(id1, "%0");
+        assert_eq!(id2, "%1");
+        assert_eq!(state.next_pane_id, 2);
+    }
+
+    #[test]
+    fn session_panes_filters_correctly() {
+        let mut state = TmuxState::default();
+        state.allocate_pane_id("t1".to_string(), "sess-a".to_string());
+        state.allocate_pane_id("t2".to_string(), "sess-b".to_string());
+        state.allocate_pane_id("t3".to_string(), "sess-a".to_string());
+
+        let panes_a = state.session_panes("sess-a");
+        assert_eq!(panes_a.len(), 2);
+        assert!(panes_a.contains(&"%0".to_string()));
+        assert!(panes_a.contains(&"%2".to_string()));
+
+        let panes_b = state.session_panes("sess-b");
+        assert_eq!(panes_b.len(), 1);
+        assert!(panes_b.contains(&"%1".to_string()));
+    }
+
+    #[test]
+    fn remove_session_cleans_panes() {
+        let mut state = TmuxState::default();
+        state.sessions.insert(
+            "sess-a".to_string(),
+            SessionMapping {
+                workspace_id: "ws-1".to_string(),
+            },
+        );
+        state.allocate_pane_id("t1".to_string(), "sess-a".to_string());
+        state.allocate_pane_id("t2".to_string(), "sess-b".to_string());
+
+        state.remove_session("sess-a");
+
+        assert!(!state.sessions.contains_key("sess-a"));
+        assert_eq!(state.panes.len(), 1);
+        assert!(state.panes.contains_key("%1"));
+    }
+
+    #[test]
+    fn state_roundtrip_json() {
+        let mut state = TmuxState::default();
+        state.sessions.insert(
+            "work".to_string(),
+            SessionMapping {
+                workspace_id: "uuid-123".to_string(),
+            },
+        );
+        state.allocate_pane_id("term-abc".to_string(), "work".to_string());
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: TmuxState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.sessions.len(), 1);
+        assert_eq!(restored.sessions["work"].workspace_id, "uuid-123");
+        assert_eq!(restored.panes.len(), 1);
+        assert_eq!(restored.panes["%0"].terminal_id, "term-abc");
+        assert_eq!(restored.panes["%0"].session, "work");
+        assert_eq!(restored.next_pane_id, 1);
+    }
+
+    #[test]
+    fn load_nonexistent_returns_default() {
+        // This test relies on a non-existent path; we just verify the default state behavior
+        let state = TmuxState::default();
+        assert!(state.sessions.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `godly-tmux-shim` binary crate (`src-tauri/tmux-shim/`) that intercepts tmux CLI commands and translates them to Godly Terminal operations via named pipes, enabling Claude Code agent teams support
- Implements session lifecycle commands (new-session, has-session, kill-session, list-sessions) with persistent state file and LockFileEx-based concurrency
- Includes MCP/daemon pipe clients, tmux CLI arg parser, format string expansion, and stubs for pane/io commands (follow-up units)

## Test plan
- [ ] CI passes `cargo check -p godly-tmux-shim` and `cargo test -p godly-tmux-shim`
- [ ] Unit tests pass for CLI parser (combined flags, value flags, positional args)
- [ ] Unit tests pass for state management (pane ID allocation, session removal, JSON roundtrip)
- [ ] Unit tests pass for format string expansion
- [ ] Verify binary builds as `tmux.exe` and responds to `-V` with `tmux 3.4`