### PR TITLE
fix: move toast notifications from center-top to bottom-right

### DIFF
--- a/changelog/unreleased/fix-toast-notification-position.md
+++ b/changelog/unreleased/fix-toast-notification-position.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Toast notification position** - Moved toast notifications from center-top (overlapping the tab bar) to bottom-right corner above the status bar, following standard UX conventions

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -6084,9 +6084,14 @@ impl GodlyApp {
         container(toasts_column)
             .width(Length::Fill)
             .height(Length::Fill)
-            .align_x(iced::alignment::Horizontal::Center)
-            .align_y(iced::alignment::Vertical::Top)
-            .padding(Padding::from([20, 0]))
+            .align_x(iced::alignment::Horizontal::Right)
+            .align_y(iced::alignment::Vertical::Bottom)
+            .padding(Padding {
+                top: 0.0,
+                right: 16.0,
+                bottom: status_bar::STATUS_BAR_HEIGHT + 12.0,
+                left: 0.0,
+            })
             .into()
     }
 


### PR DESCRIPTION
## Summary

- Repositioned toast notifications from center-top (overlapping the tab bar) to bottom-right corner
- Toasts now appear 12px above the status bar with 16px right margin
- Follows the standard toast UX convention (VS Code, macOS, Windows notifications)

## Context

The toast popup (e.g. "Quick Claude — Launching in background...") was rendered with center-horizontal + top-vertical alignment and 20px top padding, placing it directly on top of the tab bar and obscuring tabs.

## Test plan

- [ ] Trigger a toast notification (e.g. launch Quick Claude in background)
- [ ] Verify toast appears in the bottom-right corner, above the status bar
- [ ] Verify toast doesn't overlap tabs, sidebar, or terminal content
- [ ] Verify multiple stacked toasts render correctly in the new position
- [ ] Verify click-to-focus and dismiss still work