### PR TITLE
fix: prevent Cloudflare settings from disappearing on click

### DIFF
--- a/changelog/unreleased/826-cloudflare-settings-disappear.md
+++ b/changelog/unreleased/826-cloudflare-settings-disappear.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Cloudflare settings disappear on click** — wrap settings dialog in two-layer `mouse_area` widgets to prevent mouse events from leaking through the `stack!` overlay to main content, and add `scrollable` to Remote tab so Cloudflare Tunnel fields don't clip (#826)

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -59,7 +59,8 @@ pub mod diag {
 use futures_channel::mpsc;
 use iced::keyboard;
 use iced::widget::{
-    button, canvas, center, column, container, mouse_area, row, stack, text, text_input, Space,
+    button, canvas, center, column, container, mouse_area, row, scrollable, stack, text,
+    text_input, Space,
 };
 use iced::{
     event, window, Color, Element, Font, Length, Padding, Point, Shadow, Subscription, Task, Vector,
@@ -5341,7 +5342,7 @@ impl GodlyApp {
     /// Render the Appearance tab (theme selection grid with preview swatches).
     fn view_appearance_tab(&self) -> Element<'_, Message> {
         use crate::theme::{ThemeId, RADIUS_MD};
-        use iced::widget::{button, row, scrollable, text, text_input, Space};
+        use iced::widget::{button, row, text, text_input, Space};
         use iced::Theme;
 
         // -- Font section --
@@ -6905,7 +6906,7 @@ impl GodlyApp {
             );
         }
 
-        container(content).width(Length::Fill).into()
+        scrollable(content).height(Length::Fill).into()
     }
 
     fn view_claude_code_tab(&self) -> Element<'_, Message> {

--- a/src-tauri/native/iced-shell/src/settings_dialog.rs
+++ b/src-tauri/native/iced-shell/src/settings_dialog.rs
@@ -1,8 +1,8 @@
-use iced::widget::{button, center, column, container, row, scrollable, text, Space};
+use iced::widget::{button, center, column, container, mouse_area, row, scrollable, text, Space};
 use iced::{Background, Border, Color, Element, Length, Padding, Shadow, Vector};
 
 use crate::theme::{
-    BACKDROP, BORDER_FOCUSED, BORDER_VARIANT, BG_PRIMARY, BG_SECONDARY, GHOST_HOVER,
+    BACKDROP, BG_PRIMARY, BG_SECONDARY, BORDER_FOCUSED, BORDER_VARIANT, GHOST_HOVER,
     GHOST_SELECTED, RADIUS_LG, RADIUS_MD, RADIUS_SM, SURFACE_BG, TEXT_PRIMARY, TEXT_SECONDARY,
 };
 
@@ -102,8 +102,12 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
     }
 
     // Header: "Settings" title + close button
+    // Generate a no-op message for absorbing clicks on non-interactive dialog areas.
+    // Re-selecting the current tab is harmless and prevents event propagation.
+    let noop = on_tab_click(active_tab.to_string());
+
     let close_btn = button(text("\u{2715}").size(15))
-        .on_press(on_close)
+        .on_press(on_close.clone())
         .padding(Padding::from([4, 8]))
         .style(|_theme, status| {
             let (bg, text_color) = match status {
@@ -213,15 +217,21 @@ pub fn view_settings_dialog<'a, M: Clone + 'a>(
             ..container::Style::default()
         });
 
-    // Backdrop + centered dialog
-    container(center(dialog))
+    // Inner mouse_area absorbs clicks on non-interactive parts of the dialog
+    // (text labels, gaps) so they don't leak through the stack to main content.
+    let dialog = mouse_area(dialog).on_press(noop);
+
+    // Outer mouse_area captures backdrop clicks (outside the dialog) to dismiss,
+    // and prevents ALL mouse events from propagating through the stack.
+    let backdrop = container(center(dialog))
         .width(Length::Fill)
         .height(Length::Fill)
         .style(|_theme| container::Style {
             background: Some(Background::Color(tint(BACKDROP(), 0.35))),
             ..container::Style::default()
-        })
-        .into()
+        });
+
+    mouse_area(backdrop).on_press(on_close).into()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Wrap the settings dialog in two-layer `mouse_area` widgets to prevent mouse events from leaking through the `stack!` overlay to main content underneath. Inner layer absorbs clicks on non-interactive dialog areas (text labels, gaps); outer layer captures backdrop clicks to dismiss.
- Add `scrollable` wrapper to the Remote tab content so Cloudflare Tunnel fields don't get clipped when Named Tunnel mode adds extra form fields.

Fixes #826

## Test plan
- [ ] Open Settings → Remote with cloudflared installed
- [ ] Double-click the "Cloudflare Tunnel" section title — settings should remain visible
- [ ] Click "Named Tunnel" mode button — additional fields appear, scrollable if they overflow
- [ ] Click backdrop (outside dialog) — settings dialog dismisses
- [ ] Verify all buttons/inputs inside dialog still work normally