### PR TITLE
fix: match shader texture format to Iced compositor sRGB mode (#845)

### DIFF
--- a/src-tauri/native/terminal-surface/src/shader_surface.rs
+++ b/src-tauri/native/terminal-surface/src/shader_surface.rs
@@ -74,6 +74,7 @@ pub struct TerminalPipeline {
     render_pipeline: wgpu::RenderPipeline,
     bind_group_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
+    tex_format: wgpu::TextureFormat,
     texture: wgpu::Texture,
     #[allow(dead_code)]
     texture_view: wgpu::TextureView,
@@ -82,12 +83,27 @@ pub struct TerminalPipeline {
 }
 
 impl TerminalPipeline {
+    /// Pick the RGBA texture format that matches Iced's compositor sRGB mode.
+    /// Iced uses `Rgba8UnormSrgb` when `GAMMA_CORRECTION` is true (no
+    /// `web-colors` feature) and `Rgba8Unorm` when false (`web-colors`
+    /// enabled, which is the default).  Using the wrong variant causes a
+    /// colour shift because the sRGB→linear conversion on texture read is
+    /// not compensated by a matching linear→sRGB on framebuffer write.
+    fn rgba_format(compositor_format: wgpu::TextureFormat) -> wgpu::TextureFormat {
+        if compositor_format.is_srgb() {
+            wgpu::TextureFormat::Rgba8UnormSrgb
+        } else {
+            wgpu::TextureFormat::Rgba8Unorm
+        }
+    }
+
     fn create_texture(
         device: &wgpu::Device,
         layout: &wgpu::BindGroupLayout,
         sampler: &wgpu::Sampler,
         width: u32,
         height: u32,
+        tex_format: wgpu::TextureFormat,
     ) -> (wgpu::Texture, wgpu::TextureView, wgpu::BindGroup) {
         let w = width.max(1);
         let h = height.max(1);
@@ -101,7 +117,7 @@ impl TerminalPipeline {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            format: tex_format,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
         });
@@ -207,14 +223,17 @@ impl shader::Pipeline for TerminalPipeline {
             ..Default::default()
         });
 
+        let tex_format = Self::rgba_format(format);
+
         // 1x1 placeholder — resized on first prepare().
         let (texture, texture_view, bind_group) =
-            Self::create_texture(device, &bind_group_layout, &sampler, 1, 1);
+            Self::create_texture(device, &bind_group_layout, &sampler, 1, 1, tex_format);
 
         Self {
             render_pipeline,
             bind_group_layout,
             sampler,
+            tex_format,
             texture,
             texture_view,
             bind_group,
@@ -246,6 +265,7 @@ impl shader::Primitive for TerminalPrimitive {
                 &pipeline.sampler,
                 self.width,
                 self.height,
+                pipeline.tex_format,
             );
             pipeline.texture = tex;
             pipeline.texture_view = view;


### PR DESCRIPTION
## Summary

- Fixes colour shift and ClearType text artifacts introduced by the Shader widget in PR #859

## Root cause

Iced uses `Rgba8Unorm` (not sRGB) for its image atlas when the `web-colors` feature is enabled (which is the default). Our shader texture was hardcoded to `Rgba8UnormSrgb`. The sRGB-to-linear conversion on texture read was not compensated by a matching linear-to-sRGB on framebuffer write (since the compositor target is also non-sRGB with `web-colors`), causing a colour shift and ClearType sub-pixel rendering artifacts.

## Fix

Dynamically pick `Rgba8UnormSrgb` vs `Rgba8Unorm` based on whether the compositor format passed to `Pipeline::new()` is sRGB (via `TextureFormat::is_srgb()`).

## Test plan

- [ ] Colors match the canvas renderer exactly
- [ ] ClearType text is crisp without colored fringes
- [ ] No blinking (regression check)

refs #845