### PR TITLE
fix: resolve DPI double-scaling and image sizing in pixel renderer

### DIFF
--- a/changelog/unreleased/fix-841-dpi-double-scaling.md
+++ b/changelog/unreleased/fix-841-dpi-double-scaling.md
@@ -1,0 +1,3 @@
+### Fixed
+- **DPI double-scaling in DirectWrite renderer** — Glyphs were rasterized at `font_size * scale_factor²` because the pixel renderer already passes physical-pixel font sizes but `CreateGlyphRunAnalysis` applied `pixelsPerDip` again. Fixed by using `pixelsPerDip = 1.0`.
+- **Pixel buffer displayed at wrong size** — The physical-pixel image buffer was displayed with `ContentFit::None`, causing iced to treat physical dimensions as logical pixels (1.5× too large at 150% DPI). Changed to `ContentFit::Fill` for correct physical-to-logical mapping.

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -732,7 +732,8 @@ impl Default for GodlyApp {
                                     DEFAULT_FONT_FAMILY
                                 );
                                 let mut r =
-                                    godly_terminal_surface::swash_rasterizer::SwashRasterizer::new();
+                                    godly_terminal_surface::swash_rasterizer::SwashRasterizer::new(
+                                    );
                                 r.load_font(include_bytes!("../fonts/GeistMono-Regular.ttf"), 0);
                                 Box::new(r)
                             }
@@ -9984,7 +9985,7 @@ impl GodlyApp {
                 let img = iced::widget::image::Image::new(handle.clone())
                     .width(Length::Fill)
                     .height(Length::Fill)
-                    .content_fit(iced::ContentFit::None)
+                    .content_fit(iced::ContentFit::Fill)
                     .filter_method(iced::widget::image::FilterMethod::Nearest);
                 column![accent_bar, img]
             } else {

--- a/src-tauri/native/terminal-surface/src/directwrite_rasterizer.rs
+++ b/src-tauri/native/terminal-surface/src/directwrite_rasterizer.rs
@@ -52,17 +52,10 @@ pub struct DirectWriteRasterizer {
     /// Stored for future ClearType subpixel blending (`GetAlphaBlendParams`).
     #[allow(dead_code)]
     rendering_params: IDWriteRenderingParams,
-    /// DPI scale factor (pixels per DIP). At 100% scaling this is 1.0;
-    /// at 150% it is 1.5, etc. Passed to `CreateGlyphRunAnalysis` so that
-    /// DirectWrite rasterizes glyphs at the physical pixel resolution.
-    scale_factor: f32,
 }
 
 impl DirectWriteRasterizer {
     /// Create a new rasterizer, initializing the DirectWrite factory.
-    ///
-    /// The DPI scale factor defaults to 1.0. Call [`set_scale_factor`] to
-    /// update it when the window's DPI changes.
     pub fn new() -> windows::core::Result<Self> {
         unsafe {
             let factory: IDWriteFactory = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
@@ -75,20 +68,17 @@ impl DirectWriteRasterizer {
                 bold_italic_face: None,
                 font_family_name: String::new(),
                 rendering_params,
-                scale_factor: 1.0,
             })
         }
     }
 
-    /// Update the DPI scale factor (pixels per DIP).
+    /// Update the DPI scale factor.
     ///
-    /// This should be called whenever the window moves to a display with a
-    /// different DPI. After changing the scale factor the caller should
-    /// invalidate the glyph cache, since cached bitmaps were rasterized at
-    /// the old DPI.
-    pub fn set_scale_factor(&mut self, scale_factor: f32) {
-        self.scale_factor = scale_factor;
-    }
+    /// No-op: the pixel renderer already passes physical-pixel font sizes,
+    /// so DirectWrite uses `pixelsPerDip = 1.0`. The caller should still
+    /// invalidate the glyph cache after DPI changes, since cached bitmaps
+    /// were rasterized at the old physical size.
+    pub fn set_scale_factor(&mut self, _scale_factor: f32) {}
 
     /// Select the appropriate font face for the given bold/italic combination.
     ///
@@ -233,7 +223,7 @@ impl DirectWriteRasterizer {
 
             let analysis = self.factory.CreateGlyphRunAnalysis(
                 &glyph_run,
-                self.scale_factor, // pixels per DIP — actual OS scale factor
+                1.0, // font_size_px is already in physical pixels (scaled by pixel_renderer)
                 None,
                 DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
                 DWRITE_MEASURING_MODE_NATURAL,
@@ -381,10 +371,6 @@ impl GlyphRasterizer for DirectWriteRasterizer {
             }
             glyph_indices[0] != 0
         }
-    }
-
-    fn set_scale_factor(&mut self, scale: f32) {
-        self.scale_factor = scale;
     }
 }
 


### PR DESCRIPTION
## Summary
- **Double DPI scaling**: The pixel renderer already scales `font_size` by `scale_factor` before calling `rasterize()`, but DirectWrite's `CreateGlyphRunAnalysis` applied `scale_factor` again via `pixelsPerDip`. At 150% DPI, glyphs were 2.25× too large. Fixed by using `pixelsPerDip = 1.0`.
- **Image oversized in viewport**: The physical-pixel buffer was displayed with `ContentFit::None`, which treats pixel dimensions as logical pixels — making the image 1.5× too large at 150% DPI. Changed to `ContentFit::Fill` so the physical buffer maps 1:1 to physical screen pixels.
- Removed dead `scale_factor` field and trait override from `DirectWriteRasterizer`.

## Test plan
- [ ] Build succeeds in CI
- [ ] Terminal renders correctly at 150% DPI (2560×1440 display)
- [ ] No screen blinking on text updates
- [ ] Text stays within viewport bounds
- [ ] Text quality remains crisp (ClearType subpixel rendering intact)
- [ ] Works at 100% DPI (no regression)

refs #841