### PR TITLE
fix: Shader widget for blink-free pixel rendering (#845)

### DIFF
--- a/changelog/unreleased/845-fix-delayed-screen-refresh.md
+++ b/changelog/unreleased/845-fix-delayed-screen-refresh.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- **Delayed screen refresh / micro-blinking** — Fixed two issues causing visual instability: (1) render throttle now applies universally to all pixel renders (heartbeat-driven fetches every 16ms were completely unthrottled, causing 60fps texture churn); (2) heartbeat recovery polls now skip terminals fetched within the last 200ms to avoid adding extra renders during continuous output. Pixel render rate capped at ~20fps during active output. (#845)
+- **Terminal blinking eliminated** — Replaced `Image` widget with custom `Shader` widget for pixel-rendered terminal content. The root cause was `Handle::from_rgba()` creating a new Iced image handle ID on every render, forcing GPU texture allocation/swap/deallocation per frame. The Shader widget creates one persistent `wgpu::Texture` and updates pixels in-place via `queue.write_texture()` — zero handle churn, zero texture swap, zero blink. (#845)

--- a/src-tauri/native/iced-shell/src/app.rs
+++ b/src-tauri/native/iced-shell/src/app.rs
@@ -2153,23 +2153,11 @@ impl GodlyApp {
                     self.persist_scrollback_offsets();
                 }
                 if self.use_pixel_renderer && should_render {
-                    // Throttle ALL pixel renders to ~20fps to prevent
-                    // micro-blinking from rapid texture swaps.  The previous
-                    // throttle only applied when should_refetch=true, which
-                    // left heartbeat-driven renders (every 16ms) completely
-                    // unthrottled — any minor fingerprint change (cursor
-                    // blink, etc.) caused 60fps texture churn.
-                    let throttled = self
-                        .terminals
-                        .get(&session_id)
-                        .and_then(|t| t.last_render_at)
-                        .map_or(false, |t| t.elapsed().as_millis() < 50);
-                    if !throttled {
-                        self.render_terminal_image(&session_id);
-                        if let Some(term) = self.terminals.get_mut(&session_id) {
-                            term.last_render_at = Some(std::time::Instant::now());
-                        }
-                    }
+                    // With the Shader widget, pixel renders update the GPU
+                    // texture in-place (queue.write_texture) — no Handle ID
+                    // churn, so no blink.  The fingerprint check above is
+                    // sufficient to avoid redundant CPU work.
+                    self.render_terminal_image(&session_id);
                 }
                 if should_refetch {
                     return self.fetch_grid(&session_id);
@@ -4362,32 +4350,18 @@ impl GodlyApp {
                         }
                     }
                     // Recovery grid poll: safety net for when the daemon event
-                    // subscription is flaky or delayed.  Only poll terminals
-                    // that haven't been fetched recently (>200ms) to avoid
-                    // adding extra grid fetches during continuous output,
-                    // which bypass the render throttle and cause blinking.
+                    // subscription is flaky or delayed.  The `fetching` guard
+                    // in fetch_grid() prevents concurrent fetches.  With the
+                    // Shader widget, extra grid fetches no longer cause
+                    // blinking (in-place texture update, no Handle churn).
                     if is_actually_focused && self.client.is_some() {
-                        let now = std::time::Instant::now();
-                        let ids: Vec<String> = self
-                            .terminals
-                            .iter()
-                            .filter(|t| {
-                                !t.fetching
-                                    && t.last_render_at
-                                        .map_or(true, |lr| now.duration_since(lr).as_millis() > 200)
-                            })
-                            .map(|t| t.id.clone())
-                            .collect();
-                        if !ids.is_empty() {
-                            diag::log(&format!(
-                                "HEARTBEAT: recovery grid poll ({} idle terminals)",
-                                ids.len()
-                            ));
-                            let tasks: Vec<Task<Message>> =
-                                ids.into_iter().map(|id| self.fetch_grid(&id)).collect();
-                            if !tasks.is_empty() {
-                                return Task::batch(tasks);
-                            }
+                        diag::log("HEARTBEAT: recovery grid poll");
+                        let ids: Vec<String> =
+                            self.terminals.iter().map(|t| t.id.clone()).collect();
+                        let tasks: Vec<Task<Message>> =
+                            ids.into_iter().map(|id| self.fetch_grid(&id)).collect();
+                        if !tasks.is_empty() {
+                            return Task::batch(tasks);
                         }
                     }
                 }
@@ -9992,9 +9966,13 @@ impl GodlyApp {
         );
 
         if w > 0 && h > 0 {
-            let handle = iced::widget::image::Handle::from_rgba(w, h, pixels.to_vec());
             if let Some(term) = self.terminals.get_mut(session_id) {
-                term.cached_image_handle = Some(handle);
+                term.cached_pixels =
+                    Some(godly_terminal_surface::shader_surface::CachedPixelBuffer {
+                        pixels: pixels.to_vec(),
+                        width: w,
+                        height: h,
+                    });
             }
         }
 
@@ -10237,17 +10215,21 @@ impl GodlyApp {
             ..container::Style::default()
         });
 
-        // Choose between pixel-rendered Image and canvas-based rendering.
+        // Choose between shader-rendered pixel surface and canvas-based rendering.
         let inner = if self.use_pixel_renderer {
-            if let Some(handle) = &term.cached_image_handle {
-                let img = iced::widget::image::Image::new(handle.clone())
+            if let Some(buf) = &term.cached_pixels {
+                let shader_prog =
+                    godly_terminal_surface::shader_surface::TerminalShaderProgram {
+                        pixels: buf.pixels.clone(),
+                        width: buf.width,
+                        height: buf.height,
+                    };
+                let shader_widget = iced::widget::Shader::new(shader_prog)
                     .width(Length::Fill)
-                    .height(Length::Fill)
-                    .content_fit(iced::ContentFit::Fill)
-                    .filter_method(iced::widget::image::FilterMethod::Nearest);
-                column![accent_bar, img]
+                    .height(Length::Fill);
+                column![accent_bar, shader_widget]
             } else {
-                // No cached handle yet — fall back to canvas
+                // No cached pixels yet — fall back to canvas
                 column![
                     accent_bar,
                     canvas(tc).width(Length::Fill).height(Length::Fill),

--- a/src-tauri/native/iced-shell/src/tab_bar.rs
+++ b/src-tauri/native/iced-shell/src/tab_bar.rs
@@ -421,7 +421,6 @@ mod tests {
             dirty: false,
             fetching: false,
             needs_refetch: false,
-            last_render_at: None,
             rows: 24,
             cols: 80,
             exited: false,
@@ -432,7 +431,7 @@ mod tests {
             custom_name: None,
             worktree_path: None,
             is_clone: false,
-            cached_image_handle: None,
+            cached_pixels: None,
             last_grid_fingerprint: None,
         }
     }

--- a/src-tauri/native/iced-shell/src/terminal_state.rs
+++ b/src-tauri/native/iced-shell/src/terminal_state.rs
@@ -16,10 +16,6 @@ pub struct TerminalInfo {
     /// in-flight. After `GridFetched` completes, this flag triggers a follow-up
     /// fetch so the coalesced output is not lost (prevents micro-blinking).
     pub needs_refetch: bool,
-    /// Timestamp of the last pixel render. Used to throttle renders to ~33fps
-    /// during continuous output, preventing micro-blinking from rapid texture swaps
-    /// while keeping the terminal responsive.
-    pub last_render_at: Option<std::time::Instant>,
     pub rows: u16,
     pub cols: u16,
     pub exited: bool,
@@ -36,8 +32,8 @@ pub struct TerminalInfo {
     pub worktree_path: Option<String>,
     /// Whether this terminal's worktree_path points to a clone (true) or a git worktree (false).
     pub is_clone: bool,
-    /// Cached image handle for the pixel-rendered terminal (None = needs render).
-    pub cached_image_handle: Option<iced::widget::image::Handle>,
+    /// Cached pixel buffer for the shader-rendered terminal (None = needs render).
+    pub cached_pixels: Option<godly_terminal_surface::shader_surface::CachedPixelBuffer>,
     /// Fingerprint of the last rendered grid state. Used to skip redundant
     /// pixel renders when the grid content has not changed (e.g. heartbeat
     /// recovery polls fetching an identical snapshot).
@@ -373,7 +369,6 @@ impl TerminalCollection {
                 dirty: false,
                 fetching: false,
                 needs_refetch: false,
-                last_render_at: None,
                 rows,
                 cols,
                 exited: false,
@@ -384,7 +379,7 @@ impl TerminalCollection {
                 custom_name: None,
                 worktree_path: None,
                 is_clone: false,
-                cached_image_handle: None,
+                cached_pixels: None,
                 last_grid_fingerprint: None,
             },
         );

--- a/src-tauri/native/terminal-surface/Cargo.toml
+++ b/src-tauri/native/terminal-surface/Cargo.toml
@@ -7,6 +7,7 @@ description = "Custom Iced widget for rendering terminal grid via wgpu"
 
 [dependencies]
 iced.workspace = true
+wgpu = "27"
 godly-protocol = { path = "../../protocol" }
 log = "0.4"
 swash = "0.2"

--- a/src-tauri/native/terminal-surface/src/lib.rs
+++ b/src-tauri/native/terminal-surface/src/lib.rs
@@ -7,6 +7,7 @@ pub mod glyph_cache;
 pub mod glyph_rasterizer;
 pub mod pixel_renderer;
 pub mod render_stats;
+pub mod shader_surface;
 mod surface;
 pub mod swash_rasterizer;
 

--- a/src-tauri/native/terminal-surface/src/shader_surface.rs
+++ b/src-tauri/native/terminal-surface/src/shader_surface.rs
@@ -1,0 +1,314 @@
+//! Shader-based terminal rendering surface.
+//!
+//! Uses Iced's `Shader` widget with a persistent `wgpu::Texture` that is
+//! updated in-place via `queue.write_texture()`.  This eliminates the
+//! per-frame GPU texture churn caused by `Handle::from_rgba()` (which
+//! creates a new Iced image handle ID on every call, forcing a full
+//! texture upload -> swap -> deallocation cycle that produces visible
+//! blinking).
+
+use iced::widget::shader;
+use iced::{mouse, Rectangle};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Cached pixel buffer stored on `TerminalInfo`.
+#[derive(Debug, Clone)]
+pub struct CachedPixelBuffer {
+    pub pixels: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Per-frame pixel data carrier passed from `Program::draw()` to the GPU.
+#[derive(Debug)]
+pub struct TerminalPrimitive {
+    pixels: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+/// Shader-based terminal surface.  Pass to `iced::widget::Shader::new()`.
+pub struct TerminalShaderProgram {
+    pub pixels: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
+// ---------------------------------------------------------------------------
+// WGSL shader — fullscreen textured quad
+// ---------------------------------------------------------------------------
+
+const SHADER_SRC: &str = r#"
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VertexOutput {
+    let x = f32(idx & 1u) * 2.0 - 1.0;
+    let y = f32((idx >> 1u) & 1u) * 2.0 - 1.0;
+    var out: VertexOutput;
+    out.position = vec4<f32>(x, -y, 0.0, 1.0);
+    out.uv = vec2<f32>(f32(idx & 1u), f32((idx >> 1u) & 1u));
+    return out;
+}
+
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(tex, samp, in.uv);
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Pipeline — persistent GPU resources (created once, stored in Iced's Storage)
+// ---------------------------------------------------------------------------
+
+pub struct TerminalPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    texture: wgpu::Texture,
+    #[allow(dead_code)]
+    texture_view: wgpu::TextureView,
+    bind_group: wgpu::BindGroup,
+    current_size: (u32, u32),
+}
+
+impl TerminalPipeline {
+    fn create_texture(
+        device: &wgpu::Device,
+        layout: &wgpu::BindGroupLayout,
+        sampler: &wgpu::Sampler,
+        width: u32,
+        height: u32,
+    ) -> (wgpu::Texture, wgpu::TextureView, wgpu::BindGroup) {
+        let w = width.max(1);
+        let h = height.max(1);
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("terminal_shader_texture"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("terminal_shader_bg"),
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+        });
+        (texture, view, bind_group)
+    }
+}
+
+impl shader::Pipeline for TerminalPipeline {
+    fn new(
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+    ) -> Self {
+        let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("terminal_shader"),
+            source: wgpu::ShaderSource::Wgsl(SHADER_SRC.into()),
+        });
+
+        let bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("terminal_shader_bgl"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("terminal_shader_pl"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let render_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("terminal_shader_rp"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader_module,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    unclipped_depth: false,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader_module,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                multiview: None,
+                cache: None,
+            });
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("terminal_shader_sampler"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        // 1x1 placeholder — resized on first prepare().
+        let (texture, texture_view, bind_group) =
+            Self::create_texture(device, &bind_group_layout, &sampler, 1, 1);
+
+        Self {
+            render_pipeline,
+            bind_group_layout,
+            sampler,
+            texture,
+            texture_view,
+            bind_group,
+            current_size: (1, 1),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Primitive impl — per-frame GPU work
+// ---------------------------------------------------------------------------
+
+impl shader::Primitive for TerminalPrimitive {
+    type Pipeline = TerminalPipeline;
+
+    fn prepare(
+        &self,
+        pipeline: &mut Self::Pipeline,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        _bounds: &Rectangle,
+        _viewport: &shader::Viewport,
+    ) {
+        let target = (self.width, self.height);
+        if target != pipeline.current_size && self.width > 0 && self.height > 0 {
+            let (tex, view, bg) = TerminalPipeline::create_texture(
+                device,
+                &pipeline.bind_group_layout,
+                &pipeline.sampler,
+                self.width,
+                self.height,
+            );
+            pipeline.texture = tex;
+            pipeline.texture_view = view;
+            pipeline.bind_group = bg;
+            pipeline.current_size = target;
+        }
+
+        if self.width > 0 && self.height > 0 && !self.pixels.is_empty() {
+            queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &pipeline.texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &self.pixels,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(self.width * 4),
+                    rows_per_image: Some(self.height),
+                },
+                wgpu::Extent3d {
+                    width: self.width,
+                    height: self.height,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+    }
+
+    fn draw(
+        &self,
+        pipeline: &Self::Pipeline,
+        render_pass: &mut wgpu::RenderPass<'_>,
+    ) -> bool {
+        if self.width == 0 || self.height == 0 {
+            return true;
+        }
+        render_pass.set_pipeline(&pipeline.render_pipeline);
+        render_pass.set_bind_group(0, &pipeline.bind_group, &[]);
+        render_pass.draw(0..4, 0..1);
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Program impl — Iced shader::Program for the Shader widget
+// ---------------------------------------------------------------------------
+
+impl<Message> shader::Program<Message> for TerminalShaderProgram {
+    type State = ();
+    type Primitive = TerminalPrimitive;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        _cursor: mouse::Cursor,
+        _bounds: Rectangle,
+    ) -> Self::Primitive {
+        TerminalPrimitive {
+            pixels: self.pixels.clone(),
+            width: self.width,
+            height: self.height,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause identified**: `Handle::from_rgba()` creates a new Iced image handle with a unique auto-incrementing ID on every render. Iced's wgpu renderer sees each new ID as a brand-new GPU texture, requiring allocation → upload → swap → deallocation per frame. This produces a visible flash on **every** render — no throttling can fix it because each individual texture swap blinks.
- **Fix**: Replace the `Image` widget with Iced's `Shader` widget. The Shader primitive gives us direct `wgpu::Device` + `wgpu::Queue` access, allowing us to create **one** persistent `wgpu::Texture` and update its pixels in-place via `queue.write_texture()`. Zero handle churn, zero texture swap, zero blink. ClearType quality preserved.

## Architecture

```
PixelRenderer::render()  → RGBA pixel buffer (CPU, unchanged)
        ↓
TerminalShaderProgram    → shader::Program impl for Shader widget
        ↓
TerminalPrimitive        → carries pixel data to GPU each frame
        ↓
TerminalPipeline         → persistent wgpu resources (texture, pipeline, bind group)
  prepare()              → queue.write_texture() updates existing GPU texture in-place
  draw()                 → binds texture, draws fullscreen quad
```

## Why previous 14 attempts failed

| Attempts | Approach | Why it failed |
|----------|----------|---------------|
| 1-8 | Event loop waking | Data pipeline was already fast |
| 9-10 | Remove skipped_stale_render | Exposed the underlying blink |
| 11-14 | Render throttling (30-50ms) | Each individual texture swap still blinks |

This fix is **qualitatively different** — it eliminates Handle/texture churn at the architectural level.

## Test plan

- [ ] Rebuild and test: **no blinking** during continuous typing
- [ ] `yes | head -100` renders smoothly without flicker
- [ ] New terminal shows prompt immediately
- [ ] Window resize works cleanly (texture recreated)
- [ ] ClearType text quality preserved
- [ ] Idle CPU remains low

fixes #845