### PR TITLE
fix: run critcmp from src-tauri so it finds Criterion baselines

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,7 +55,9 @@ jobs:
           cargo bench -p godly-vt --bench throughput -- --save-baseline base 2>/dev/null || true
 
       - name: Compare benchmarks
-        run: critcmp base pr --threshold 15 | tee /tmp/bench-comparison.txt
+        run: |
+          cd src-tauri
+          critcmp base pr --threshold 15 | tee /tmp/bench-comparison.txt
 
       - name: Post benchmark results as PR comment
         if: always()


### PR DESCRIPTION
## Summary
- `cargo bench` runs from `src-tauri/`, saving baselines under `src-tauri/target/criterion/`
- `critcmp` was running from the repo root and couldn't find them, resulting in empty benchmark PR comments
- Fix: `cd src-tauri` before running `critcmp`

## Test plan
- [ ] Verify next PR touching `terminal-surface/` gets a benchmark comment with actual data