### PR TITLE
fix: deploy tmux shim and guard TMUX env vars

### DIFF
--- a/changelog/unreleased/fix-tmux-shim-deploy.md
+++ b/changelog/unreleased/fix-tmux-shim-deploy.md
@@ -1,0 +1,5 @@
+### Fixed
+- **tmux shim not deployed** — `tmux.exe` was missing from the build pipeline and installer, causing Claude Code's Agent Teams to fail with "Could not determine current tmux pane/window". Added the shim to `production-build.ps1`, WiX manifest, and `unlock-binaries.js`.
+- **TMUX env vars set without shim** — The daemon unconditionally set `TMUX` and `TMUX_PANE` even when `tmux.exe` didn't exist, tricking Claude Code into trying tmux commands that would fail. Now only sets these when the shim binary is present.
+- **Missing tmux command handlers** — Added no-op handlers for cosmetic tmux commands (`set-option`, `select-layout`, `resize-pane`, etc.) that Claude Code's TmuxBackend calls, preventing spurious error exit codes.
+- **CLI parsing for `-l` and `-T` flags** — Added size (`-l`) and title (`-T`) to the tmux shim's value flags so `split-window -l 70%` and `select-pane -T name` parse correctly.

--- a/scripts/production-build.ps1
+++ b/scripts/production-build.ps1
@@ -38,7 +38,8 @@ $crates = @(
     "godly-mcp",
     "godly-notify",
     "godly-remote",
-    "godly-iced-shell"
+    "godly-iced-shell",
+    "godly-tmux-shim"
 )
 
 foreach ($crate in $crates) {

--- a/scripts/unlock-binaries.js
+++ b/scripts/unlock-binaries.js
@@ -5,9 +5,9 @@
 import { mkdir, rename, unlink, writeFile, stat } from 'fs/promises';
 import { join } from 'path';
 
-const BINARIES = ['godly-daemon.exe', 'godly-mcp.exe', 'godly-notify.exe', 'godly-terminal.exe', 'godly-native.exe'];
+const BINARIES = ['godly-daemon.exe', 'godly-mcp.exe', 'godly-notify.exe', 'godly-terminal.exe', 'godly-native.exe', 'tmux.exe'];
 // Binaries referenced in tauri.conf.json bundle.resources (release profile only)
-const RESOURCE_BINARIES = ['godly-daemon.exe', 'godly-mcp.exe', 'godly-notify.exe', 'godly-native.exe'];
+const RESOURCE_BINARIES = ['godly-daemon.exe', 'godly-mcp.exe', 'godly-notify.exe', 'godly-native.exe', 'tmux.exe'];
 const TARGET_DIR = join(import.meta.dirname, '..', 'src-tauri', 'target');
 // Only unlock the requested profile. Default to 'debug' to avoid destroying
 // release binaries that Tauri's build.rs needs for resource path validation.

--- a/src-tauri/daemon/src/shim_client.rs
+++ b/src-tauri/daemon/src/shim_client.rs
@@ -49,16 +49,19 @@ pub fn spawn_shim(
         cmd.env("GODLY_INSTANCE", &instance);
     }
 
-    // TMUX compat: set env vars so tools like Claude Code detect a tmux-like environment.
-    // Format matches tmux's $TMUX: <socket_path>,<server_pid>,<session_index>
-    cmd.env("TMUX", format!("/tmp/godly-tmux,{},0", std::process::id()));
-    cmd.env("TMUX_PANE", "%0");
-
-    // Prepend the directory containing our tmux shim to PATH so that `tmux`
-    // resolves to our shim binary instead of a system-installed tmux.
+    // TMUX compat: set env vars so tools like Claude Code detect a tmux-like environment,
+    // but ONLY if our tmux shim binary is available. Setting TMUX without a working
+    // `tmux` command causes Claude Code to fail with "Could not determine current
+    // tmux pane/window" because it tries to run tmux commands that don't exist.
     if let Ok(exe_path) = std::env::current_exe() {
         if let Some(exe_dir) = exe_path.parent() {
             if exe_dir.join("tmux.exe").exists() {
+                // Format matches tmux's $TMUX: <socket_path>,<server_pid>,<session_index>
+                cmd.env("TMUX", format!("/tmp/godly-tmux,{},0", std::process::id()));
+                cmd.env("TMUX_PANE", "%0");
+
+                // Prepend the directory containing our tmux shim to PATH so that
+                // `tmux` resolves to our shim binary instead of a system-installed tmux.
                 if let Some(current_path) = std::env::var_os("PATH") {
                     let mut new_path = exe_dir.as_os_str().to_os_string();
                     new_path.push(";");

--- a/src-tauri/tmux-shim/src/cli.rs
+++ b/src-tauri/tmux-shim/src/cli.rs
@@ -40,7 +40,7 @@ pub struct TmuxArgs {
 
 impl TmuxArgs {
     /// Flags that take a value argument.
-    const VALUE_FLAGS: &[char] = &['s', 't', 'F', 'c', 'x', 'y', 'f', 'n', 'e'];
+    const VALUE_FLAGS: &[char] = &['s', 't', 'F', 'c', 'x', 'y', 'f', 'n', 'e', 'l', 'T'];
 
     /// Parse tmux-style arguments from a slice of strings.
     pub fn parse(args: &[String]) -> Self {

--- a/src-tauri/tmux-shim/src/main.rs
+++ b/src-tauri/tmux-shim/src/main.rs
@@ -43,6 +43,18 @@ fn main() {
             "display-message" | "display" => commands::io::handle("display-message", &args[2..]),
             "capture-pane" | "capturep" => commands::io::handle("capture-pane", &args[2..]),
 
+            // No-op commands: these are used by Claude Code's TmuxBackend for
+            // cosmetic/layout purposes. We accept them silently to avoid error
+            // exit codes that could abort the agent team workflow.
+            "set-option" | "set" => 0,
+            "select-layout" | "selectl" => 0,
+            "resize-pane" | "resizep" => 0,
+            "new-window" | "neww" => 0,
+            "break-pane" | "breakp" => 0,
+            "join-pane" | "joinp" => 0,
+            "switch-client" | "switchc" => 0,
+            "show-options" | "show" => 0,
+
             unknown => {
                 eprintln!("tmux: unknown command: {}", unknown);
                 1

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -110,6 +110,13 @@
                     KeyPath='yes' />
             </Component>
 
+            <Component Id='TmuxShimBinary' Guid='A1B2C3D4-1111-2222-3333-44445555FF22'>
+                <File Id='TmuxShimEXE'
+                    Name='tmux.exe'
+                    Source='src-tauri\target\release\tmux.exe'
+                    KeyPath='yes' />
+            </Component>
+
             <Component Id='IconFile' Guid='A1B2C3D4-1111-2222-3333-44445555CCCC'>
                 <File Id='AppIcon'
                     Name='icon.ico'
@@ -210,6 +217,7 @@
             <ComponentRef Id='NotifyBinary' />
             <ComponentRef Id='PtyShimBinary' />
             <ComponentRef Id='RemoteBinary' />
+            <ComponentRef Id='TmuxShimBinary' />
             <ComponentRef Id='IconFile' />
             <ComponentRef Id='SoundFiles' />
             <ComponentRef Id='DefaultSoundpack' />


### PR DESCRIPTION
## Summary

- **Root cause**: `tmux.exe` (the tmux shim) was never included in the build pipeline or WiX installer. The daemon set `TMUX`/`TMUX_PANE` env vars unconditionally, so Claude Code detected tmux, tried running `tmux display-message`, got "command not found", and errored with "Could not determine current tmux pane/window".

- **Build pipeline**: Added `godly-tmux-shim` to `production-build.ps1`, WiX manifest, and `unlock-binaries.js` so `tmux.exe` ships alongside `godly-daemon.exe`.

- **Defensive guard**: Moved `TMUX`/`TMUX_PANE` env setup inside the `tmux.exe` existence check — if the shim isn't present, Claude Code falls back to its in-process agent backend instead of crashing.

- **No-op command handlers**: Added silent success (exit 0) for cosmetic tmux commands Claude Code calls (`set-option`, `select-layout`, `resize-pane`, `show-options`, etc.) to avoid spurious failures.

- **CLI flag fix**: Added `-l` (pane size) and `-T` (pane title) to VALUE_FLAGS so `split-window -l 70%` parses correctly.

## Test plan
- [ ] Build with `production-build.ps1` — verify `tmux.exe` appears in `target/release/`
- [ ] Install via MSI — verify `tmux.exe` exists in `AppData\Local\Godly Terminal\`
- [ ] Open Godly Terminal, run `echo $TMUX` — should be set (e.g. `/tmp/godly-tmux,<pid>,0`)
- [ ] Run `which tmux` — should resolve to Godly Terminal's install dir
- [ ] Run `tmux -V` — should print `tmux 3.4`
- [ ] Ask Claude Code to spawn agent teams — should create split panes instead of erroring